### PR TITLE
fix: skip redundant body fields

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.38.1-0.20260821183352-4eaeba5d8e1a
+version: v0.38.1-0.20260824162858-1baf7d92dfda
 repo: googleapis/google-cloud-rust
 sources:
   conformance:

--- a/src/generated/ads/datamanager/v1/src/transport.rs
+++ b/src/generated/ads/datamanager/v1/src/transport.rs
@@ -358,6 +358,7 @@ impl super::stub::MarketingDataInsightsService for MarketingDataInsightsService 
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -372,6 +373,7 @@ impl super::stub::MarketingDataInsightsService for MarketingDataInsightsService 
                 let path = format!("/v1/{}/insights:retrieve", var_parent,);
                 let path_template = "/v1/{parent}/insights:retrieve";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/api/apikeys/v2/src/transport.rs
+++ b/src/generated/api/apikeys/v2/src/transport.rs
@@ -501,6 +501,7 @@ impl super::stub::ApiKeys for ApiKeys {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -518,6 +519,7 @@ impl super::stub::ApiKeys for ApiKeys {
                 let path_template = "/v2/{name}:undelete";
 
                 let resource_name = format!("//apikeys.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/api/servicecontrol/v1/src/transport.rs
+++ b/src/generated/api/servicecontrol/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::QuotaController for QuotaController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_service_name = try_match(
@@ -65,6 +66,7 @@ impl super::stub::QuotaController for QuotaController {
                 let path = format!("/v1/services/{}:allocateQuota", var_service_name,);
                 let path_template = "/v1/services/{service_name}:allocateQuota";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.service_name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -141,6 +143,7 @@ impl super::stub::ServiceController for ServiceController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_service_name = try_match(
@@ -150,6 +153,7 @@ impl super::stub::ServiceController for ServiceController {
                 let path = format!("/v1/services/{}:check", var_service_name,);
                 let path_template = "/v1/services/{service_name}:check";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.service_name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -197,6 +201,7 @@ impl super::stub::ServiceController for ServiceController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_service_name = try_match(
@@ -206,6 +211,7 @@ impl super::stub::ServiceController for ServiceController {
                 let path = format!("/v1/services/{}:report", var_service_name,);
                 let path_template = "/v1/services/{service_name}:report";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.service_name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/api/servicecontrol/v2/src/transport.rs
+++ b/src/generated/api/servicecontrol/v2/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::ServiceController for ServiceController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_service_name = try_match(
@@ -65,6 +66,7 @@ impl super::stub::ServiceController for ServiceController {
                 let path = format!("/v2/services/{}:check", var_service_name,);
                 let path_template = "/v2/services/{service_name}:check";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.service_name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -112,6 +114,7 @@ impl super::stub::ServiceController for ServiceController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_service_name = try_match(
@@ -121,6 +124,7 @@ impl super::stub::ServiceController for ServiceController {
                 let path = format!("/v2/services/{}:report", var_service_name,);
                 let path_template = "/v2/services/{service_name}:report";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.service_name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/api/servicemanagement/v1/src/transport.rs
+++ b/src/generated/api/servicemanagement/v1/src/transport.rs
@@ -532,6 +532,7 @@ impl super::stub::ServiceManager for ServiceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_service_name = try_match(
@@ -541,6 +542,7 @@ impl super::stub::ServiceManager for ServiceManager {
                 let path = format!("/v1/services/{}/configs:submit", var_service_name,);
                 let path_template = "/v1/services/{service_name}/configs:submit";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.service_name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -826,6 +828,7 @@ impl super::stub::ServiceManager for ServiceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -836,6 +839,7 @@ impl super::stub::ServiceManager for ServiceManager {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//servicemanagement.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -854,6 +858,7 @@ impl super::stub::ServiceManager for ServiceManager {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//servicemanagement.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -917,6 +922,7 @@ impl super::stub::ServiceManager for ServiceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -927,6 +933,7 @@ impl super::stub::ServiceManager for ServiceManager {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//servicemanagement.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -945,6 +952,7 @@ impl super::stub::ServiceManager for ServiceManager {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//servicemanagement.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1008,6 +1016,7 @@ impl super::stub::ServiceManager for ServiceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1018,6 +1027,7 @@ impl super::stub::ServiceManager for ServiceManager {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//servicemanagement.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1036,6 +1046,7 @@ impl super::stub::ServiceManager for ServiceManager {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//servicemanagement.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/api/serviceusage/v1/src/transport.rs
+++ b/src/generated/api/serviceusage/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::ServiceUsage for ServiceUsage {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -71,6 +72,7 @@ impl super::stub::ServiceUsage for ServiceUsage {
                 let path = format!("/v1/{}:enable", var_name,);
                 let path_template = "/v1/{name}:enable";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -124,6 +126,7 @@ impl super::stub::ServiceUsage for ServiceUsage {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -139,6 +142,7 @@ impl super::stub::ServiceUsage for ServiceUsage {
                 let path = format!("/v1/{}:disable", var_name,);
                 let path_template = "/v1/{name}:disable";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -327,6 +331,7 @@ impl super::stub::ServiceUsage for ServiceUsage {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -340,6 +345,7 @@ impl super::stub::ServiceUsage for ServiceUsage {
                 let path = format!("/v1/{}/services:batchEnable", var_parent,);
                 let path_template = "/v1/{parent}/services:batchEnable";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/appengine/v1/src/transport.rs
+++ b/src/generated/appengine/v1/src/transport.rs
@@ -224,6 +224,7 @@ impl super::stub::Applications for Applications {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -233,6 +234,7 @@ impl super::stub::Applications for Applications {
                 let path = format!("/v1/{}:repair", var_name,);
                 let path_template = "/v1/{name}:repair";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1637,6 +1639,7 @@ impl super::stub::Instances for Instances {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1655,6 +1658,7 @@ impl super::stub::Instances for Instances {
                 let path = format!("/v1/{}:debug", var_name,);
                 let path_template = "/v1/{name}:debug";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1940,6 +1944,7 @@ impl super::stub::Firewall for Firewall {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1953,6 +1958,7 @@ impl super::stub::Firewall for Firewall {
                 let path = format!("/v1/{}:batchUpdate", var_name,);
                 let path_template = "/v1/{name}:batchUpdate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/apps/events/subscriptions/v1/src/transport.rs
+++ b/src/generated/apps/events/subscriptions/v1/src/transport.rs
@@ -344,6 +344,7 @@ impl super::stub::SubscriptionsService for SubscriptionsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -354,6 +355,7 @@ impl super::stub::SubscriptionsService for SubscriptionsService {
                 let path_template = "/v1/{name}:reactivate";
 
                 let resource_name = format!("//workspaceevents.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/apps/meet/v2/src/transport.rs
+++ b/src/generated/apps/meet/v2/src/transport.rs
@@ -232,6 +232,7 @@ impl super::stub::SpacesService for SpacesService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -242,6 +243,7 @@ impl super::stub::SpacesService for SpacesService {
                 let path_template = "/v2/{name}:endActiveConference";
 
                 let resource_name = format!("//meet.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/bigtable/admin/v2/src/transport.rs
+++ b/src/generated/bigtable/admin/v2/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -66,6 +67,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 let path_template = "/v2/{parent}/instances";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -241,6 +243,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -255,6 +258,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 let path = format!("/v2/{}", var_name,);
                 let path_template = "/v2/{name}";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PUT, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PUT, path_template)))
@@ -677,6 +681,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -693,6 +698,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 let path = format!("/v2/{}", var_name,);
                 let path_template = "/v2/{name}";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PUT, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PUT, path_template)))
@@ -1303,6 +1309,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1318,6 +1325,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 let path_template = "/v2/{resource}:getIamPolicy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1338,6 +1346,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 let path_template = "/v2/{resource}:getIamPolicy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1358,6 +1367,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 let path_template = "/v2/{resource}:getIamPolicy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1445,6 +1455,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1460,6 +1471,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1480,6 +1492,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1500,6 +1513,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1587,6 +1601,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1602,6 +1617,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1622,6 +1638,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1642,6 +1659,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2909,6 +2927,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2924,6 +2943,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{parent}/tables";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2977,6 +2997,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2992,6 +3013,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{parent}/tables:createFromSnapshot";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3358,6 +3380,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3375,6 +3398,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{name}:undelete";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3839,6 +3863,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3856,6 +3881,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{name}:modifyColumnFamilies";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3913,6 +3939,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3930,6 +3957,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{name}:dropRowRange";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3991,6 +4019,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4008,6 +4037,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{name}:generateConsistencyToken";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4065,6 +4095,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4082,6 +4113,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{name}:checkConsistency";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4137,6 +4169,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4154,6 +4187,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{name}:snapshot";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4840,6 +4874,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -4855,6 +4890,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{parent}/tables:restore";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4908,6 +4944,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -4925,6 +4962,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{parent}/backups:copy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4980,6 +5018,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4997,6 +5036,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{resource}:getIamPolicy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5019,6 +5059,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{resource}:getIamPolicy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5041,6 +5082,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{resource}:getIamPolicy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5063,6 +5105,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{resource}:getIamPolicy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5175,6 +5218,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -5192,6 +5236,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5214,6 +5259,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5236,6 +5282,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5258,6 +5305,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5370,6 +5418,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -5387,6 +5436,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5409,6 +5459,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5431,6 +5482,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5453,6 +5505,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//bigtableadmin.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/chat/v1/src/transport.rs
+++ b/src/generated/chat/v1/src/transport.rs
@@ -608,6 +608,7 @@ impl super::stub::ChatService for ChatService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -618,6 +619,7 @@ impl super::stub::ChatService for ChatService {
                 let path_template = "/v1/{parent}/messages:search";
 
                 let resource_name = format!("//chat.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -738,6 +740,7 @@ impl super::stub::ChatService for ChatService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -748,6 +751,7 @@ impl super::stub::ChatService for ChatService {
                 let path_template = "/v1/{parent}/attachments:upload";
 
                 let resource_name = format!("//chat.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1180,6 +1184,7 @@ impl super::stub::ChatService for ChatService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1190,6 +1195,7 @@ impl super::stub::ChatService for ChatService {
                 let path_template = "/v1/{name}:completeImport";
 
                 let resource_name = format!("//chat.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2273,6 +2279,7 @@ impl super::stub::ChatService for ChatService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2287,6 +2294,7 @@ impl super::stub::ChatService for ChatService {
                 let path_template = "/v1/{name}:markAsActive";
 
                 let resource_name = format!("//chat.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2339,6 +2347,7 @@ impl super::stub::ChatService for ChatService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2353,6 +2362,7 @@ impl super::stub::ChatService for ChatService {
                 let path_template = "/v1/{name}:markAsAway";
 
                 let resource_name = format!("//chat.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2405,6 +2415,7 @@ impl super::stub::ChatService for ChatService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2419,6 +2430,7 @@ impl super::stub::ChatService for ChatService {
                 let path_template = "/v1/{name}:markAsDoNotDisturb";
 
                 let resource_name = format!("//chat.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3114,6 +3126,7 @@ impl super::stub::ChatService for ChatService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3129,6 +3142,7 @@ impl super::stub::ChatService for ChatService {
                 let path_template = "/v1/{name}:position";
 
                 let resource_name = format!("//chat.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3253,6 +3267,7 @@ impl super::stub::ChatService for ChatService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3270,6 +3285,7 @@ impl super::stub::ChatService for ChatService {
                 let path_template = "/v1/{name}:move";
 
                 let resource_name = format!("//chat.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/accessapproval/v1/src/transport.rs
+++ b/src/generated/cloud/accessapproval/v1/src/transport.rs
@@ -307,6 +307,7 @@ impl super::stub::AccessApproval for AccessApproval {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -322,6 +323,7 @@ impl super::stub::AccessApproval for AccessApproval {
                 let path_template = "/v1/{name}:approve";
 
                 let resource_name = format!("//accessapproval.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -340,6 +342,7 @@ impl super::stub::AccessApproval for AccessApproval {
                 let path_template = "/v1/{name}:approve";
 
                 let resource_name = format!("//accessapproval.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -358,6 +361,7 @@ impl super::stub::AccessApproval for AccessApproval {
                 let path_template = "/v1/{name}:approve";
 
                 let resource_name = format!("//accessapproval.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -443,6 +447,7 @@ impl super::stub::AccessApproval for AccessApproval {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -458,6 +463,7 @@ impl super::stub::AccessApproval for AccessApproval {
                 let path_template = "/v1/{name}:dismiss";
 
                 let resource_name = format!("//accessapproval.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -476,6 +482,7 @@ impl super::stub::AccessApproval for AccessApproval {
                 let path_template = "/v1/{name}:dismiss";
 
                 let resource_name = format!("//accessapproval.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -494,6 +501,7 @@ impl super::stub::AccessApproval for AccessApproval {
                 let path_template = "/v1/{name}:dismiss";
 
                 let resource_name = format!("//accessapproval.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -579,6 +587,7 @@ impl super::stub::AccessApproval for AccessApproval {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -594,6 +603,7 @@ impl super::stub::AccessApproval for AccessApproval {
                 let path_template = "/v1/{name}:invalidate";
 
                 let resource_name = format!("//accessapproval.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -612,6 +622,7 @@ impl super::stub::AccessApproval for AccessApproval {
                 let path_template = "/v1/{name}:invalidate";
 
                 let resource_name = format!("//accessapproval.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -630,6 +641,7 @@ impl super::stub::AccessApproval for AccessApproval {
                 let path_template = "/v1/{name}:invalidate";
 
                 let resource_name = format!("//accessapproval.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/agentidentity/v1/src/transport.rs
+++ b/src/generated/cloud/agentidentity/v1/src/transport.rs
@@ -449,6 +449,7 @@ impl super::stub::AuthProviderService for AuthProviderService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -466,6 +467,7 @@ impl super::stub::AuthProviderService for AuthProviderService {
                 let path_template = "/v1/{name}:undelete";
 
                 let resource_name = format!("//agentidentity.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1061,6 +1063,7 @@ impl super::stub::AuthProviderService for AuthProviderService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1078,6 +1081,7 @@ impl super::stub::AuthProviderService for AuthProviderService {
                 let path_template = "/v1/{name}:revokeAuthorization";
 
                 let resource_name = format!("//agentidentity.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1135,6 +1139,7 @@ impl super::stub::AuthProviderService for AuthProviderService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1152,6 +1157,7 @@ impl super::stub::AuthProviderService for AuthProviderService {
                 let path_template = "/v1/{name}:enable";
 
                 let resource_name = format!("//agentidentity.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1209,6 +1215,7 @@ impl super::stub::AuthProviderService for AuthProviderService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1226,6 +1233,7 @@ impl super::stub::AuthProviderService for AuthProviderService {
                 let path_template = "/v1/{name}:disable";
 
                 let resource_name = format!("//agentidentity.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1408,6 +1416,7 @@ impl super::stub::AuthProviderService for AuthProviderService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1425,6 +1434,7 @@ impl super::stub::AuthProviderService for AuthProviderService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//agentidentity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1564,6 +1574,7 @@ impl super::stub::AuthProviderService for AuthProviderService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1581,6 +1592,7 @@ impl super::stub::AuthProviderService for AuthProviderService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//agentidentity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/agentregistry/v1/src/transport.rs
+++ b/src/generated/cloud/agentregistry/v1/src/transport.rs
@@ -128,6 +128,7 @@ impl super::stub::AgentRegistry for AgentRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -143,6 +144,7 @@ impl super::stub::AgentRegistry for AgentRegistry {
                 let path_template = "/v1/{parent}/agents:search";
 
                 let resource_name = format!("//agentregistry.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -483,6 +485,7 @@ impl super::stub::AgentRegistry for AgentRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -498,6 +501,7 @@ impl super::stub::AgentRegistry for AgentRegistry {
                 let path_template = "/v1/{parent}/mcpServers:search";
 
                 let resource_name = format!("//agentregistry.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1794,6 +1798,7 @@ impl super::stub::AgentRegistry for AgentRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1810,6 +1815,7 @@ impl super::stub::AgentRegistry for AgentRegistry {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/alloydb/v1/src/transport.rs
+++ b/src/generated/cloud/alloydb/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::AlloyDBCSQLAdmin for AlloyDBCSQLAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -71,6 +72,7 @@ impl super::stub::AlloyDBCSQLAdmin for AlloyDBCSQLAdmin {
                 let path_template = "/v1/{parent}/clusters:restoreFromCloudSQL";
 
                 let resource_name = format!("//alloydb.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -466,6 +468,7 @@ impl super::stub::AlloyDBCSQLAdmin for AlloyDBCSQLAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -482,6 +485,7 @@ impl super::stub::AlloyDBCSQLAdmin for AlloyDBCSQLAdmin {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -892,6 +896,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -909,6 +914,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 let path_template = "/v1/{name}:export";
 
                 let resource_name = format!("//alloydb.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -964,6 +970,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -981,6 +988,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 let path_template = "/v1/{name}:import";
 
                 let resource_name = format!("//alloydb.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1036,6 +1044,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1053,6 +1062,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 let path_template = "/v1/{name}:upgrade";
 
                 let resource_name = format!("//alloydb.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -1184,6 +1194,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1201,6 +1212,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 let path_template = "/v1/{name}:promote";
 
                 let resource_name = format!("//alloydb.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1256,6 +1268,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1273,6 +1286,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 let path_template = "/v1/{name}:switchover";
 
                 let resource_name = format!("//alloydb.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1328,6 +1342,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1343,6 +1358,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 let path_template = "/v1/{parent}/clusters:restore";
 
                 let resource_name = format!("//alloydb.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2017,6 +2033,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2036,6 +2053,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 let path_template = "/v1/{name}:failover";
 
                 let resource_name = format!("//alloydb.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2093,6 +2111,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2112,6 +2131,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 let path_template = "/v1/{name}:injectFault";
 
                 let resource_name = format!("//alloydb.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2169,6 +2189,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2188,6 +2209,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 let path_template = "/v1/{name}:restart";
 
                 let resource_name = format!("//alloydb.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2245,6 +2267,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_instance = try_match(
@@ -2264,6 +2287,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 let path_template = "/v1/{instance}:executeSql";
 
                 let resource_name = format!("//alloydb.googleapis.com/{}", var_instance,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.instance));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2775,6 +2799,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2792,6 +2817,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 let path_template = "/v1/{parent}:generateClientCertificate";
 
                 let resource_name = format!("//alloydb.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3749,6 +3775,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3765,6 +3792,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/apigateway/v1/src/transport.rs
+++ b/src/generated/cloud/apigateway/v1/src/transport.rs
@@ -1413,6 +1413,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1429,6 +1430,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/apihub/v1/src/transport.rs
+++ b/src/generated/cloud/apihub/v1/src/transport.rs
@@ -2586,6 +2586,7 @@ impl super::stub::ApiHub for ApiHub {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_location = try_match(
@@ -2601,6 +2602,7 @@ impl super::stub::ApiHub for ApiHub {
                 let path_template = "/v1/{location}:searchResources";
 
                 let resource_name = format!("//apihub.googleapis.com/{}", var_location,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.location));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3373,6 +3375,7 @@ impl super::stub::ApiHub for ApiHub {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3389,6 +3392,7 @@ impl super::stub::ApiHub for ApiHub {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4198,6 +4202,7 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4214,6 +4219,7 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4303,6 +4309,7 @@ impl super::stub::ApiHubCollect for ApiHubCollect {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_location = try_match(
@@ -4318,6 +4325,7 @@ impl super::stub::ApiHubCollect for ApiHubCollect {
                 let path_template = "/v1/{location}:collectApiData";
 
                 let resource_name = format!("//apihub.googleapis.com/{}", var_location,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.location));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4713,6 +4721,7 @@ impl super::stub::ApiHubCollect for ApiHubCollect {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4729,6 +4738,7 @@ impl super::stub::ApiHubCollect for ApiHubCollect {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5552,6 +5562,7 @@ impl super::stub::ApiHubCurate for ApiHubCurate {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5568,6 +5579,7 @@ impl super::stub::ApiHubCurate for ApiHubCurate {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6283,6 +6295,7 @@ impl super::stub::ApiHubDiscovery for ApiHubDiscovery {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6299,6 +6312,7 @@ impl super::stub::ApiHubDiscovery for ApiHubDiscovery {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6946,6 +6960,7 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6962,6 +6977,7 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -7289,6 +7305,7 @@ impl super::stub::LintingService for LintingService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7310,6 +7327,7 @@ impl super::stub::LintingService for LintingService {
                 let path_template = "/v1/{name}:lint";
 
                 let resource_name = format!("//apihub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7717,6 +7735,7 @@ impl super::stub::LintingService for LintingService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7733,6 +7752,7 @@ impl super::stub::LintingService for LintingService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -7894,6 +7914,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7911,6 +7932,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
                 let path_template = "/v1/{name}:enable";
 
                 let resource_name = format!("//apihub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7966,6 +7988,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7983,6 +8006,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
                 let path_template = "/v1/{name}:disable";
 
                 let resource_name = format!("//apihub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8323,6 +8347,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -8342,6 +8367,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
                 let path_template = "/v1/{name}:executeAction";
 
                 let resource_name = format!("//apihub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8552,6 +8578,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -8571,6 +8598,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
                 let path_template = "/v1/{name}:enableAction";
 
                 let resource_name = format!("//apihub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8630,6 +8658,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -8649,6 +8678,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
                 let path_template = "/v1/{name}:disableAction";
 
                 let resource_name = format!("//apihub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9218,6 +9248,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -9234,6 +9265,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -9960,6 +9992,7 @@ impl super::stub::Provisioning for Provisioning {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -9976,6 +10009,7 @@ impl super::stub::Provisioning for Provisioning {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -10783,6 +10817,7 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -10799,6 +10834,7 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/apphub/v1/src/transport.rs
+++ b/src/generated/cloud/apphub/v1/src/transport.rs
@@ -414,6 +414,7 @@ impl super::stub::AppHub for AppHub {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -429,6 +430,7 @@ impl super::stub::AppHub for AppHub {
                 let path_template = "/v1/{name}:detachServiceProjectAttachment";
 
                 let resource_name = format!("//apphub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2201,6 +2203,7 @@ impl super::stub::AppHub for AppHub {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2218,6 +2221,7 @@ impl super::stub::AppHub for AppHub {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//apphub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2357,6 +2361,7 @@ impl super::stub::AppHub for AppHub {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2374,6 +2379,7 @@ impl super::stub::AppHub for AppHub {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//apphub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2646,6 +2652,7 @@ impl super::stub::AppHub for AppHub {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2662,6 +2669,7 @@ impl super::stub::AppHub for AppHub {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/asset/v1/src/transport.rs
+++ b/src/generated/cloud/asset/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::AssetService for AssetService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -70,6 +71,7 @@ impl super::stub::AssetService for AssetService {
                 let path_template = "/v1/{parent}:exportAssets";
 
                 let resource_name = format!("//cloudasset.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -296,6 +298,7 @@ impl super::stub::AssetService for AssetService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -309,6 +312,7 @@ impl super::stub::AssetService for AssetService {
                 let path = format!("/v1/{}/feeds", var_parent,);
                 let path_template = "/v1/{parent}/feeds";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -494,6 +498,7 @@ impl super::stub::AssetService for AssetService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_feed_name = try_match(
@@ -512,6 +517,9 @@ impl super::stub::AssetService for AssetService {
                 let path = format!("/v1/{}", var_feed_name,);
                 let path_template = "/v1/{feed.name}";
 
+                let _ = Some(&mut req)
+                    .and_then(|m| m.feed.as_mut())
+                    .map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template)))
@@ -894,6 +902,7 @@ impl super::stub::AssetService for AssetService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_analysis_query_scope = try_match(
@@ -913,6 +922,9 @@ impl super::stub::AssetService for AssetService {
                 );
                 let path_template = "/v1/{analysis_query.scope}:analyzeIamPolicyLongrunning";
 
+                let _ = Some(&mut req)
+                    .and_then(|m| m.analysis_query.as_mut())
+                    .map(|m| std::mem::take(&mut m.scope));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1037,6 +1049,7 @@ impl super::stub::AssetService for AssetService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1051,6 +1064,7 @@ impl super::stub::AssetService for AssetService {
                 let path_template = "/v1/{parent}:queryAssets";
 
                 let resource_name = format!("//cloudasset.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/assuredworkloads/v1/src/transport.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/transport.rs
@@ -217,6 +217,7 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -233,6 +234,7 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
                 let path = format!("/v1/{}:restrictAllowedResources", var_name,);
                 let path_template = "/v1/{name}:restrictAllowedResources";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/auditmanager/v1/src/transport.rs
+++ b/src/generated/cloud/auditmanager/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::AuditManager for AuditManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_scope = try_match(
@@ -70,6 +71,7 @@ impl super::stub::AuditManager for AuditManager {
                 let path = format!("/v1/{}:enrollResource", var_scope,);
                 let path_template = "/v1/{scope}:enrollResource";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.scope));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -87,6 +89,7 @@ impl super::stub::AuditManager for AuditManager {
                 let path = format!("/v1/{}:enrollResource", var_scope,);
                 let path_template = "/v1/{scope}:enrollResource";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.scope));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -104,6 +107,7 @@ impl super::stub::AuditManager for AuditManager {
                 let path = format!("/v1/{}:enrollResource", var_scope,);
                 let path_template = "/v1/{scope}:enrollResource";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.scope));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -186,6 +190,7 @@ impl super::stub::AuditManager for AuditManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_scope = try_match(
@@ -200,6 +205,7 @@ impl super::stub::AuditManager for AuditManager {
                 let path = format!("/v1/{}/auditScopeReports:generate", var_scope,);
                 let path_template = "/v1/{scope}/auditScopeReports:generate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.scope));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -217,6 +223,7 @@ impl super::stub::AuditManager for AuditManager {
                 let path = format!("/v1/{}/auditScopeReports:generate", var_scope,);
                 let path_template = "/v1/{scope}/auditScopeReports:generate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.scope));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -234,6 +241,7 @@ impl super::stub::AuditManager for AuditManager {
                 let path = format!("/v1/{}/auditScopeReports:generate", var_scope,);
                 let path_template = "/v1/{scope}/auditScopeReports:generate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.scope));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -318,6 +326,7 @@ impl super::stub::AuditManager for AuditManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_scope = try_match(
@@ -332,6 +341,7 @@ impl super::stub::AuditManager for AuditManager {
                 let path = format!("/v1/{}/auditReports:generate", var_scope,);
                 let path_template = "/v1/{scope}/auditReports:generate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.scope));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -349,6 +359,7 @@ impl super::stub::AuditManager for AuditManager {
                 let path = format!("/v1/{}/auditReports:generate", var_scope,);
                 let path_template = "/v1/{scope}/auditReports:generate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.scope));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -366,6 +377,7 @@ impl super::stub::AuditManager for AuditManager {
                 let path = format!("/v1/{}/auditReports:generate", var_scope,);
                 let path_template = "/v1/{scope}/auditReports:generate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.scope));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1592,6 +1604,7 @@ impl super::stub::AuditManager for AuditManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1608,6 +1621,7 @@ impl super::stub::AuditManager for AuditManager {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1627,6 +1641,7 @@ impl super::stub::AuditManager for AuditManager {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/backupdr/v1/src/transport.rs
+++ b/src/generated/cloud/backupdr/v1/src/transport.rs
@@ -1482,6 +1482,7 @@ impl super::stub::BackupDR for BackupDR {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1503,6 +1504,7 @@ impl super::stub::BackupDR for BackupDR {
                 let path_template = "/v1/{name}:restore";
 
                 let resource_name = format!("//backupdr.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2541,6 +2543,7 @@ impl super::stub::BackupDR for BackupDR {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2558,6 +2561,7 @@ impl super::stub::BackupDR for BackupDR {
                 let path_template = "/v1/{name}:triggerBackup";
 
                 let resource_name = format!("//backupdr.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2834,6 +2838,7 @@ impl super::stub::BackupDR for BackupDR {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2849,6 +2854,7 @@ impl super::stub::BackupDR for BackupDR {
                 let path = format!("/v1/{}:initialize", var_name,);
                 let path_template = "/v1/{name}:initialize";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3027,6 +3033,7 @@ impl super::stub::BackupDR for BackupDR {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3044,6 +3051,7 @@ impl super::stub::BackupDR for BackupDR {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//backupdr.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3183,6 +3191,7 @@ impl super::stub::BackupDR for BackupDR {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3200,6 +3209,7 @@ impl super::stub::BackupDR for BackupDR {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//backupdr.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3472,6 +3482,7 @@ impl super::stub::BackupDR for BackupDR {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3488,6 +3499,7 @@ impl super::stub::BackupDR for BackupDR {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3788,6 +3800,7 @@ impl super::stub::BackupDrProtectionSummary for BackupDrProtectionSummary {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3805,6 +3818,7 @@ impl super::stub::BackupDrProtectionSummary for BackupDrProtectionSummary {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//backupdr.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3944,6 +3958,7 @@ impl super::stub::BackupDrProtectionSummary for BackupDrProtectionSummary {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3961,6 +3976,7 @@ impl super::stub::BackupDrProtectionSummary for BackupDrProtectionSummary {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//backupdr.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4233,6 +4249,7 @@ impl super::stub::BackupDrProtectionSummary for BackupDrProtectionSummary {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4249,6 +4266,7 @@ impl super::stub::BackupDrProtectionSummary for BackupDrProtectionSummary {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/baremetalsolution/v2/src/transport.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/transport.rs
@@ -293,6 +293,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -310,6 +311,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 let path_template = "/v2/{name}:rename";
 
                 let resource_name = format!("//baremetalsolution.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -367,6 +369,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -384,6 +387,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 let path_template = "/v2/{name}:reset";
 
                 let resource_name = format!("//baremetalsolution.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -441,6 +445,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -458,6 +463,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 let path_template = "/v2/{name}:start";
 
                 let resource_name = format!("//baremetalsolution.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -515,6 +521,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -532,6 +539,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 let path_template = "/v2/{name}:stop";
 
                 let resource_name = format!("//baremetalsolution.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -589,6 +597,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -606,6 +615,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 let path_template = "/v2/{name}:enableInteractiveSerialConsole";
 
                 let resource_name = format!("//baremetalsolution.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -661,6 +671,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -678,6 +689,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 let path_template = "/v2/{name}:disableInteractiveSerialConsole";
 
                 let resource_name = format!("//baremetalsolution.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -733,6 +745,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_instance = try_match(
@@ -750,6 +763,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 let path_template = "/v2/{instance}:detachLun";
 
                 let resource_name = format!("//baremetalsolution.googleapis.com/{}", var_instance,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.instance));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1263,6 +1277,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1280,6 +1295,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 let path_template = "/v2/{name}:rename";
 
                 let resource_name = format!("//baremetalsolution.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1337,6 +1353,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1354,6 +1371,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 let path_template = "/v2/{name}:evict";
 
                 let resource_name = format!("//baremetalsolution.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1411,6 +1429,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_volume = try_match(
@@ -1428,6 +1447,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 let path_template = "/v2/{volume}:resize";
 
                 let resource_name = format!("//baremetalsolution.googleapis.com/{}", var_volume,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.volume));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1866,6 +1886,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_volume_snapshot = try_match(
@@ -1886,6 +1907,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
 
                 let resource_name =
                     format!("//baremetalsolution.googleapis.com/{}", var_volume_snapshot,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.volume_snapshot));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2333,6 +2355,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2352,6 +2375,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 let path_template = "/v2/{name}:evict";
 
                 let resource_name = format!("//baremetalsolution.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2716,6 +2740,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2733,6 +2758,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 let path_template = "/v2/{name}:rename";
 
                 let resource_name = format!("//baremetalsolution.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2934,6 +2960,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2949,6 +2976,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 let path_template = "/v2/{parent}/provisioningConfigs:submit";
 
                 let resource_name = format!("//baremetalsolution.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3234,6 +3262,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3251,6 +3280,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 let path_template = "/v2/{name}:rename";
 
                 let resource_name = format!("//baremetalsolution.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/transport.rs
@@ -632,6 +632,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -649,6 +650,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -669,6 +671,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -689,6 +692,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -709,6 +713,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -729,6 +734,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1132,6 +1138,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1149,6 +1156,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1169,6 +1177,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1189,6 +1198,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1209,6 +1219,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1229,6 +1240,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1569,6 +1581,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1585,6 +1598,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/transport.rs
@@ -435,6 +435,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_app_connector = try_match(
@@ -452,6 +453,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 let path_template = "/v1/{app_connector}:reportStatus";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_app_connector,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.app_connector));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -632,6 +634,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -649,6 +652,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -669,6 +673,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -689,6 +694,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -709,6 +715,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -729,6 +736,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1132,6 +1140,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1149,6 +1158,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1169,6 +1179,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1189,6 +1200,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1209,6 +1221,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1229,6 +1242,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1569,6 +1583,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1585,6 +1600,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/transport.rs
@@ -474,6 +474,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -491,6 +492,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -511,6 +513,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -531,6 +534,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -551,6 +555,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -571,6 +576,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -974,6 +980,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -991,6 +998,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1011,6 +1019,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1031,6 +1040,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1051,6 +1061,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1071,6 +1082,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1411,6 +1423,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1427,6 +1440,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/transport.rs
@@ -562,6 +562,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -579,6 +580,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -599,6 +601,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -619,6 +622,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -639,6 +643,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -659,6 +664,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1062,6 +1068,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1079,6 +1086,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1099,6 +1107,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1119,6 +1128,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1139,6 +1149,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1159,6 +1170,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1499,6 +1511,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1515,6 +1528,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/transport.rs
@@ -470,6 +470,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -487,6 +488,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -507,6 +509,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -527,6 +530,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -547,6 +551,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -567,6 +572,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -970,6 +976,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -987,6 +994,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1007,6 +1015,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1027,6 +1036,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1047,6 +1057,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1067,6 +1078,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//beyondcorp.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1407,6 +1419,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1423,6 +1436,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/biglake/hive/v1/src/transport.rs
+++ b/src/generated/cloud/biglake/hive/v1/src/transport.rs
@@ -1215,6 +1215,7 @@ impl super::stub::HiveMetastoreService for HiveMetastoreService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1234,6 +1235,7 @@ impl super::stub::HiveMetastoreService for HiveMetastoreService {
                 let path_template = "/hive/v1/{parent}/partitions:batchCreate";
 
                 let resource_name = format!("//biglake.googleapis.com/hive/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1293,6 +1295,7 @@ impl super::stub::HiveMetastoreService for HiveMetastoreService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1312,6 +1315,7 @@ impl super::stub::HiveMetastoreService for HiveMetastoreService {
                 let path_template = "/hive/v1/{parent}/partitions:batchDelete";
 
                 let resource_name = format!("//biglake.googleapis.com/hive/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1377,6 +1381,7 @@ impl super::stub::HiveMetastoreService for HiveMetastoreService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1396,6 +1401,7 @@ impl super::stub::HiveMetastoreService for HiveMetastoreService {
                 let path_template = "/hive/v1/{parent}/partitions:batchUpdate";
 
                 let resource_name = format!("//biglake.googleapis.com/hive/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1455,6 +1461,7 @@ impl super::stub::HiveMetastoreService for HiveMetastoreService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1469,6 +1476,7 @@ impl super::stub::HiveMetastoreService for HiveMetastoreService {
                 let path = format!("/hive/v1/{}:failover", var_name,);
                 let path_template = "/hive/v1/{name}:failover";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/biglake/v1/src/transport.rs
+++ b/src/generated/cloud/biglake/v1/src/transport.rs
@@ -595,6 +595,7 @@ impl super::stub::IcebergCatalogService for IcebergCatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -615,6 +616,7 @@ impl super::stub::IcebergCatalogService for IcebergCatalogService {
                     "//biglake.googleapis.com/iceberg/restcatalog/{}",
                     var_parent,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -916,6 +918,7 @@ impl super::stub::IcebergCatalogService for IcebergCatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -936,6 +939,7 @@ impl super::stub::IcebergCatalogService for IcebergCatalogService {
 
                 let resource_name =
                     format!("//biglake.googleapis.com/iceberg/restcatalog/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -995,6 +999,7 @@ impl super::stub::IcebergCatalogService for IcebergCatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1015,6 +1020,7 @@ impl super::stub::IcebergCatalogService for IcebergCatalogService {
                     "//biglake.googleapis.com/iceberg/restcatalog/{}",
                     var_parent,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1072,6 +1078,7 @@ impl super::stub::IcebergCatalogService for IcebergCatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1092,6 +1099,7 @@ impl super::stub::IcebergCatalogService for IcebergCatalogService {
 
                 let resource_name =
                     format!("//biglake.googleapis.com/iceberg/restcatalog/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1530,6 +1538,7 @@ impl super::stub::IcebergCatalogService for IcebergCatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1544,6 +1553,7 @@ impl super::stub::IcebergCatalogService for IcebergCatalogService {
                 let path = format!("/iceberg/v1/restcatalog/extensions/{}:failover", var_name,);
                 let path_template = "/iceberg/v1/restcatalog/extensions/{name}:failover";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/transport.rs
@@ -911,6 +911,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -930,6 +931,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 let path_template = "/v1/{name}:subscribe";
 
                 let resource_name = format!("//analyticshub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -987,6 +989,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1004,6 +1007,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 let path_template = "/v1/{name}:subscribe";
 
                 let resource_name = format!("//analyticshub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1059,6 +1063,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1076,6 +1081,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 let path_template = "/v1/{name}:refresh";
 
                 let resource_name = format!("//analyticshub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1401,6 +1407,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1418,6 +1425,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 let path_template = "/v1/{name}:revoke";
 
                 let resource_name = format!("//analyticshub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1545,6 +1553,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1562,6 +1571,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//analyticshub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1584,6 +1594,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//analyticshub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1604,6 +1615,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//analyticshub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1697,6 +1709,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1714,6 +1727,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//analyticshub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1736,6 +1750,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//analyticshub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1756,6 +1771,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//analyticshub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1849,6 +1865,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1866,6 +1883,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//analyticshub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1888,6 +1906,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//analyticshub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2359,6 +2378,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2378,6 +2398,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 let path_template = "/v1/{name}:submit";
 
                 let resource_name = format!("//analyticshub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2435,6 +2456,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2454,6 +2476,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 let path_template = "/v1/{name}:approve";
 
                 let resource_name = format!("//analyticshub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/bigquery/connection/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/transport.rs
@@ -439,6 +439,7 @@ impl super::stub::ConnectionService for ConnectionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -457,6 +458,7 @@ impl super::stub::ConnectionService for ConnectionService {
 
                 let resource_name =
                     format!("//bigqueryconnection.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -514,6 +516,7 @@ impl super::stub::ConnectionService for ConnectionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -532,6 +535,7 @@ impl super::stub::ConnectionService for ConnectionService {
 
                 let resource_name =
                     format!("//bigqueryconnection.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -589,6 +593,7 @@ impl super::stub::ConnectionService for ConnectionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -607,6 +612,7 @@ impl super::stub::ConnectionService for ConnectionService {
 
                 let resource_name =
                     format!("//bigqueryconnection.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/transport.rs
@@ -216,6 +216,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -232,6 +233,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
                 let path = format!("/v1/{}:rename", var_name,);
                 let path_template = "/v1/{name}:rename";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -515,6 +517,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -533,6 +536,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
 
                 let resource_name =
                     format!("//bigquerydatapolicy.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -590,6 +594,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -608,6 +613,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
 
                 let resource_name =
                     format!("//bigquerydatapolicy.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -665,6 +671,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -683,6 +690,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
 
                 let resource_name =
                     format!("//bigquerydatapolicy.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/bigquery/datapolicies/v2/src/transport.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v2/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -71,6 +72,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
                 let path_template = "/v2/{parent}/dataPolicies";
 
                 let resource_name = format!("//bigquerydatapolicy.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -126,6 +128,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_data_policy = try_match(
@@ -144,6 +147,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
 
                 let resource_name =
                     format!("//bigquerydatapolicy.googleapis.com/{}", var_data_policy,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.data_policy));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -201,6 +205,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_data_policy = try_match(
@@ -219,6 +224,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
 
                 let resource_name =
                     format!("//bigquerydatapolicy.googleapis.com/{}", var_data_policy,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.data_policy));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -594,6 +600,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -612,6 +619,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
 
                 let resource_name =
                     format!("//bigquerydatapolicy.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -669,6 +677,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -687,6 +696,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
 
                 let resource_name =
                     format!("//bigquerydatapolicy.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -744,6 +754,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -762,6 +773,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
 
                 let resource_name =
                     format!("//bigquerydatapolicy.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/transport.rs
@@ -828,6 +828,7 @@ impl super::stub::DataTransferService for DataTransferService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -846,6 +847,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//bigquerydatatransfer.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -865,6 +867,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//bigquerydatatransfer.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -935,6 +938,7 @@ impl super::stub::DataTransferService for DataTransferService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -953,6 +957,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//bigquerydatatransfer.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -972,6 +977,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//bigquerydatatransfer.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1524,6 +1530,7 @@ impl super::stub::DataTransferService for DataTransferService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1541,6 +1548,7 @@ impl super::stub::DataTransferService for DataTransferService {
                 let path_template = "/v1/{name}:checkValidCreds";
 
                 let resource_name = format!("//bigquerydatatransfer.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1559,6 +1567,7 @@ impl super::stub::DataTransferService for DataTransferService {
                 let path_template = "/v1/{name}:checkValidCreds";
 
                 let resource_name = format!("//bigquerydatatransfer.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1631,6 +1640,7 @@ impl super::stub::DataTransferService for DataTransferService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1645,6 +1655,7 @@ impl super::stub::DataTransferService for DataTransferService {
                 let path = format!("/v1/{}:enrollDataSources", var_name,);
                 let path_template = "/v1/{name}:enrollDataSources";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1657,6 +1668,7 @@ impl super::stub::DataTransferService for DataTransferService {
                 let path = format!("/v1/{}:enrollDataSources", var_name,);
                 let path_template = "/v1/{name}:enrollDataSources";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1725,6 +1737,7 @@ impl super::stub::DataTransferService for DataTransferService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1739,6 +1752,7 @@ impl super::stub::DataTransferService for DataTransferService {
                 let path = format!("/v1/{}:unenrollDataSources", var_name,);
                 let path_template = "/v1/{name}:unenrollDataSources";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/bigquery/migration/v2/src/transport.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/transport.rs
@@ -370,6 +370,7 @@ impl super::stub::MigrationService for MigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -387,6 +388,7 @@ impl super::stub::MigrationService for MigrationService {
                 let path_template = "/v2/{name}:start";
 
                 let resource_name = format!("//bigquerymigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/bigquery/reservation/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/transport.rs
@@ -443,6 +443,7 @@ impl super::stub::ReservationService for ReservationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -460,6 +461,7 @@ impl super::stub::ReservationService for ReservationService {
                 let path_template = "/v1/{name}:failoverReservation";
 
                 let resource_name = format!("//bigqueryreservation.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -898,6 +900,7 @@ impl super::stub::ReservationService for ReservationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -915,6 +918,7 @@ impl super::stub::ReservationService for ReservationService {
                 let path_template = "/v1/{name}:split";
 
                 let resource_name = format!("//bigqueryreservation.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -970,6 +974,7 @@ impl super::stub::ReservationService for ReservationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -985,6 +990,7 @@ impl super::stub::ReservationService for ReservationService {
                 let path_template = "/v1/{parent}/capacityCommitments:merge";
 
                 let resource_name = format!("//bigqueryreservation.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1417,6 +1423,7 @@ impl super::stub::ReservationService for ReservationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1436,6 +1443,7 @@ impl super::stub::ReservationService for ReservationService {
                 let path_template = "/v1/{name}:move";
 
                 let resource_name = format!("//bigqueryreservation.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1888,6 +1896,7 @@ impl super::stub::ReservationService for ReservationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1906,6 +1915,7 @@ impl super::stub::ReservationService for ReservationService {
 
                 let resource_name =
                     format!("//bigqueryreservation.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1929,6 +1939,7 @@ impl super::stub::ReservationService for ReservationService {
 
                 let resource_name =
                     format!("//bigqueryreservation.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2005,6 +2016,7 @@ impl super::stub::ReservationService for ReservationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2023,6 +2035,7 @@ impl super::stub::ReservationService for ReservationService {
 
                 let resource_name =
                     format!("//bigqueryreservation.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2046,6 +2059,7 @@ impl super::stub::ReservationService for ReservationService {
 
                 let resource_name =
                     format!("//bigqueryreservation.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/bigquery/v2/src/transport.rs
+++ b/src/generated/cloud/bigquery/v2/src/transport.rs
@@ -473,6 +473,7 @@ impl super::stub::DatasetService for DatasetService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_project_id = try_match(
@@ -490,6 +491,8 @@ impl super::stub::DatasetService for DatasetService {
                 let path_template =
                     "/bigquery/v2/projects/{project_id}/datasets/{dataset_id}:undelete";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.dataset_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2353,6 +2356,7 @@ impl super::stub::RowAccessPolicyService for RowAccessPolicyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
         .or_else(|| {
             let var_project_id = try_match(Some(&req).map(|m| &m.project_id).map(|s| s.as_str()), &[Segment::SingleWildcard])?;
@@ -2366,6 +2370,9 @@ impl super::stub::RowAccessPolicyService for RowAccessPolicyService {
             );
             let path_template = "/bigquery/v2/projects/{project_id}/datasets/{dataset_id}/tables/{table_id}/rowAccessPolicies:batchDelete";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.dataset_id));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.table_id));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/billing/v1/src/transport.rs
+++ b/src/generated/cloud/billing/v1/src/transport.rs
@@ -655,6 +655,7 @@ impl super::stub::CloudBilling for CloudBilling {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -668,6 +669,7 @@ impl super::stub::CloudBilling for CloudBilling {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudbilling.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -719,6 +721,7 @@ impl super::stub::CloudBilling for CloudBilling {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -732,6 +735,7 @@ impl super::stub::CloudBilling for CloudBilling {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudbilling.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -783,6 +787,7 @@ impl super::stub::CloudBilling for CloudBilling {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -796,6 +801,7 @@ impl super::stub::CloudBilling for CloudBilling {
                 let path_template = "/v1/{name}:move";
 
                 let resource_name = format!("//cloudbilling.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -821,6 +827,8 @@ impl super::stub::CloudBilling for CloudBilling {
                     "//cloudbilling.googleapis.com/{}/{}",
                     var_destination_parent, var_name,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.destination_parent));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::GET, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::GET, path_template, resource_name)))

--- a/src/generated/cloud/binaryauthorization/v1/src/transport.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/transport.rs
@@ -527,6 +527,7 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -542,6 +543,7 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
 
                 let resource_name =
                     format!("//binaryauthorization.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -561,6 +563,7 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
 
                 let resource_name =
                     format!("//binaryauthorization.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -753,6 +756,7 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -768,6 +772,7 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
 
                 let resource_name =
                     format!("//binaryauthorization.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -787,6 +792,7 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
 
                 let resource_name =
                     format!("//binaryauthorization.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -951,6 +957,7 @@ impl super::stub::SystemPolicyV1 for SystemPolicyV1 {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -966,6 +973,7 @@ impl super::stub::SystemPolicyV1 for SystemPolicyV1 {
 
                 let resource_name =
                     format!("//binaryauthorization.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -985,6 +993,7 @@ impl super::stub::SystemPolicyV1 for SystemPolicyV1 {
 
                 let resource_name =
                     format!("//binaryauthorization.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1177,6 +1186,7 @@ impl super::stub::SystemPolicyV1 for SystemPolicyV1 {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1192,6 +1202,7 @@ impl super::stub::SystemPolicyV1 for SystemPolicyV1 {
 
                 let resource_name =
                     format!("//binaryauthorization.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1211,6 +1222,7 @@ impl super::stub::SystemPolicyV1 for SystemPolicyV1 {
 
                 let resource_name =
                     format!("//binaryauthorization.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1307,6 +1319,7 @@ impl super::stub::ValidationHelperV1 for ValidationHelperV1 {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_attestor = try_match(
@@ -1321,6 +1334,7 @@ impl super::stub::ValidationHelperV1 for ValidationHelperV1 {
                 let path = format!("/v1/{}:validateAttestationOccurrence", var_attestor,);
                 let path_template = "/v1/{attestor}:validateAttestationOccurrence";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.attestor));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1373,6 +1387,7 @@ impl super::stub::ValidationHelperV1 for ValidationHelperV1 {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1388,6 +1403,7 @@ impl super::stub::ValidationHelperV1 for ValidationHelperV1 {
 
                 let resource_name =
                     format!("//binaryauthorization.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1407,6 +1423,7 @@ impl super::stub::ValidationHelperV1 for ValidationHelperV1 {
 
                 let resource_name =
                     format!("//binaryauthorization.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1599,6 +1616,7 @@ impl super::stub::ValidationHelperV1 for ValidationHelperV1 {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1614,6 +1632,7 @@ impl super::stub::ValidationHelperV1 for ValidationHelperV1 {
 
                 let resource_name =
                     format!("//binaryauthorization.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1633,6 +1652,7 @@ impl super::stub::ValidationHelperV1 for ValidationHelperV1 {
 
                 let resource_name =
                     format!("//binaryauthorization.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/blockchainnodeengine/v1/src/transport.rs
+++ b/src/generated/cloud/blockchainnodeengine/v1/src/transport.rs
@@ -776,6 +776,7 @@ impl super::stub::BlockchainNodeEngine for BlockchainNodeEngine {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -792,6 +793,7 @@ impl super::stub::BlockchainNodeEngine for BlockchainNodeEngine {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/certificatemanager/v1/src/transport.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/transport.rs
@@ -2599,6 +2599,7 @@ impl super::stub::CertificateManager for CertificateManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2615,6 +2616,7 @@ impl super::stub::CertificateManager for CertificateManager {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/ces/v1/src/transport.rs
+++ b/src/generated/cloud/ces/v1/src/transport.rs
@@ -430,6 +430,7 @@ impl super::stub::AgentService for AgentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -447,6 +448,7 @@ impl super::stub::AgentService for AgentService {
                 let path_template = "/v1/{name}:exportApp";
 
                 let resource_name = format!("//ces.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -502,6 +504,7 @@ impl super::stub::AgentService for AgentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -517,6 +520,7 @@ impl super::stub::AgentService for AgentService {
                 let path_template = "/v1/{parent}/apps:importApp";
 
                 let resource_name = format!("//ces.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1763,6 +1767,7 @@ impl super::stub::AgentService for AgentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1780,6 +1785,7 @@ impl super::stub::AgentService for AgentService {
                 let path_template = "/v1/{parent}/conversations:batchDelete";
 
                 let resource_name = format!("//ces.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3593,6 +3599,7 @@ impl super::stub::AgentService for AgentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3612,6 +3619,7 @@ impl super::stub::AgentService for AgentService {
                 let path_template = "/v1/{name}:restore";
 
                 let resource_name = format!("//ces.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4163,6 +4171,7 @@ impl super::stub::AgentService for AgentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4179,6 +4188,7 @@ impl super::stub::AgentService for AgentService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4282,6 +4292,7 @@ impl super::stub::SessionService for SessionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_config_session = try_match(
@@ -4304,6 +4315,9 @@ impl super::stub::SessionService for SessionService {
                 let path_template = "/v1/{config.session}:runSession";
 
                 let resource_name = format!("//ces.googleapis.com/{}", var_config_session,);
+                let _ = Some(&mut req)
+                    .and_then(|m| m.config.as_mut())
+                    .map(|m| std::mem::take(&mut m.session));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4706,6 +4720,7 @@ impl super::stub::SessionService for SessionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4722,6 +4737,7 @@ impl super::stub::SessionService for SessionService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4811,6 +4827,7 @@ impl super::stub::ToolService for ToolService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -4828,6 +4845,7 @@ impl super::stub::ToolService for ToolService {
                 let path_template = "/v1/{parent}:executeTool";
 
                 let resource_name = format!("//ces.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4883,6 +4901,7 @@ impl super::stub::ToolService for ToolService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -4900,6 +4919,7 @@ impl super::stub::ToolService for ToolService {
                 let path_template = "/v1/{parent}:retrieveToolSchema";
 
                 let resource_name = format!("//ces.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4955,6 +4975,7 @@ impl super::stub::ToolService for ToolService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_toolset = try_match(
@@ -4974,6 +4995,7 @@ impl super::stub::ToolService for ToolService {
                 let path_template = "/v1/{toolset}:retrieveTools";
 
                 let resource_name = format!("//ces.googleapis.com/{}", var_toolset,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.toolset));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5373,6 +5395,7 @@ impl super::stub::ToolService for ToolService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5389,6 +5412,7 @@ impl super::stub::ToolService for ToolService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5478,6 +5502,7 @@ impl super::stub::WidgetService for WidgetService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5497,6 +5522,7 @@ impl super::stub::WidgetService for WidgetService {
                 let path_template = "/v1/{name}:generateChatToken";
 
                 let resource_name = format!("//ces.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5896,6 +5922,7 @@ impl super::stub::WidgetService for WidgetService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5912,6 +5939,7 @@ impl super::stub::WidgetService for WidgetService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/chronicle/v1/src/transport.rs
+++ b/src/generated/cloud/chronicle/v1/src/transport.rs
@@ -224,6 +224,7 @@ impl super::stub::BigQueryExportService for BigQueryExportService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -241,6 +242,7 @@ impl super::stub::BigQueryExportService for BigQueryExportService {
                 let path_template = "/v1/{parent}/bigQueryExport:provision";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -527,6 +529,7 @@ impl super::stub::BigQueryExportService for BigQueryExportService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -545,6 +548,7 @@ impl super::stub::BigQueryExportService for BigQueryExportService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1021,6 +1025,7 @@ impl super::stub::DashboardChartService for DashboardChartService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1039,6 +1044,7 @@ impl super::stub::DashboardChartService for DashboardChartService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1208,6 +1214,7 @@ impl super::stub::DashboardQueryService for DashboardQueryService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1225,6 +1232,7 @@ impl super::stub::DashboardQueryService for DashboardQueryService {
                 let path_template = "/v1/{parent}/dashboardQueries:execute";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1511,6 +1519,7 @@ impl super::stub::DashboardQueryService for DashboardQueryService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1529,6 +1538,7 @@ impl super::stub::DashboardQueryService for DashboardQueryService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2671,6 +2681,7 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2689,6 +2700,7 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3597,6 +3609,7 @@ impl super::stub::DataTableService for DataTableService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -3616,6 +3629,7 @@ impl super::stub::DataTableService for DataTableService {
                 let path_template = "/v1/{parent}/dataTableRows:bulkCreate";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3675,6 +3689,7 @@ impl super::stub::DataTableService for DataTableService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -3694,6 +3709,7 @@ impl super::stub::DataTableService for DataTableService {
                 let path_template = "/v1/{parent}/dataTableRows:bulkGet";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3753,6 +3769,7 @@ impl super::stub::DataTableService for DataTableService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -3772,6 +3789,7 @@ impl super::stub::DataTableService for DataTableService {
                 let path_template = "/v1/{parent}/dataTableRows:bulkReplace";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3831,6 +3849,7 @@ impl super::stub::DataTableService for DataTableService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -3850,6 +3869,7 @@ impl super::stub::DataTableService for DataTableService {
                 let path_template = "/v1/{parent}/dataTableRows:bulkUpdate";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4216,6 +4236,7 @@ impl super::stub::DataTableService for DataTableService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4234,6 +4255,7 @@ impl super::stub::DataTableService for DataTableService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4953,6 +4975,7 @@ impl super::stub::EntityService for EntityService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4971,6 +4994,7 @@ impl super::stub::EntityService for EntityService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5199,6 +5223,7 @@ impl super::stub::FeaturedContentNativeDashboardService for FeaturedContentNativ
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
         .or_else(|| {
             let var_name = try_match(Some(&req).map(|m| &m.name).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/instances/"), Segment::SingleWildcard, Segment::Literal("/contentHub/featuredContentNativeDashboards/"), Segment::SingleWildcard])?;
@@ -5212,6 +5237,7 @@ impl super::stub::FeaturedContentNativeDashboardService for FeaturedContentNativ
                 "//chronicle.googleapis.com/{}",
                 var_name,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5488,6 +5514,7 @@ impl super::stub::FeaturedContentNativeDashboardService for FeaturedContentNativ
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5506,6 +5533,7 @@ impl super::stub::FeaturedContentNativeDashboardService for FeaturedContentNativ
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6160,6 +6188,7 @@ impl super::stub::FindingsRefinementService for FindingsRefinementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6179,6 +6208,7 @@ impl super::stub::FindingsRefinementService for FindingsRefinementService {
                 let path_template = "/v1/{name}:computeFindingsRefinementActivity";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6236,6 +6266,7 @@ impl super::stub::FindingsRefinementService for FindingsRefinementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_instance = try_match(
@@ -6256,6 +6287,7 @@ impl super::stub::FindingsRefinementService for FindingsRefinementService {
                 let path_template = "/v1/{instance}:computeAllFindingsRefinementActivities";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_instance,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.instance));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6540,6 +6572,7 @@ impl super::stub::FindingsRefinementService for FindingsRefinementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6558,6 +6591,7 @@ impl super::stub::FindingsRefinementService for FindingsRefinementService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6950,6 +6984,7 @@ impl super::stub::InstanceService for InstanceService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6968,6 +7003,7 @@ impl super::stub::InstanceService for InstanceService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -7386,6 +7422,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7405,6 +7442,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
                 let path_template = "/v1/{name}:duplicate";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7548,6 +7586,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7567,6 +7606,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
                 let path_template = "/v1/{name}:addChart";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7624,6 +7664,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7643,6 +7684,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
                 let path_template = "/v1/{name}:removeChart";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7700,6 +7742,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7719,6 +7762,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
                 let path_template = "/v1/{name}:editChart";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7776,6 +7820,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7795,6 +7840,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
                 let path_template = "/v1/{name}:duplicateChart";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7854,6 +7900,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -7871,6 +7918,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
                 let path_template = "/v1/{parent}/nativeDashboards:export";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7928,6 +7976,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -7945,6 +7994,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
                 let path_template = "/v1/{parent}/nativeDashboards:import";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8231,6 +8281,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -8249,6 +8300,7 @@ impl super::stub::NativeDashboardService for NativeDashboardService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -8665,6 +8717,7 @@ impl super::stub::ReferenceListService for ReferenceListService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_instance = try_match(
@@ -8682,6 +8735,7 @@ impl super::stub::ReferenceListService for ReferenceListService {
                 let path_template = "/v1/{instance}:verifyReferenceList";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_instance,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.instance));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8968,6 +9022,7 @@ impl super::stub::ReferenceListService for ReferenceListService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -8986,6 +9041,7 @@ impl super::stub::ReferenceListService for ReferenceListService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -9477,6 +9533,7 @@ impl super::stub::RuleService for RuleService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_instance = try_match(
@@ -9494,6 +9551,7 @@ impl super::stub::RuleService for RuleService {
                 let path_template = "/v1/{instance}:verifyRuleText";
 
                 let resource_name = format!("//chronicle.googleapis.com/{}", var_instance,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.instance));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10343,6 +10401,7 @@ impl super::stub::RuleService for RuleService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -10361,6 +10420,7 @@ impl super::stub::RuleService for RuleService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -10770,6 +10830,7 @@ impl super::stub::RuleExecutionErrorService for RuleExecutionErrorService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -10788,6 +10849,7 @@ impl super::stub::RuleExecutionErrorService for RuleExecutionErrorService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/clouddms/v1/src/transport.rs
+++ b/src/generated/cloud/clouddms/v1/src/transport.rs
@@ -441,6 +441,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -458,6 +459,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{name}:start";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -515,6 +517,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -532,6 +535,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{name}:stop";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -589,6 +593,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -606,6 +611,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{name}:resume";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -663,6 +669,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -680,6 +687,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{name}:promote";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -737,6 +745,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -754,6 +763,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{name}:verify";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -811,6 +821,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -828,6 +839,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{name}:restart";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -885,6 +897,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_migration_job = try_match(
@@ -903,6 +916,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
 
                 let resource_name =
                     format!("//datamigration.googleapis.com/{}", var_migration_job,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.migration_job));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -960,6 +974,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_migration_job = try_match(
@@ -978,6 +993,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
 
                 let resource_name =
                     format!("//datamigration.googleapis.com/{}", var_migration_job,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.migration_job));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2422,6 +2438,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2439,6 +2456,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{name}:seed";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2496,6 +2514,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2513,6 +2532,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{parent}/mappingRules:import";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2570,6 +2590,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2587,6 +2608,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{name}:convert";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2644,6 +2666,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2661,6 +2684,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{name}:commit";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2718,6 +2742,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2735,6 +2760,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{name}:rollback";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2792,6 +2818,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2809,6 +2836,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{name}:apply";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3331,6 +3359,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3348,6 +3377,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3368,6 +3398,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3388,6 +3419,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3408,6 +3440,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3745,6 +3778,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3762,6 +3796,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3782,6 +3817,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3802,6 +3838,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3822,6 +3859,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//datamigration.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4145,6 +4183,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4161,6 +4200,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/cloudsecuritycompliance/v1/src/transport.rs
+++ b/src/generated/cloud/cloudsecuritycompliance/v1/src/transport.rs
@@ -54,6 +54,7 @@ impl super::stub::Audit for Audit {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_scope = try_match(
@@ -72,6 +73,7 @@ impl super::stub::Audit for Audit {
                 let path_template =
                     "/v1/{scope}/frameworkAuditScopeReports:generateFrameworkAuditScopeReport";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.scope));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -93,6 +95,7 @@ impl super::stub::Audit for Audit {
                 let path_template =
                     "/v1/{scope}/frameworkAuditScopeReports:generateFrameworkAuditScopeReport";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.scope));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -114,6 +117,7 @@ impl super::stub::Audit for Audit {
                 let path_template =
                     "/v1/{scope}/frameworkAuditScopeReports:generateFrameworkAuditScopeReport";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.scope));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1145,6 +1149,7 @@ impl super::stub::Audit for Audit {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1161,6 +1166,7 @@ impl super::stub::Audit for Audit {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1180,6 +1186,7 @@ impl super::stub::Audit for Audit {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2141,6 +2148,7 @@ impl super::stub::CmEnrollmentService for CmEnrollmentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2157,6 +2165,7 @@ impl super::stub::CmEnrollmentService for CmEnrollmentService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2176,6 +2185,7 @@ impl super::stub::CmEnrollmentService for CmEnrollmentService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3976,6 +3986,7 @@ impl super::stub::Config for Config {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3992,6 +4003,7 @@ impl super::stub::Config for Config {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4011,6 +4023,7 @@ impl super::stub::Config for Config {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5291,6 +5304,7 @@ impl super::stub::Deployment for Deployment {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5307,6 +5321,7 @@ impl super::stub::Deployment for Deployment {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5326,6 +5341,7 @@ impl super::stub::Deployment for Deployment {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6857,6 +6873,7 @@ impl super::stub::Monitoring for Monitoring {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6873,6 +6890,7 @@ impl super::stub::Monitoring for Monitoring {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6892,6 +6910,7 @@ impl super::stub::Monitoring for Monitoring {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/transport.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/transport.rs
@@ -210,6 +210,7 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -225,6 +226,7 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
                 let path = format!("/v1/{}:assign", var_parent,);
                 let path_template = "/v1/{parent}:assign";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -278,6 +280,7 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -293,6 +296,7 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
                 let path = format!("/v1/{}:unassign", var_parent,);
                 let path_template = "/v1/{parent}:unassign";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -515,6 +519,7 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -531,6 +536,7 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
                     "//cloudcommerceconsumerprocurement.googleapis.com/{}",
                     var_parent,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -713,6 +719,7 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -727,6 +734,7 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
                 let path = format!("/v1/{}:modify", var_name,);
                 let path_template = "/v1/{name}:modify";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -779,6 +787,7 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -793,6 +802,7 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/confidentialcomputing/v1/src/transport.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/transport.rs
@@ -125,6 +125,7 @@ impl super::stub::ConfidentialComputing for ConfidentialComputing {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_challenge = try_match(
@@ -143,6 +144,7 @@ impl super::stub::ConfidentialComputing for ConfidentialComputing {
 
                 let resource_name =
                     format!("//confidentialcomputing.googleapis.com/{}", var_challenge,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.challenge));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -198,6 +200,7 @@ impl super::stub::ConfidentialComputing for ConfidentialComputing {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_challenge = try_match(
@@ -216,6 +219,7 @@ impl super::stub::ConfidentialComputing for ConfidentialComputing {
 
                 let resource_name =
                     format!("//confidentialcomputing.googleapis.com/{}", var_challenge,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.challenge));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -271,6 +275,7 @@ impl super::stub::ConfidentialComputing for ConfidentialComputing {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_challenge = try_match(
@@ -289,6 +294,7 @@ impl super::stub::ConfidentialComputing for ConfidentialComputing {
 
                 let resource_name =
                     format!("//confidentialcomputing.googleapis.com/{}", var_challenge,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.challenge));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/config/v1/src/transport.rs
+++ b/src/generated/cloud/config/v1/src/transport.rs
@@ -746,6 +746,7 @@ impl super::stub::Config for Config {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -763,6 +764,7 @@ impl super::stub::Config for Config {
                 let path_template = "/v1/{parent}:exportState";
 
                 let resource_name = format!("//config.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -818,6 +820,7 @@ impl super::stub::Config for Config {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -837,6 +840,7 @@ impl super::stub::Config for Config {
                 let path_template = "/v1/{parent}:exportState";
 
                 let resource_name = format!("//config.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -894,6 +898,7 @@ impl super::stub::Config for Config {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -911,6 +916,7 @@ impl super::stub::Config for Config {
                 let path_template = "/v1/{parent}:importState";
 
                 let resource_name = format!("//config.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -966,6 +972,7 @@ impl super::stub::Config for Config {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -983,6 +990,7 @@ impl super::stub::Config for Config {
                 let path_template = "/v1/{name}:deleteState";
 
                 let resource_name = format!("//config.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1044,6 +1052,7 @@ impl super::stub::Config for Config {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1061,6 +1070,7 @@ impl super::stub::Config for Config {
                 let path_template = "/v1/{name}:lock";
 
                 let resource_name = format!("//config.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1116,6 +1126,7 @@ impl super::stub::Config for Config {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1133,6 +1144,7 @@ impl super::stub::Config for Config {
                 let path_template = "/v1/{name}:unlock";
 
                 let resource_name = format!("//config.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1547,6 +1559,7 @@ impl super::stub::Config for Config {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1564,6 +1577,7 @@ impl super::stub::Config for Config {
                 let path_template = "/v1/{parent}:export";
 
                 let resource_name = format!("//config.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2604,6 +2618,7 @@ impl super::stub::Config for Config {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2621,6 +2636,7 @@ impl super::stub::Config for Config {
                 let path_template = "/v1/{name}:provision";
 
                 let resource_name = format!("//config.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2676,6 +2692,7 @@ impl super::stub::Config for Config {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2693,6 +2710,7 @@ impl super::stub::Config for Config {
                 let path_template = "/v1/{name}:deprovision";
 
                 let resource_name = format!("//config.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3023,6 +3041,7 @@ impl super::stub::Config for Config {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3040,6 +3059,7 @@ impl super::stub::Config for Config {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//config.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3179,6 +3199,7 @@ impl super::stub::Config for Config {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3196,6 +3217,7 @@ impl super::stub::Config for Config {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//config.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3468,6 +3490,7 @@ impl super::stub::Config for Config {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3484,6 +3507,7 @@ impl super::stub::Config for Config {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/configdelivery/v1/src/transport.rs
+++ b/src/generated/cloud/configdelivery/v1/src/transport.rs
@@ -1794,6 +1794,7 @@ impl super::stub::ConfigDelivery for ConfigDelivery {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1813,6 +1814,7 @@ impl super::stub::ConfigDelivery for ConfigDelivery {
                 let path_template = "/v1/{name}:suspend";
 
                 let resource_name = format!("//configdelivery.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1870,6 +1872,7 @@ impl super::stub::ConfigDelivery for ConfigDelivery {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1889,6 +1892,7 @@ impl super::stub::ConfigDelivery for ConfigDelivery {
                 let path_template = "/v1/{name}:resume";
 
                 let resource_name = format!("//configdelivery.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1946,6 +1950,7 @@ impl super::stub::ConfigDelivery for ConfigDelivery {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1965,6 +1970,7 @@ impl super::stub::ConfigDelivery for ConfigDelivery {
                 let path_template = "/v1/{name}:abort";
 
                 let resource_name = format!("//configdelivery.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2364,6 +2370,7 @@ impl super::stub::ConfigDelivery for ConfigDelivery {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2380,6 +2387,7 @@ impl super::stub::ConfigDelivery for ConfigDelivery {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/connectors/v1/src/transport.rs
+++ b/src/generated/cloud/connectors/v1/src/transport.rs
@@ -959,6 +959,7 @@ impl super::stub::Connectors for Connectors {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -977,6 +978,7 @@ impl super::stub::Connectors for Connectors {
                 let path_template = "/v1/{name}:refresh";
 
                 let resource_name = format!("//connectors.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1450,6 +1452,7 @@ impl super::stub::Connectors for Connectors {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1467,6 +1470,7 @@ impl super::stub::Connectors for Connectors {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//connectors.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1487,6 +1491,7 @@ impl super::stub::Connectors for Connectors {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//connectors.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1692,6 +1697,7 @@ impl super::stub::Connectors for Connectors {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1709,6 +1715,7 @@ impl super::stub::Connectors for Connectors {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//connectors.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1729,6 +1736,7 @@ impl super::stub::Connectors for Connectors {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//connectors.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2018,6 +2026,7 @@ impl super::stub::Connectors for Connectors {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2034,6 +2043,7 @@ impl super::stub::Connectors for Connectors {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
@@ -126,6 +126,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -142,6 +143,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
 
                 let resource_name =
                     format!("//contactcenterinsights.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -820,6 +822,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -836,6 +839,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
 
                 let resource_name =
                     format!("//contactcenterinsights.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -889,6 +893,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -905,6 +910,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
 
                 let resource_name =
                     format!("//contactcenterinsights.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -958,6 +964,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -974,6 +981,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
 
                 let resource_name =
                     format!("//contactcenterinsights.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1027,6 +1035,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1043,6 +1052,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
 
                 let resource_name =
                     format!("//contactcenterinsights.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1468,6 +1478,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1485,6 +1496,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 let path_template = "/v1/{name}:deploy";
 
                 let resource_name = format!("//contactcenterinsights.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1540,6 +1552,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1557,6 +1570,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 let path_template = "/v1/{name}:undeploy";
 
                 let resource_name = format!("//contactcenterinsights.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1612,6 +1626,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1629,6 +1644,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 let path_template = "/v1/{name}:export";
 
                 let resource_name = format!("//contactcenterinsights.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1684,6 +1700,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1700,6 +1717,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
 
                 let resource_name =
                     format!("//contactcenterinsights.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3255,6 +3273,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_encryption_spec_name = try_match(
@@ -3273,6 +3292,9 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 let path = format!("/v1/{}:initialize", var_encryption_spec_name,);
                 let path_template = "/v1/{encryption_spec.name}:initialize";
 
+                let _ = Some(&mut req)
+                    .and_then(|m| m.encryption_spec.as_mut())
+                    .map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3717,6 +3739,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_location = try_match(
@@ -3733,6 +3756,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
 
                 let resource_name =
                     format!("//contactcenterinsights.googleapis.com/{}", var_location,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.location));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3756,6 +3780,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
 
                 let resource_name =
                     format!("//contactcenterinsights.googleapis.com/{}", var_location,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.location));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4782,6 +4807,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -4802,6 +4828,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
 
                 let resource_name =
                     format!("//contactcenterinsights.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4859,6 +4886,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4878,6 +4906,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 let path_template = "/v1/{name}:deploy";
 
                 let resource_name = format!("//contactcenterinsights.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4935,6 +4964,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4954,6 +4984,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 let path_template = "/v1/{name}:undeploy";
 
                 let resource_name = format!("//contactcenterinsights.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5642,6 +5673,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -5658,6 +5690,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
 
                 let resource_name =
                     format!("//contactcenterinsights.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5711,6 +5744,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -5727,6 +5761,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
 
                 let resource_name =
                     format!("//contactcenterinsights.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/datacatalog/lineage/v1/src/transport.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/transport.rs
@@ -1223,6 +1223,7 @@ impl super::stub::Lineage for Lineage {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1238,6 +1239,7 @@ impl super::stub::Lineage for Lineage {
                 let path_template = "/v1/{parent}:searchLinks";
 
                 let resource_name = format!("//datalineage.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1291,6 +1293,7 @@ impl super::stub::Lineage for Lineage {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1306,6 +1309,7 @@ impl super::stub::Lineage for Lineage {
                 let path_template = "/v1/{parent}:batchSearchLinkProcesses";
 
                 let resource_name = format!("//datalineage.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1578,6 +1582,7 @@ impl super::stub::Lineage for Lineage {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1594,6 +1599,7 @@ impl super::stub::Lineage for Lineage {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/datacatalog/v1/src/transport.rs
+++ b/src/generated/cloud/datacatalog/v1/src/transport.rs
@@ -960,6 +960,7 @@ impl super::stub::DataCatalog for DataCatalog {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -979,6 +980,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{name}:modifyEntryOverview";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1036,6 +1038,7 @@ impl super::stub::DataCatalog for DataCatalog {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1055,6 +1058,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{name}:modifyEntryContacts";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1585,6 +1589,7 @@ impl super::stub::DataCatalog for DataCatalog {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1604,6 +1609,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{name}:rename";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1663,6 +1669,7 @@ impl super::stub::DataCatalog for DataCatalog {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1684,6 +1691,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{name}:rename";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2341,6 +2349,7 @@ impl super::stub::DataCatalog for DataCatalog {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2360,6 +2369,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{parent}/tags:reconcile";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2417,6 +2427,7 @@ impl super::stub::DataCatalog for DataCatalog {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2436,6 +2447,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{name}:star";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2493,6 +2505,7 @@ impl super::stub::DataCatalog for DataCatalog {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2512,6 +2525,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{name}:unstar";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2569,6 +2583,7 @@ impl super::stub::DataCatalog for DataCatalog {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2586,6 +2601,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2606,6 +2622,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2678,6 +2695,7 @@ impl super::stub::DataCatalog for DataCatalog {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2695,6 +2713,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2715,6 +2734,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2737,6 +2757,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2828,6 +2849,7 @@ impl super::stub::DataCatalog for DataCatalog {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2845,6 +2867,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2865,6 +2888,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2887,6 +2911,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2978,6 +3003,7 @@ impl super::stub::DataCatalog for DataCatalog {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2995,6 +3021,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path_template = "/v1/{parent}/entries:import";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3050,6 +3077,7 @@ impl super::stub::DataCatalog for DataCatalog {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3064,6 +3092,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path = format!("/v1/{}:setConfig", var_name,);
                 let path_template = "/v1/{name}:setConfig";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3081,6 +3110,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 let path = format!("/v1/{}:setConfig", var_name,);
                 let path_template = "/v1/{name}:setConfig";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4423,6 +4453,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4440,6 +4471,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4462,6 +4494,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4536,6 +4569,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4553,6 +4587,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4575,6 +4610,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4649,6 +4685,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4666,6 +4703,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4688,6 +4726,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5086,6 +5125,7 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5103,6 +5143,7 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
                 let path_template = "/v1/{name}:replace";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5160,6 +5201,7 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -5175,6 +5217,7 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
                 let path_template = "/v1/{parent}/taxonomies:import";
 
                 let resource_name = format!("//datacatalog.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/dataform/v1/src/transport.rs
+++ b/src/generated/cloud/dataform/v1/src/transport.rs
@@ -362,6 +362,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -379,6 +380,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{name}:deleteTree";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -888,6 +890,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -905,6 +908,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{name}:deleteTree";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1108,6 +1112,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1125,6 +1130,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{name}:move";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1560,6 +1566,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1577,6 +1584,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{name}:move";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1632,6 +1640,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1649,6 +1658,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{name}:commit";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2383,6 +2393,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_workspace = try_match(
@@ -2402,6 +2413,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{workspace}:installNpmPackages";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_workspace,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.workspace));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2459,6 +2471,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2478,6 +2491,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{name}:pull";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2535,6 +2549,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2554,6 +2569,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{name}:push";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2764,6 +2780,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2783,6 +2800,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{name}:commit";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2840,6 +2858,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2859,6 +2878,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{name}:reset";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3152,6 +3172,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_workspace = try_match(
@@ -3171,6 +3192,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{workspace}:makeDirectory";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_workspace,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.workspace));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3228,6 +3250,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_workspace = try_match(
@@ -3247,6 +3270,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{workspace}:removeDirectory";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_workspace,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.workspace));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3304,6 +3328,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_workspace = try_match(
@@ -3323,6 +3348,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{workspace}:moveDirectory";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_workspace,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.workspace));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3458,6 +3484,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_workspace = try_match(
@@ -3477,6 +3504,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{workspace}:removeFile";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_workspace,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.workspace));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3534,6 +3562,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_workspace = try_match(
@@ -3553,6 +3582,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{workspace}:moveFile";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_workspace,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.workspace));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3610,6 +3640,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_workspace = try_match(
@@ -3629,6 +3660,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{workspace}:writeFile";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_workspace,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.workspace));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5091,6 +5123,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5110,6 +5143,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{name}:cancel";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5638,6 +5672,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -5655,6 +5690,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5677,6 +5713,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5697,6 +5734,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5717,6 +5755,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5825,6 +5864,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -5842,6 +5882,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5864,6 +5905,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5884,6 +5926,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5904,6 +5947,7 @@ impl super::stub::Dataform for Dataform {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataform.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6354,6 +6398,7 @@ impl super::stub::Dataform for Dataform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6370,6 +6415,7 @@ impl super::stub::Dataform for Dataform {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/datafusion/v1/src/transport.rs
+++ b/src/generated/cloud/datafusion/v1/src/transport.rs
@@ -502,6 +502,7 @@ impl super::stub::DataFusion for DataFusion {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -519,6 +520,7 @@ impl super::stub::DataFusion for DataFusion {
                 let path_template = "/v1/{name}:restart";
 
                 let resource_name = format!("//datafusion.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -791,6 +793,7 @@ impl super::stub::DataFusion for DataFusion {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -807,6 +810,7 @@ impl super::stub::DataFusion for DataFusion {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/dataplex/v1/src/transport.rs
+++ b/src/generated/cloud/dataplex/v1/src/transport.rs
@@ -1383,6 +1383,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1400,6 +1401,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1422,6 +1424,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1446,6 +1449,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1468,6 +1472,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1488,6 +1493,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1508,6 +1514,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1530,6 +1537,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1550,6 +1558,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1570,6 +1579,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1590,6 +1600,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1610,6 +1621,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1630,6 +1642,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1650,6 +1663,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1670,6 +1684,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1692,6 +1707,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1714,6 +1730,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1734,6 +1751,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1754,6 +1772,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1774,6 +1793,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1794,6 +1814,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3229,6 +3250,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3246,6 +3268,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3268,6 +3291,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3292,6 +3316,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3314,6 +3339,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3334,6 +3360,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3354,6 +3381,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3376,6 +3404,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3396,6 +3425,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3416,6 +3446,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3436,6 +3467,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3456,6 +3488,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3476,6 +3509,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3496,6 +3530,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3516,6 +3551,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3538,6 +3574,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3560,6 +3597,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3580,6 +3618,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3600,6 +3639,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3620,6 +3660,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3640,6 +3681,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4358,6 +4400,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4374,6 +4417,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4393,6 +4437,7 @@ impl super::stub::BusinessGlossaryService for BusinessGlossaryService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6131,6 +6176,7 @@ impl super::stub::CatalogService for CatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6145,6 +6191,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path = format!("/v1/{}:modifyEntry", var_name,);
                 let path_template = "/v1/{name}:modifyEntry";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6485,6 +6532,7 @@ impl super::stub::CatalogService for CatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6502,6 +6550,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{name}:cancel";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6872,6 +6921,7 @@ impl super::stub::CatalogService for CatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6886,6 +6936,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path = format!("/v1/{}:lookupContext", var_name,);
                 let path_template = "/v1/{name}:lookupContext";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -7514,6 +7565,7 @@ impl super::stub::CatalogService for CatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -7531,6 +7583,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7553,6 +7606,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7577,6 +7631,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7599,6 +7654,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7619,6 +7675,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7639,6 +7696,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7661,6 +7719,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7681,6 +7740,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7701,6 +7761,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7721,6 +7782,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7741,6 +7803,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7761,6 +7824,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7781,6 +7845,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7801,6 +7866,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7823,6 +7889,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7845,6 +7912,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7865,6 +7933,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7885,6 +7954,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7905,6 +7975,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7925,6 +7996,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9360,6 +9432,7 @@ impl super::stub::CatalogService for CatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -9377,6 +9450,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9399,6 +9473,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9423,6 +9498,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9445,6 +9521,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9465,6 +9542,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9485,6 +9563,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9507,6 +9586,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9527,6 +9607,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9547,6 +9628,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9567,6 +9649,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9587,6 +9670,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9607,6 +9691,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9627,6 +9712,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9647,6 +9733,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9669,6 +9756,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9691,6 +9779,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9711,6 +9800,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9731,6 +9821,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9751,6 +9842,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9771,6 +9863,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10489,6 +10582,7 @@ impl super::stub::CatalogService for CatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -10505,6 +10599,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -10524,6 +10619,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -11146,6 +11242,7 @@ impl super::stub::CmekService for CmekService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -11163,6 +11260,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11185,6 +11283,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11209,6 +11308,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11231,6 +11331,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11251,6 +11352,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11271,6 +11373,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11293,6 +11396,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11313,6 +11417,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11333,6 +11438,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11353,6 +11459,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11373,6 +11480,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11393,6 +11501,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11413,6 +11522,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11433,6 +11543,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11455,6 +11566,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11477,6 +11589,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11497,6 +11610,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11517,6 +11631,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11537,6 +11652,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11557,6 +11673,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -12992,6 +13109,7 @@ impl super::stub::CmekService for CmekService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -13009,6 +13127,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13031,6 +13150,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13055,6 +13175,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13077,6 +13198,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13097,6 +13219,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13117,6 +13240,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13139,6 +13263,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13159,6 +13284,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13179,6 +13305,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13199,6 +13326,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13219,6 +13347,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13239,6 +13368,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13259,6 +13389,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13279,6 +13410,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13301,6 +13433,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13323,6 +13456,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13343,6 +13477,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13363,6 +13498,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13383,6 +13519,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13403,6 +13540,7 @@ impl super::stub::CmekService for CmekService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14121,6 +14259,7 @@ impl super::stub::CmekService for CmekService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -14137,6 +14276,7 @@ impl super::stub::CmekService for CmekService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -14156,6 +14296,7 @@ impl super::stub::CmekService for CmekService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -14401,6 +14542,7 @@ impl super::stub::ContentService for ContentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -14418,6 +14560,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14440,6 +14583,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14464,6 +14608,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14486,6 +14631,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14506,6 +14652,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14526,6 +14673,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14548,6 +14696,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14568,6 +14717,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14588,6 +14738,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14608,6 +14759,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14628,6 +14780,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14648,6 +14801,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14668,6 +14822,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14688,6 +14843,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14710,6 +14866,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14732,6 +14889,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14752,6 +14910,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14772,6 +14931,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14792,6 +14952,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14812,6 +14973,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16247,6 +16409,7 @@ impl super::stub::ContentService for ContentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -16264,6 +16427,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16286,6 +16450,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16310,6 +16475,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16332,6 +16498,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16352,6 +16519,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16372,6 +16540,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16394,6 +16563,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16414,6 +16584,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16434,6 +16605,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16454,6 +16626,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16474,6 +16647,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16494,6 +16668,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16514,6 +16689,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16534,6 +16710,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16556,6 +16733,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16578,6 +16756,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16598,6 +16777,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16618,6 +16798,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16638,6 +16819,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16658,6 +16840,7 @@ impl super::stub::ContentService for ContentService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -17376,6 +17559,7 @@ impl super::stub::ContentService for ContentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -17392,6 +17576,7 @@ impl super::stub::ContentService for ContentService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -17411,6 +17596,7 @@ impl super::stub::ContentService for ContentService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -17894,6 +18080,7 @@ impl super::stub::DataProductService for DataProductService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -17911,6 +18098,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{parent}:requestAccess";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18490,6 +18678,7 @@ impl super::stub::DataProductService for DataProductService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -18507,6 +18696,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18529,6 +18719,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18553,6 +18744,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18575,6 +18767,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18595,6 +18788,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18615,6 +18809,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18637,6 +18832,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18657,6 +18853,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18677,6 +18874,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18697,6 +18895,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18717,6 +18916,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18737,6 +18937,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18757,6 +18958,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18777,6 +18979,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18799,6 +19002,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18821,6 +19025,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18841,6 +19046,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18861,6 +19067,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18881,6 +19088,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18901,6 +19109,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20336,6 +20545,7 @@ impl super::stub::DataProductService for DataProductService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -20353,6 +20563,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20375,6 +20586,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20399,6 +20611,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20421,6 +20634,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20441,6 +20655,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20461,6 +20676,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20483,6 +20699,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20503,6 +20720,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20523,6 +20741,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20543,6 +20762,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20563,6 +20783,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20583,6 +20804,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20603,6 +20825,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20623,6 +20846,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20645,6 +20869,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20667,6 +20892,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20687,6 +20913,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20707,6 +20934,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20727,6 +20955,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20747,6 +20976,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -21465,6 +21695,7 @@ impl super::stub::DataProductService for DataProductService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -21481,6 +21712,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -21500,6 +21732,7 @@ impl super::stub::DataProductService for DataProductService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -22931,6 +23164,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -22948,6 +23182,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -22970,6 +23205,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -22994,6 +23230,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23016,6 +23253,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23036,6 +23274,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23056,6 +23295,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23078,6 +23318,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23098,6 +23339,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23118,6 +23360,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23138,6 +23381,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23158,6 +23402,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23178,6 +23423,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23198,6 +23444,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23218,6 +23465,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23240,6 +23488,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23262,6 +23511,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23282,6 +23532,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23302,6 +23553,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23322,6 +23574,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23342,6 +23595,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24777,6 +25031,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -24794,6 +25049,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24816,6 +25072,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24840,6 +25097,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24862,6 +25120,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24882,6 +25141,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24902,6 +25162,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24924,6 +25185,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24944,6 +25206,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24964,6 +25227,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24984,6 +25248,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25004,6 +25269,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25024,6 +25290,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25044,6 +25311,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25064,6 +25332,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25086,6 +25355,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25108,6 +25378,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25128,6 +25399,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25148,6 +25420,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25168,6 +25441,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25188,6 +25462,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25906,6 +26181,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -25922,6 +26198,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -25941,6 +26218,7 @@ impl super::stub::DataTaxonomyService for DataTaxonomyService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -26438,6 +26716,7 @@ impl super::stub::DataScanService for DataScanService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -26455,6 +26734,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{name}:run";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -26662,6 +26942,7 @@ impl super::stub::DataScanService for DataScanService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -26681,6 +26962,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{name}:cancel";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -26738,6 +27020,7 @@ impl super::stub::DataScanService for DataScanService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -26754,6 +27037,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path = format!("/v1/{}:generateDataQualityRules", var_name,);
                 let path_template = "/v1/{name}:generateDataQualityRules";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -26775,6 +27059,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path = format!("/v1/{}:generateDataQualityRules", var_name,);
                 let path_template = "/v1/{name}:generateDataQualityRules";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -26975,6 +27260,7 @@ impl super::stub::DataScanService for DataScanService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -26992,6 +27278,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27014,6 +27301,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27038,6 +27326,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27060,6 +27349,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27080,6 +27370,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27100,6 +27391,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27122,6 +27414,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27142,6 +27435,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27162,6 +27456,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27182,6 +27477,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27202,6 +27498,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27222,6 +27519,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27242,6 +27540,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27262,6 +27561,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27284,6 +27584,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27306,6 +27607,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27326,6 +27628,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27346,6 +27649,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27366,6 +27670,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -27386,6 +27691,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -28821,6 +29127,7 @@ impl super::stub::DataScanService for DataScanService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -28838,6 +29145,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -28860,6 +29168,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -28884,6 +29193,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -28906,6 +29216,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -28926,6 +29237,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -28946,6 +29258,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -28968,6 +29281,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -28988,6 +29302,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29008,6 +29323,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29028,6 +29344,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29048,6 +29365,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29068,6 +29386,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29088,6 +29407,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29108,6 +29428,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29130,6 +29451,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29152,6 +29474,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29172,6 +29495,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29192,6 +29516,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29212,6 +29537,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29232,6 +29558,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29950,6 +30277,7 @@ impl super::stub::DataScanService for DataScanService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -29966,6 +30294,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -29985,6 +30314,7 @@ impl super::stub::DataScanService for DataScanService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -30981,6 +31311,7 @@ impl super::stub::MetadataService for MetadataService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -30998,6 +31329,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31020,6 +31352,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31044,6 +31377,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31066,6 +31400,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31086,6 +31421,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31106,6 +31442,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31128,6 +31465,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31148,6 +31486,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31168,6 +31507,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31188,6 +31528,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31208,6 +31549,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31228,6 +31570,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31248,6 +31591,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31268,6 +31612,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31290,6 +31635,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31312,6 +31658,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31332,6 +31679,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31352,6 +31700,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31372,6 +31721,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31392,6 +31742,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -32827,6 +33178,7 @@ impl super::stub::MetadataService for MetadataService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -32844,6 +33196,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -32866,6 +33219,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -32890,6 +33244,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -32912,6 +33267,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -32932,6 +33288,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -32952,6 +33309,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -32974,6 +33332,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -32994,6 +33353,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -33014,6 +33374,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -33034,6 +33395,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -33054,6 +33416,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -33074,6 +33437,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -33094,6 +33458,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -33114,6 +33479,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -33136,6 +33502,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -33158,6 +33525,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -33178,6 +33546,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -33198,6 +33567,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -33218,6 +33588,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -33238,6 +33609,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -33956,6 +34328,7 @@ impl super::stub::MetadataService for MetadataService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -33972,6 +34345,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -33991,6 +34365,7 @@ impl super::stub::MetadataService for MetadataService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -35997,6 +36372,7 @@ impl super::stub::DataplexService for DataplexService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -36016,6 +36392,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{name}:run";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36153,6 +36530,7 @@ impl super::stub::DataplexService for DataplexService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -36174,6 +36552,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{name}:cancel";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36364,6 +36743,7 @@ impl super::stub::DataplexService for DataplexService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -36381,6 +36761,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36403,6 +36784,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36427,6 +36809,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36449,6 +36832,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36469,6 +36853,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36489,6 +36874,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36511,6 +36897,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36531,6 +36918,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36551,6 +36939,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36571,6 +36960,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36591,6 +36981,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36611,6 +37002,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36631,6 +37023,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36651,6 +37044,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36673,6 +37067,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36695,6 +37090,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36715,6 +37111,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36735,6 +37132,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36755,6 +37153,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -36775,6 +37174,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38210,6 +38610,7 @@ impl super::stub::DataplexService for DataplexService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -38227,6 +38628,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38249,6 +38651,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38273,6 +38676,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38295,6 +38699,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38315,6 +38720,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38335,6 +38741,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38357,6 +38764,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38377,6 +38785,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38397,6 +38806,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38417,6 +38827,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38437,6 +38848,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38457,6 +38869,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38477,6 +38890,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38497,6 +38911,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38519,6 +38934,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38541,6 +38957,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38561,6 +38978,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38581,6 +38999,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38601,6 +39020,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -38621,6 +39041,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataplex.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -39339,6 +39760,7 @@ impl super::stub::DataplexService for DataplexService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -39355,6 +39777,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -39374,6 +39797,7 @@ impl super::stub::DataplexService for DataplexService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/dataproc/v1/src/transport.rs
+++ b/src/generated/cloud/dataproc/v1/src/transport.rs
@@ -614,6 +614,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -631,6 +632,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -651,6 +653,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -671,6 +674,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -691,6 +695,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -711,6 +716,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -731,6 +737,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -751,6 +758,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -908,6 +916,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -925,6 +934,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -945,6 +955,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -965,6 +976,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -985,6 +997,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1005,6 +1018,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1025,6 +1039,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1045,6 +1060,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1202,6 +1218,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1219,6 +1236,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1239,6 +1257,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1259,6 +1278,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1279,6 +1299,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1299,6 +1320,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1319,6 +1341,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1339,6 +1362,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2259,6 +2283,7 @@ impl super::stub::BatchController for BatchController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2276,6 +2301,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2296,6 +2322,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2316,6 +2343,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2336,6 +2364,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2356,6 +2385,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2376,6 +2406,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2396,6 +2427,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2553,6 +2585,7 @@ impl super::stub::BatchController for BatchController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2570,6 +2603,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2590,6 +2624,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2610,6 +2645,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2630,6 +2666,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2650,6 +2687,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2670,6 +2708,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2690,6 +2729,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2847,6 +2887,7 @@ impl super::stub::BatchController for BatchController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2864,6 +2905,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2884,6 +2926,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2904,6 +2947,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2924,6 +2968,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2944,6 +2989,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2964,6 +3010,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2984,6 +3031,7 @@ impl super::stub::BatchController for BatchController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3803,6 +3851,7 @@ impl super::stub::ClusterController for ClusterController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_project_id = try_match(
@@ -3824,6 +3873,9 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template =
                     "/v1/projects/{project_id}/regions/{region}/clusters/{cluster_name}:stop";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.region));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3883,6 +3935,7 @@ impl super::stub::ClusterController for ClusterController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_project_id = try_match(
@@ -3904,6 +3957,9 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template =
                     "/v1/projects/{project_id}/regions/{region}/clusters/{cluster_name}:start";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.region));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4197,6 +4253,7 @@ impl super::stub::ClusterController for ClusterController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_project_id = try_match(
@@ -4218,6 +4275,9 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template =
                     "/v1/projects/{project_id}/regions/{region}/clusters/{cluster_name}:diagnose";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.region));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4277,6 +4337,7 @@ impl super::stub::ClusterController for ClusterController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4294,6 +4355,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4314,6 +4376,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4334,6 +4397,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4354,6 +4418,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4374,6 +4439,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4394,6 +4460,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4414,6 +4481,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4571,6 +4639,7 @@ impl super::stub::ClusterController for ClusterController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4588,6 +4657,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4608,6 +4678,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4628,6 +4699,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4648,6 +4720,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4668,6 +4741,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4688,6 +4762,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4708,6 +4783,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4865,6 +4941,7 @@ impl super::stub::ClusterController for ClusterController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4882,6 +4959,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4902,6 +4980,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4922,6 +5001,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4942,6 +5022,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4962,6 +5043,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4982,6 +5064,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5002,6 +5085,7 @@ impl super::stub::ClusterController for ClusterController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5644,6 +5728,7 @@ impl super::stub::JobController for JobController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_project_id = try_match(
@@ -5660,6 +5745,8 @@ impl super::stub::JobController for JobController {
                 );
                 let path_template = "/v1/projects/{project_id}/regions/{region}/jobs:submit";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.region));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5713,6 +5800,7 @@ impl super::stub::JobController for JobController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_project_id = try_match(
@@ -5730,6 +5818,8 @@ impl super::stub::JobController for JobController {
                 let path_template =
                     "/v1/projects/{project_id}/regions/{region}/jobs:submitAsOperation";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.region));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6027,6 +6117,7 @@ impl super::stub::JobController for JobController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_project_id = try_match(
@@ -6048,6 +6139,9 @@ impl super::stub::JobController for JobController {
                 let path_template =
                     "/v1/projects/{project_id}/regions/{region}/jobs/{job_id}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.region));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.job_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6192,6 +6286,7 @@ impl super::stub::JobController for JobController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -6209,6 +6304,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6229,6 +6325,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6249,6 +6346,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6269,6 +6367,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6289,6 +6388,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6309,6 +6409,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6329,6 +6430,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6486,6 +6588,7 @@ impl super::stub::JobController for JobController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -6503,6 +6606,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6523,6 +6627,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6543,6 +6648,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6563,6 +6669,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6583,6 +6690,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6603,6 +6711,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6623,6 +6732,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6780,6 +6890,7 @@ impl super::stub::JobController for JobController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -6797,6 +6908,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6817,6 +6929,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6837,6 +6950,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6857,6 +6971,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6877,6 +6992,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6897,6 +7013,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6917,6 +7034,7 @@ impl super::stub::JobController for JobController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7633,6 +7751,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7651,6 +7770,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path = format!("/v1/{}:resize", var_name,);
                 let path_template = "/v1/{name}:resize";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -7783,6 +7903,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -7800,6 +7921,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7820,6 +7942,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7840,6 +7963,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7860,6 +7984,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7880,6 +8005,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7900,6 +8026,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7920,6 +8047,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8077,6 +8205,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -8094,6 +8223,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8114,6 +8244,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8134,6 +8265,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8154,6 +8286,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8174,6 +8307,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8194,6 +8328,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8214,6 +8349,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8371,6 +8507,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -8388,6 +8525,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8408,6 +8546,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8428,6 +8567,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8448,6 +8588,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8468,6 +8609,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8488,6 +8630,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8508,6 +8651,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9525,6 +9669,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -9542,6 +9687,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9562,6 +9708,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9582,6 +9729,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9602,6 +9750,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9622,6 +9771,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9642,6 +9792,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9662,6 +9813,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9819,6 +9971,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -9836,6 +9989,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9856,6 +10010,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9876,6 +10031,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9896,6 +10052,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9916,6 +10073,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9936,6 +10094,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9956,6 +10115,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10113,6 +10273,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -10130,6 +10291,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10150,6 +10312,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10170,6 +10333,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10190,6 +10354,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10210,6 +10375,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10230,6 +10396,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10250,6 +10417,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11091,6 +11259,7 @@ impl super::stub::SessionController for SessionController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -11108,6 +11277,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{name}:terminate";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11236,6 +11406,7 @@ impl super::stub::SessionController for SessionController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -11253,6 +11424,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11273,6 +11445,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11293,6 +11466,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11313,6 +11487,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11333,6 +11508,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11353,6 +11529,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11373,6 +11550,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11530,6 +11708,7 @@ impl super::stub::SessionController for SessionController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -11547,6 +11726,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11567,6 +11747,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11587,6 +11768,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11607,6 +11789,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11627,6 +11810,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11647,6 +11831,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11667,6 +11852,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11824,6 +12010,7 @@ impl super::stub::SessionController for SessionController {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -11841,6 +12028,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11861,6 +12049,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11881,6 +12070,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11901,6 +12091,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11921,6 +12112,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11941,6 +12133,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11961,6 +12154,7 @@ impl super::stub::SessionController for SessionController {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -12819,6 +13013,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -12836,6 +13031,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{name}:instantiate";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -12856,6 +13052,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{name}:instantiate";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13377,6 +13574,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -13394,6 +13592,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13414,6 +13613,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13434,6 +13634,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13454,6 +13655,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13474,6 +13676,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13494,6 +13697,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13514,6 +13718,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13671,6 +13876,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -13688,6 +13894,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13708,6 +13915,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13728,6 +13936,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13748,6 +13957,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13768,6 +13978,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13788,6 +13999,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13808,6 +14020,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13965,6 +14178,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -13982,6 +14196,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14002,6 +14217,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14022,6 +14238,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14042,6 +14259,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14062,6 +14280,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14082,6 +14301,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14102,6 +14322,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//dataproc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/datastream/v1/src/transport.rs
+++ b/src/generated/cloud/datastream/v1/src/transport.rs
@@ -436,6 +436,7 @@ impl super::stub::Datastream for Datastream {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -451,6 +452,7 @@ impl super::stub::Datastream for Datastream {
                 let path_template = "/v1/{parent}/connectionProfiles:discover";
 
                 let resource_name = format!("//datastream.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -886,6 +888,7 @@ impl super::stub::Datastream for Datastream {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -903,6 +906,7 @@ impl super::stub::Datastream for Datastream {
                 let path_template = "/v1/{name}:run";
 
                 let resource_name = format!("//datastream.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1034,6 +1038,7 @@ impl super::stub::Datastream for Datastream {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1051,6 +1056,7 @@ impl super::stub::Datastream for Datastream {
                 let path_template = "/v1/{parent}/objects:lookup";
 
                 let resource_name = format!("//datastream.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1180,6 +1186,7 @@ impl super::stub::Datastream for Datastream {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_object = try_match(
@@ -1199,6 +1206,7 @@ impl super::stub::Datastream for Datastream {
                 let path_template = "/v1/{object}:startBackfillJob";
 
                 let resource_name = format!("//datastream.googleapis.com/{}", var_object,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.object));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1256,6 +1264,7 @@ impl super::stub::Datastream for Datastream {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_object = try_match(
@@ -1275,6 +1284,7 @@ impl super::stub::Datastream for Datastream {
                 let path_template = "/v1/{object}:stopBackfillJob";
 
                 let resource_name = format!("//datastream.googleapis.com/{}", var_object,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.object));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2337,6 +2347,7 @@ impl super::stub::Datastream for Datastream {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2353,6 +2364,7 @@ impl super::stub::Datastream for Datastream {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/deploy/v1/src/transport.rs
+++ b/src/generated/cloud/deploy/v1/src/transport.rs
@@ -511,6 +511,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -528,6 +529,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path_template = "/v1/{name}:rollbackTarget";
 
                 let resource_name = format!("//clouddeploy.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1508,6 +1510,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1527,6 +1530,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path_template = "/v1/{name}:abandon";
 
                 let resource_name = format!("//clouddeploy.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1966,6 +1970,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1987,6 +1992,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path_template = "/v1/{name}:approve";
 
                 let resource_name = format!("//clouddeploy.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2046,6 +2052,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2067,6 +2074,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path_template = "/v1/{name}:advance";
 
                 let resource_name = format!("//clouddeploy.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2126,6 +2134,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2147,6 +2156,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path_template = "/v1/{name}:cancel";
 
                 let resource_name = format!("//clouddeploy.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2452,6 +2462,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_rollout = try_match(
@@ -2473,6 +2484,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path_template = "/v1/{rollout}:ignoreJob";
 
                 let resource_name = format!("//clouddeploy.googleapis.com/{}", var_rollout,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.rollout));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2532,6 +2544,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_rollout = try_match(
@@ -2553,6 +2566,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path_template = "/v1/{rollout}:retryJob";
 
                 let resource_name = format!("//clouddeploy.googleapis.com/{}", var_rollout,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.rollout));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2756,6 +2770,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
         .or_else(|| {
             let var_name = try_match(Some(&req).map(|m| &m.name).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/deliveryPipelines/"), Segment::SingleWildcard, Segment::Literal("/releases/"), Segment::SingleWildcard, Segment::Literal("/rollouts/"), Segment::SingleWildcard, Segment::Literal("/jobRuns/"), Segment::SingleWildcard])?;
@@ -2769,6 +2784,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 "//clouddeploy.googleapis.com/{}",
                 var_name,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3440,6 +3456,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3459,6 +3476,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path_template = "/v1/{name}:cancel";
 
                 let resource_name = format!("//clouddeploy.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3641,6 +3659,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3658,6 +3677,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//clouddeploy.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3678,6 +3698,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//clouddeploy.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3698,6 +3719,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//clouddeploy.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3718,6 +3740,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//clouddeploy.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4055,6 +4078,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4072,6 +4096,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//clouddeploy.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4092,6 +4117,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//clouddeploy.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4381,6 +4407,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4397,6 +4424,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/developerconnect/v1/src/transport.rs
+++ b/src/generated/cloud/developerconnect/v1/src/transport.rs
@@ -762,6 +762,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_git_repository_link = try_match(
@@ -786,6 +787,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
                     "//developerconnect.googleapis.com/{}",
                     var_git_repository_link,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.git_repository_link));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -847,6 +849,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_git_repository_link = try_match(
@@ -871,6 +874,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
                     "//developerconnect.googleapis.com/{}",
                     var_git_repository_link,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.git_repository_link));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1560,6 +1564,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_account_connector = try_match(
@@ -1580,6 +1585,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
                     "//developerconnect.googleapis.com/{}",
                     var_account_connector,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.account_connector));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2448,6 +2454,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2464,6 +2471,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3432,6 +3440,7 @@ impl super::stub::InsightsConfigService for InsightsConfigService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3448,6 +3457,7 @@ impl super::stub::InsightsConfigService for InsightsConfigService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/devicestreaming/v1/src/transport.rs
+++ b/src/generated/cloud/devicestreaming/v1/src/transport.rs
@@ -250,6 +250,7 @@ impl super::stub::DirectAccessService for DirectAccessService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -265,6 +266,7 @@ impl super::stub::DirectAccessService for DirectAccessService {
                 let path_template = "/v1/{name}:cancel";
 
                 let resource_name = format!("//devicestreaming.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
@@ -458,6 +458,7 @@ impl super::stub::Agents for Agents {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -475,6 +476,7 @@ impl super::stub::Agents for Agents {
                 let path_template = "/v3/{name}:export";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -530,6 +532,7 @@ impl super::stub::Agents for Agents {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -547,6 +550,7 @@ impl super::stub::Agents for Agents {
                 let path_template = "/v3/{name}:restore";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -602,6 +606,7 @@ impl super::stub::Agents for Agents {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -619,6 +624,7 @@ impl super::stub::Agents for Agents {
                 let path_template = "/v3/{name}:validate";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3036,6 +3042,7 @@ impl super::stub::EntityTypes for EntityTypes {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -3053,6 +3060,7 @@ impl super::stub::EntityTypes for EntityTypes {
                 let path_template = "/v3/{parent}/entityTypes:export";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3108,6 +3116,7 @@ impl super::stub::EntityTypes for EntityTypes {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -3125,6 +3134,7 @@ impl super::stub::EntityTypes for EntityTypes {
                 let path_template = "/v3/{parent}/entityTypes:import";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4136,6 +4146,7 @@ impl super::stub::Environments for Environments {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_environment = try_match(
@@ -4155,6 +4166,7 @@ impl super::stub::Environments for Environments {
                 let path_template = "/v3/{environment}:runContinuousTest";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_environment,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.environment));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4292,6 +4304,7 @@ impl super::stub::Environments for Environments {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_environment = try_match(
@@ -4311,6 +4324,7 @@ impl super::stub::Environments for Environments {
                 let path_template = "/v3/{environment}:deployFlow";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_environment,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.environment));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6147,6 +6161,7 @@ impl super::stub::Experiments for Experiments {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6168,6 +6183,7 @@ impl super::stub::Experiments for Experiments {
                 let path_template = "/v3/{name}:start";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6227,6 +6243,7 @@ impl super::stub::Experiments for Experiments {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6248,6 +6265,7 @@ impl super::stub::Experiments for Experiments {
                 let path_template = "/v3/{name}:stop";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7172,6 +7190,7 @@ impl super::stub::Flows for Flows {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7191,6 +7210,7 @@ impl super::stub::Flows for Flows {
                 let path_template = "/v3/{name}:train";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7248,6 +7268,7 @@ impl super::stub::Flows for Flows {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7267,6 +7288,7 @@ impl super::stub::Flows for Flows {
                 let path_template = "/v3/{name}:validate";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7403,6 +7425,7 @@ impl super::stub::Flows for Flows {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -7420,6 +7443,7 @@ impl super::stub::Flows for Flows {
                 let path_template = "/v3/{parent}/flows:import";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7475,6 +7499,7 @@ impl super::stub::Flows for Flows {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7494,6 +7519,7 @@ impl super::stub::Flows for Flows {
                 let path_template = "/v3/{name}:export";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9299,6 +9325,7 @@ impl super::stub::Intents for Intents {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -9316,6 +9343,7 @@ impl super::stub::Intents for Intents {
                 let path_template = "/v3/{parent}/intents:import";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9371,6 +9399,7 @@ impl super::stub::Intents for Intents {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -9388,6 +9417,7 @@ impl super::stub::Intents for Intents {
                 let path_template = "/v3/{parent}/intents:export";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11112,6 +11142,7 @@ impl super::stub::Playbooks for Playbooks {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -11131,6 +11162,7 @@ impl super::stub::Playbooks for Playbooks {
                 let path_template = "/v3/{name}:export";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11188,6 +11220,7 @@ impl super::stub::Playbooks for Playbooks {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -11205,6 +11238,7 @@ impl super::stub::Playbooks for Playbooks {
                 let path_template = "/v3/{parent}/playbooks:import";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11508,6 +11542,7 @@ impl super::stub::Playbooks for Playbooks {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -11529,6 +11564,7 @@ impl super::stub::Playbooks for Playbooks {
                 let path_template = "/v3/{name}:restore";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13078,6 +13114,7 @@ impl super::stub::Sessions for Sessions {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_session = try_match(
@@ -13097,6 +13134,7 @@ impl super::stub::Sessions for Sessions {
                 let path_template = "/v3/{session}:detectIntent";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_session,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.session));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13121,6 +13159,7 @@ impl super::stub::Sessions for Sessions {
                 let path_template = "/v3/{session}:detectIntent";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_session,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.session));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13199,6 +13238,7 @@ impl super::stub::Sessions for Sessions {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_session = try_match(
@@ -13218,6 +13258,7 @@ impl super::stub::Sessions for Sessions {
                 let path_template = "/v3/{session}:matchIntent";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_session,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.session));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13242,6 +13283,7 @@ impl super::stub::Sessions for Sessions {
                 let path_template = "/v3/{session}:matchIntent";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_session,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.session));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13320,6 +13362,7 @@ impl super::stub::Sessions for Sessions {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_match_intent_request_session = try_match(
@@ -13345,6 +13388,9 @@ impl super::stub::Sessions for Sessions {
                     "//dialogflow.googleapis.com/{}",
                     var_match_intent_request_session,
                 );
+                let _ = Some(&mut req)
+                    .and_then(|m| m.match_intent_request.as_mut())
+                    .map(|m| std::mem::take(&mut m.session));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13375,6 +13421,9 @@ impl super::stub::Sessions for Sessions {
                     "//dialogflow.googleapis.com/{}",
                     var_match_intent_request_session,
                 );
+                let _ = Some(&mut req)
+                    .and_then(|m| m.match_intent_request.as_mut())
+                    .map(|m| std::mem::take(&mut m.session));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13459,6 +13508,7 @@ impl super::stub::Sessions for Sessions {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_session = try_match(
@@ -13478,6 +13528,7 @@ impl super::stub::Sessions for Sessions {
                 let path_template = "/v3/{session}:submitAnswerFeedback";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_session,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.session));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -15224,6 +15275,7 @@ impl super::stub::TestCases for TestCases {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -15241,6 +15293,7 @@ impl super::stub::TestCases for TestCases {
                 let path_template = "/v3/{parent}/testCases:batchDelete";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -15542,6 +15595,7 @@ impl super::stub::TestCases for TestCases {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -15561,6 +15615,7 @@ impl super::stub::TestCases for TestCases {
                 let path_template = "/v3/{name}:run";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -15618,6 +15673,7 @@ impl super::stub::TestCases for TestCases {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -15635,6 +15691,7 @@ impl super::stub::TestCases for TestCases {
                 let path_template = "/v3/{parent}/testCases:batchRun";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -15763,6 +15820,7 @@ impl super::stub::TestCases for TestCases {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -15780,6 +15838,7 @@ impl super::stub::TestCases for TestCases {
                 let path_template = "/v3/{parent}/testCases:import";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -15835,6 +15894,7 @@ impl super::stub::TestCases for TestCases {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -15852,6 +15912,7 @@ impl super::stub::TestCases for TestCases {
                 let path_template = "/v3/{parent}/testCases:export";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -17262,6 +17323,7 @@ impl super::stub::Tools for Tools {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -17283,6 +17345,7 @@ impl super::stub::Tools for Tools {
                 let path_template = "/v3/{name}:restore";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19332,6 +19395,7 @@ impl super::stub::Versions for Versions {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -19353,6 +19417,7 @@ impl super::stub::Versions for Versions {
                 let path_template = "/v3/{name}:load";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19412,6 +19477,7 @@ impl super::stub::Versions for Versions {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_base_version = try_match(
@@ -19433,6 +19499,7 @@ impl super::stub::Versions for Versions {
                 let path_template = "/v3/{base_version}:compareVersions";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_base_version,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.base_version));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/dialogflow/v2/src/transport.rs
+++ b/src/generated/cloud/dialogflow/v2/src/transport.rs
@@ -494,6 +494,7 @@ impl super::stub::Agents for Agents {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -504,6 +505,7 @@ impl super::stub::Agents for Agents {
                 let path_template = "/v2/{parent}/agent:train";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -522,6 +524,7 @@ impl super::stub::Agents for Agents {
                 let path_template = "/v2/{parent}/agent:train";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -585,6 +588,7 @@ impl super::stub::Agents for Agents {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -595,6 +599,7 @@ impl super::stub::Agents for Agents {
                 let path_template = "/v2/{parent}/agent:export";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -613,6 +618,7 @@ impl super::stub::Agents for Agents {
                 let path_template = "/v2/{parent}/agent:export";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -676,6 +682,7 @@ impl super::stub::Agents for Agents {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -686,6 +693,7 @@ impl super::stub::Agents for Agents {
                 let path_template = "/v2/{parent}/agent:import";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -704,6 +712,7 @@ impl super::stub::Agents for Agents {
                 let path_template = "/v2/{parent}/agent:import";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -767,6 +776,7 @@ impl super::stub::Agents for Agents {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -777,6 +787,7 @@ impl super::stub::Agents for Agents {
                 let path_template = "/v2/{parent}/agent:restore";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -795,6 +806,7 @@ impl super::stub::Agents for Agents {
                 let path_template = "/v2/{parent}/agent:restore";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4174,6 +4186,7 @@ impl super::stub::Conversations for Conversations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4189,6 +4202,7 @@ impl super::stub::Conversations for Conversations {
                 let path_template = "/v2/{name}:complete";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4209,6 +4223,7 @@ impl super::stub::Conversations for Conversations {
                 let path_template = "/v2/{name}:complete";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4279,6 +4294,7 @@ impl super::stub::Conversations for Conversations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_conversation = try_match(
@@ -4296,6 +4312,7 @@ impl super::stub::Conversations for Conversations {
                 let path_template = "/v2/{conversation}:ingestContextReferences";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_conversation,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.conversation));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4464,6 +4481,7 @@ impl super::stub::Conversations for Conversations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_conversation = try_match(
@@ -4482,6 +4500,7 @@ impl super::stub::Conversations for Conversations {
                 let path_template = "/v2/{conversation}/suggestions:suggestConversationSummary";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_conversation,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.conversation));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4505,6 +4524,7 @@ impl super::stub::Conversations for Conversations {
                 let path_template = "/v2/{conversation}/suggestions:suggestConversationSummary";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_conversation,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.conversation));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4577,6 +4597,7 @@ impl super::stub::Conversations for Conversations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_stateless_conversation_parent = try_match(
@@ -4597,6 +4618,9 @@ impl super::stub::Conversations for Conversations {
                     "//dialogflow.googleapis.com/{}",
                     var_stateless_conversation_parent,
                 );
+                let _ = Some(&mut req)
+                    .and_then(|m| m.stateless_conversation.as_mut())
+                    .map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4625,6 +4649,9 @@ impl super::stub::Conversations for Conversations {
                     "//dialogflow.googleapis.com/{}",
                     var_stateless_conversation_parent,
                 );
+                let _ = Some(&mut req)
+                    .and_then(|m| m.stateless_conversation.as_mut())
+                    .map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4696,6 +4723,7 @@ impl super::stub::Conversations for Conversations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -4711,6 +4739,7 @@ impl super::stub::Conversations for Conversations {
                 let path_template = "/v2/{parent}/statelessSuggestion:generate";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4766,6 +4795,7 @@ impl super::stub::Conversations for Conversations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -4776,6 +4806,7 @@ impl super::stub::Conversations for Conversations {
                 let path_template = "/v2/{parent}/suggestions:searchKnowledge";
 
                 let resource_name = String::new();
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4794,6 +4825,7 @@ impl super::stub::Conversations for Conversations {
                 let path_template = "/v2/{parent}/suggestions:searchKnowledge";
 
                 let resource_name = String::new();
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4812,6 +4844,7 @@ impl super::stub::Conversations for Conversations {
                 let path_template = "/v2/{conversation}/suggestions:searchKnowledge";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_conversation,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.conversation));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4832,6 +4865,7 @@ impl super::stub::Conversations for Conversations {
                 let path_template = "/v2/{conversation}/suggestions:searchKnowledge";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_conversation,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.conversation));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4927,6 +4961,7 @@ impl super::stub::Conversations for Conversations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_conversation = try_match(
@@ -4942,6 +4977,7 @@ impl super::stub::Conversations for Conversations {
                 let path_template = "/v2/{conversation}/suggestions:generate";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_conversation,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.conversation));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4962,6 +4998,7 @@ impl super::stub::Conversations for Conversations {
                 let path_template = "/v2/{conversation}/suggestions:generate";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_conversation,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.conversation));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5844,6 +5881,7 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5859,6 +5897,7 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
                 let path_template = "/v2/{name}:importConversationData";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5879,6 +5918,7 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
                 let path_template = "/v2/{name}:importConversationData";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6823,6 +6863,7 @@ impl super::stub::ConversationModels for ConversationModels {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6837,6 +6878,7 @@ impl super::stub::ConversationModels for ConversationModels {
                 let path = format!("/v2/{}:deploy", var_name,);
                 let path_template = "/v2/{name}:deploy";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6856,6 +6898,7 @@ impl super::stub::ConversationModels for ConversationModels {
                 let path = format!("/v2/{}:deploy", var_name,);
                 let path_template = "/v2/{name}:deploy";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6927,6 +6970,7 @@ impl super::stub::ConversationModels for ConversationModels {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6941,6 +6985,7 @@ impl super::stub::ConversationModels for ConversationModels {
                 let path = format!("/v2/{}:undeploy", var_name,);
                 let path_template = "/v2/{name}:undeploy";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6960,6 +7005,7 @@ impl super::stub::ConversationModels for ConversationModels {
                 let path = format!("/v2/{}:undeploy", var_name,);
                 let path_template = "/v2/{name}:undeploy";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -7247,6 +7293,7 @@ impl super::stub::ConversationModels for ConversationModels {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -7264,6 +7311,7 @@ impl super::stub::ConversationModels for ConversationModels {
                 let path_template = "/v2/{parent}/evaluations";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8349,6 +8397,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_conversation_profile = try_match(
@@ -8368,6 +8417,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
                 );
                 let path_template = "/v2/{conversation_profile}:setSuggestionFeatureConfig";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.conversation_profile));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -8392,6 +8442,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
                 );
                 let path_template = "/v2/{conversation_profile}:setSuggestionFeatureConfig";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.conversation_profile));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -8465,6 +8516,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_conversation_profile = try_match(
@@ -8484,6 +8536,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
                 );
                 let path_template = "/v2/{conversation_profile}:clearSuggestionFeatureConfig";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.conversation_profile));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -8508,6 +8561,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
                 );
                 let path_template = "/v2/{conversation_profile}:clearSuggestionFeatureConfig";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.conversation_profile));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -9496,6 +9550,7 @@ impl super::stub::Documents for Documents {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -9511,6 +9566,7 @@ impl super::stub::Documents for Documents {
                 let path_template = "/v2/{parent}/documents:import";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9531,6 +9587,7 @@ impl super::stub::Documents for Documents {
                 let path_template = "/v2/{parent}/documents:import";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9951,6 +10008,7 @@ impl super::stub::Documents for Documents {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -9968,6 +10026,7 @@ impl super::stub::Documents for Documents {
                 let path_template = "/v2/{name}:reload";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9990,6 +10049,7 @@ impl super::stub::Documents for Documents {
                 let path_template = "/v2/{name}:reload";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10010,6 +10070,7 @@ impl super::stub::Documents for Documents {
                 let path_template = "/v2/{name}:reload";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10101,6 +10162,7 @@ impl super::stub::Documents for Documents {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -10118,6 +10180,7 @@ impl super::stub::Documents for Documents {
                 let path_template = "/v2/{name}:export";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10140,6 +10203,7 @@ impl super::stub::Documents for Documents {
                 let path_template = "/v2/{name}:export";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10766,6 +10830,7 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_encryption_spec_name = try_match(
@@ -10784,6 +10849,9 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
                 let path = format!("/v2/{}:initialize", var_encryption_spec_name,);
                 let path_template = "/v2/{encryption_spec.name}:initialize";
 
+                let _ = Some(&mut req)
+                    .and_then(|m| m.encryption_spec.as_mut())
+                    .map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -11890,6 +11958,7 @@ impl super::stub::EntityTypes for EntityTypes {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -11904,6 +11973,7 @@ impl super::stub::EntityTypes for EntityTypes {
                 let path_template = "/v2/{parent}/entityTypes:batchUpdate";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11923,6 +11993,7 @@ impl super::stub::EntityTypes for EntityTypes {
                 let path_template = "/v2/{parent}/entityTypes:batchUpdate";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11991,6 +12062,7 @@ impl super::stub::EntityTypes for EntityTypes {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -12005,6 +12077,7 @@ impl super::stub::EntityTypes for EntityTypes {
                 let path_template = "/v2/{parent}/entityTypes:batchDelete";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -12024,6 +12097,7 @@ impl super::stub::EntityTypes for EntityTypes {
                 let path_template = "/v2/{parent}/entityTypes:batchDelete";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -12092,6 +12166,7 @@ impl super::stub::EntityTypes for EntityTypes {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -12107,6 +12182,7 @@ impl super::stub::EntityTypes for EntityTypes {
                 let path_template = "/v2/{parent}/entities:batchCreate";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -12127,6 +12203,7 @@ impl super::stub::EntityTypes for EntityTypes {
                 let path_template = "/v2/{parent}/entities:batchCreate";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -12197,6 +12274,7 @@ impl super::stub::EntityTypes for EntityTypes {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -12212,6 +12290,7 @@ impl super::stub::EntityTypes for EntityTypes {
                 let path_template = "/v2/{parent}/entities:batchUpdate";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -12232,6 +12311,7 @@ impl super::stub::EntityTypes for EntityTypes {
                 let path_template = "/v2/{parent}/entities:batchUpdate";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -12302,6 +12382,7 @@ impl super::stub::EntityTypes for EntityTypes {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -12317,6 +12398,7 @@ impl super::stub::EntityTypes for EntityTypes {
                 let path_template = "/v2/{parent}/entities:batchDelete";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -12337,6 +12419,7 @@ impl super::stub::EntityTypes for EntityTypes {
                 let path_template = "/v2/{parent}/entities:batchDelete";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -17071,6 +17154,7 @@ impl super::stub::Intents for Intents {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -17085,6 +17169,7 @@ impl super::stub::Intents for Intents {
                 let path_template = "/v2/{parent}/intents:batchUpdate";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -17104,6 +17189,7 @@ impl super::stub::Intents for Intents {
                 let path_template = "/v2/{parent}/intents:batchUpdate";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -17172,6 +17258,7 @@ impl super::stub::Intents for Intents {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -17186,6 +17273,7 @@ impl super::stub::Intents for Intents {
                 let path_template = "/v2/{parent}/intents:batchDelete";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -17205,6 +17293,7 @@ impl super::stub::Intents for Intents {
                 let path_template = "/v2/{parent}/intents:batchDelete";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19418,6 +19507,7 @@ impl super::stub::Participants for Participants {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_participant = try_match(
@@ -19435,6 +19525,7 @@ impl super::stub::Participants for Participants {
                 let path_template = "/v2/{participant}:analyzeContent";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_participant,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.participant));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19457,6 +19548,7 @@ impl super::stub::Participants for Participants {
                 let path_template = "/v2/{participant}:analyzeContent";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_participant,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.participant));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19531,6 +19623,7 @@ impl super::stub::Participants for Participants {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -19548,6 +19641,7 @@ impl super::stub::Participants for Participants {
                 let path_template = "/v2/{parent}/suggestions:suggestArticles";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19570,6 +19664,7 @@ impl super::stub::Participants for Participants {
                 let path_template = "/v2/{parent}/suggestions:suggestArticles";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19644,6 +19739,7 @@ impl super::stub::Participants for Participants {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -19661,6 +19757,7 @@ impl super::stub::Participants for Participants {
                 let path_template = "/v2/{parent}/suggestions:suggestFaqAnswers";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19683,6 +19780,7 @@ impl super::stub::Participants for Participants {
                 let path_template = "/v2/{parent}/suggestions:suggestFaqAnswers";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19757,6 +19855,7 @@ impl super::stub::Participants for Participants {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -19774,6 +19873,7 @@ impl super::stub::Participants for Participants {
                 let path_template = "/v2/{parent}/suggestions:suggestSmartReplies";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19796,6 +19896,7 @@ impl super::stub::Participants for Participants {
                 let path_template = "/v2/{parent}/suggestions:suggestSmartReplies";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19870,6 +19971,7 @@ impl super::stub::Participants for Participants {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -19887,6 +19989,7 @@ impl super::stub::Participants for Participants {
                 let path_template = "/v2/{parent}/suggestions:suggestKnowledgeAssist";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19909,6 +20012,7 @@ impl super::stub::Participants for Participants {
                 let path_template = "/v2/{parent}/suggestions:suggestKnowledgeAssist";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20451,6 +20555,7 @@ impl super::stub::Sessions for Sessions {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_session = try_match(
@@ -20466,6 +20571,7 @@ impl super::stub::Sessions for Sessions {
                 let path_template = "/v2/{session}:detectIntent";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_session,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.session));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20488,6 +20594,7 @@ impl super::stub::Sessions for Sessions {
                 let path_template = "/v2/{session}:detectIntent";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_session,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.session));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20508,6 +20615,7 @@ impl super::stub::Sessions for Sessions {
                 let path_template = "/v2/{session}:detectIntent";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_session,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.session));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20532,6 +20640,7 @@ impl super::stub::Sessions for Sessions {
                 let path_template = "/v2/{session}:detectIntent";
 
                 let resource_name = format!("//dialogflow.googleapis.com/{}", var_session,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.session));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/discoveryengine/v1/src/transport.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/transport.rs
@@ -887,6 +887,7 @@ impl super::stub::AssistantService for AssistantService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -901,6 +902,7 @@ impl super::stub::AssistantService for AssistantService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -926,6 +928,7 @@ impl super::stub::AssistantService for AssistantService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -949,6 +952,7 @@ impl super::stub::AssistantService for AssistantService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -972,6 +976,7 @@ impl super::stub::AssistantService for AssistantService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2305,6 +2310,7 @@ impl super::stub::CmekConfigService for CmekConfigService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2319,6 +2325,7 @@ impl super::stub::CmekConfigService for CmekConfigService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2344,6 +2351,7 @@ impl super::stub::CmekConfigService for CmekConfigService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2367,6 +2375,7 @@ impl super::stub::CmekConfigService for CmekConfigService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2390,6 +2399,7 @@ impl super::stub::CmekConfigService for CmekConfigService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2685,6 +2695,7 @@ impl super::stub::CompletionService for CompletionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2704,6 +2715,7 @@ impl super::stub::CompletionService for CompletionService {
                 let path_template = "/v1/{parent}/suggestionDenyListEntries:import";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2724,6 +2736,7 @@ impl super::stub::CompletionService for CompletionService {
                 let path_template = "/v1/{parent}/suggestionDenyListEntries:import";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2798,6 +2811,7 @@ impl super::stub::CompletionService for CompletionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2817,6 +2831,7 @@ impl super::stub::CompletionService for CompletionService {
                 let path_template = "/v1/{parent}/suggestionDenyListEntries:purge";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2837,6 +2852,7 @@ impl super::stub::CompletionService for CompletionService {
                 let path_template = "/v1/{parent}/suggestionDenyListEntries:purge";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2911,6 +2927,7 @@ impl super::stub::CompletionService for CompletionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2930,6 +2947,7 @@ impl super::stub::CompletionService for CompletionService {
                 let path_template = "/v1/{parent}/completionSuggestions:import";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2950,6 +2968,7 @@ impl super::stub::CompletionService for CompletionService {
                 let path_template = "/v1/{parent}/completionSuggestions:import";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3024,6 +3043,7 @@ impl super::stub::CompletionService for CompletionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -3043,6 +3063,7 @@ impl super::stub::CompletionService for CompletionService {
                 let path_template = "/v1/{parent}/completionSuggestions:purge";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3063,6 +3084,7 @@ impl super::stub::CompletionService for CompletionService {
                 let path_template = "/v1/{parent}/completionSuggestions:purge";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3941,6 +3963,7 @@ impl super::stub::CompletionService for CompletionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3955,6 +3978,7 @@ impl super::stub::CompletionService for CompletionService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3980,6 +4004,7 @@ impl super::stub::CompletionService for CompletionService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4003,6 +4028,7 @@ impl super::stub::CompletionService for CompletionService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4026,6 +4052,7 @@ impl super::stub::CompletionService for CompletionService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5874,6 +5901,7 @@ impl super::stub::ControlService for ControlService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5888,6 +5916,7 @@ impl super::stub::ControlService for ControlService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5913,6 +5942,7 @@ impl super::stub::ControlService for ControlService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5936,6 +5966,7 @@ impl super::stub::ControlService for ControlService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5959,6 +5990,7 @@ impl super::stub::ControlService for ControlService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6115,6 +6147,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6134,6 +6167,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
                 let path_template = "/v1/{name}:converse";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6158,6 +6192,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
                 let path_template = "/v1/{name}:converse";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6182,6 +6217,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
                 let path_template = "/v1/{name}:converse";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7155,6 +7191,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_serving_config = try_match(
@@ -7175,6 +7212,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
 
                 let resource_name =
                     format!("//discoveryengine.googleapis.com/{}", var_serving_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.serving_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7200,6 +7238,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
 
                 let resource_name =
                     format!("//discoveryengine.googleapis.com/{}", var_serving_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.serving_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7225,6 +7264,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
 
                 let resource_name =
                     format!("//discoveryengine.googleapis.com/{}", var_serving_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.serving_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9200,6 +9240,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -9214,6 +9255,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -9239,6 +9281,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -9262,6 +9305,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -9285,6 +9329,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -10869,6 +10914,7 @@ impl super::stub::DataStoreService for DataStoreService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -10883,6 +10929,7 @@ impl super::stub::DataStoreService for DataStoreService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -10908,6 +10955,7 @@ impl super::stub::DataStoreService for DataStoreService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -10931,6 +10979,7 @@ impl super::stub::DataStoreService for DataStoreService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -10954,6 +11003,7 @@ impl super::stub::DataStoreService for DataStoreService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -11806,6 +11856,7 @@ impl super::stub::DocumentService for DocumentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -11825,6 +11876,7 @@ impl super::stub::DocumentService for DocumentService {
                 let path_template = "/v1/{parent}/documents:import";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11849,6 +11901,7 @@ impl super::stub::DocumentService for DocumentService {
                 let path_template = "/v1/{parent}/documents:import";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11929,6 +11982,7 @@ impl super::stub::DocumentService for DocumentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -11948,6 +12002,7 @@ impl super::stub::DocumentService for DocumentService {
                 let path_template = "/v1/{parent}/documents:purge";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11972,6 +12027,7 @@ impl super::stub::DocumentService for DocumentService {
                 let path_template = "/v1/{parent}/documents:purge";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13003,6 +13059,7 @@ impl super::stub::DocumentService for DocumentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -13017,6 +13074,7 @@ impl super::stub::DocumentService for DocumentService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -13042,6 +13100,7 @@ impl super::stub::DocumentService for DocumentService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -13065,6 +13124,7 @@ impl super::stub::DocumentService for DocumentService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -13088,6 +13148,7 @@ impl super::stub::DocumentService for DocumentService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -14454,6 +14515,7 @@ impl super::stub::EngineService for EngineService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -14468,6 +14530,7 @@ impl super::stub::EngineService for EngineService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -14493,6 +14556,7 @@ impl super::stub::EngineService for EngineService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -14516,6 +14580,7 @@ impl super::stub::EngineService for EngineService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -14539,6 +14604,7 @@ impl super::stub::EngineService for EngineService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -14709,6 +14775,7 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_location = try_match(
@@ -14724,6 +14791,7 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
                 let path_template = "/v1/{location}:generateGroundedContent";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_location,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.location));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14777,6 +14845,7 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_grounding_config = try_match(
@@ -14795,6 +14864,7 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
 
                 let resource_name =
                     format!("//discoveryengine.googleapis.com/{}", var_grounding_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.grounding_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -15656,6 +15726,7 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -15670,6 +15741,7 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -15695,6 +15767,7 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -15718,6 +15791,7 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -15741,6 +15815,7 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -16118,6 +16193,7 @@ impl super::stub::IdentityMappingStoreService for IdentityMappingStoreService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_identity_mapping_store = try_match(
@@ -16140,6 +16216,7 @@ impl super::stub::IdentityMappingStoreService for IdentityMappingStoreService {
                     "//discoveryengine.googleapis.com/{}",
                     var_identity_mapping_store,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.identity_mapping_store));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -16197,6 +16274,7 @@ impl super::stub::IdentityMappingStoreService for IdentityMappingStoreService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_identity_mapping_store = try_match(
@@ -16219,6 +16297,7 @@ impl super::stub::IdentityMappingStoreService for IdentityMappingStoreService {
                     "//discoveryengine.googleapis.com/{}",
                     var_identity_mapping_store,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.identity_mapping_store));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -17231,6 +17310,7 @@ impl super::stub::IdentityMappingStoreService for IdentityMappingStoreService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -17245,6 +17325,7 @@ impl super::stub::IdentityMappingStoreService for IdentityMappingStoreService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -17270,6 +17351,7 @@ impl super::stub::IdentityMappingStoreService for IdentityMappingStoreService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -17293,6 +17375,7 @@ impl super::stub::IdentityMappingStoreService for IdentityMappingStoreService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -17316,6 +17399,7 @@ impl super::stub::IdentityMappingStoreService for IdentityMappingStoreService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -17486,6 +17570,7 @@ impl super::stub::ProjectService for ProjectService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -17496,6 +17581,7 @@ impl super::stub::ProjectService for ProjectService {
                 let path_template = "/v1/{name}:provision";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18350,6 +18436,7 @@ impl super::stub::ProjectService for ProjectService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -18364,6 +18451,7 @@ impl super::stub::ProjectService for ProjectService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -18389,6 +18477,7 @@ impl super::stub::ProjectService for ProjectService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -18412,6 +18501,7 @@ impl super::stub::ProjectService for ProjectService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -18435,6 +18525,7 @@ impl super::stub::ProjectService for ProjectService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -18605,6 +18696,7 @@ impl super::stub::RankService for RankService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_ranking_config = try_match(
@@ -18623,6 +18715,7 @@ impl super::stub::RankService for RankService {
 
                 let resource_name =
                     format!("//discoveryengine.googleapis.com/{}", var_ranking_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.ranking_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19482,6 +19575,7 @@ impl super::stub::RankService for RankService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -19496,6 +19590,7 @@ impl super::stub::RankService for RankService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -19521,6 +19616,7 @@ impl super::stub::RankService for RankService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -19544,6 +19640,7 @@ impl super::stub::RankService for RankService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -19567,6 +19664,7 @@ impl super::stub::RankService for RankService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -19723,6 +19821,7 @@ impl super::stub::RecommendationService for RecommendationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_serving_config = try_match(
@@ -19743,6 +19842,7 @@ impl super::stub::RecommendationService for RecommendationService {
 
                 let resource_name =
                     format!("//discoveryengine.googleapis.com/{}", var_serving_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.serving_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19768,6 +19868,7 @@ impl super::stub::RecommendationService for RecommendationService {
 
                 let resource_name =
                     format!("//discoveryengine.googleapis.com/{}", var_serving_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.serving_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19793,6 +19894,7 @@ impl super::stub::RecommendationService for RecommendationService {
 
                 let resource_name =
                     format!("//discoveryengine.googleapis.com/{}", var_serving_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.serving_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20698,6 +20800,7 @@ impl super::stub::RecommendationService for RecommendationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -20712,6 +20815,7 @@ impl super::stub::RecommendationService for RecommendationService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -20737,6 +20841,7 @@ impl super::stub::RecommendationService for RecommendationService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -20760,6 +20865,7 @@ impl super::stub::RecommendationService for RecommendationService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -20783,6 +20889,7 @@ impl super::stub::RecommendationService for RecommendationService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -22349,6 +22456,7 @@ impl super::stub::SchemaService for SchemaService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -22363,6 +22471,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -22388,6 +22497,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -22411,6 +22521,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -22434,6 +22545,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -22604,6 +22716,7 @@ impl super::stub::SearchService for SearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_serving_config = try_match(
@@ -22624,6 +22737,7 @@ impl super::stub::SearchService for SearchService {
 
                 let resource_name =
                     format!("//discoveryengine.googleapis.com/{}", var_serving_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.serving_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -22649,6 +22763,7 @@ impl super::stub::SearchService for SearchService {
 
                 let resource_name =
                     format!("//discoveryengine.googleapis.com/{}", var_serving_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.serving_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -22674,6 +22789,7 @@ impl super::stub::SearchService for SearchService {
 
                 let resource_name =
                     format!("//discoveryengine.googleapis.com/{}", var_serving_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.serving_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -22773,6 +22889,7 @@ impl super::stub::SearchService for SearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_serving_config = try_match(
@@ -22793,6 +22910,7 @@ impl super::stub::SearchService for SearchService {
 
                 let resource_name =
                     format!("//discoveryengine.googleapis.com/{}", var_serving_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.serving_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -22818,6 +22936,7 @@ impl super::stub::SearchService for SearchService {
 
                 let resource_name =
                     format!("//discoveryengine.googleapis.com/{}", var_serving_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.serving_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -22843,6 +22962,7 @@ impl super::stub::SearchService for SearchService {
 
                 let resource_name =
                     format!("//discoveryengine.googleapis.com/{}", var_serving_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.serving_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23746,6 +23866,7 @@ impl super::stub::SearchService for SearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -23760,6 +23881,7 @@ impl super::stub::SearchService for SearchService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -23785,6 +23907,7 @@ impl super::stub::SearchService for SearchService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -23808,6 +23931,7 @@ impl super::stub::SearchService for SearchService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -23831,6 +23955,7 @@ impl super::stub::SearchService for SearchService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -23987,6 +24112,7 @@ impl super::stub::SearchTuningService for SearchTuningService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_data_store = try_match(
@@ -24006,6 +24132,7 @@ impl super::stub::SearchTuningService for SearchTuningService {
                 let path_template = "/v1/{data_store}:trainCustomModel";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_data_store,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.data_store));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24947,6 +25074,7 @@ impl super::stub::SearchTuningService for SearchTuningService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -24961,6 +25089,7 @@ impl super::stub::SearchTuningService for SearchTuningService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -24986,6 +25115,7 @@ impl super::stub::SearchTuningService for SearchTuningService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -25009,6 +25139,7 @@ impl super::stub::SearchTuningService for SearchTuningService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -25032,6 +25163,7 @@ impl super::stub::SearchTuningService for SearchTuningService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -26224,6 +26356,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -26238,6 +26371,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -26263,6 +26397,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -26286,6 +26421,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -26309,6 +26445,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -28149,6 +28286,7 @@ impl super::stub::SessionService for SessionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -28163,6 +28301,7 @@ impl super::stub::SessionService for SessionService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -28188,6 +28327,7 @@ impl super::stub::SessionService for SessionService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -28211,6 +28351,7 @@ impl super::stub::SessionService for SessionService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -28234,6 +28375,7 @@ impl super::stub::SessionService for SessionService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -28626,6 +28768,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -28644,6 +28787,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                 let path_template = "/v1/{parent}/targetSites:batchCreate";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -28667,6 +28811,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                 let path_template = "/v1/{parent}/targetSites:batchCreate";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29467,6 +29612,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_site_search_engine = try_match(
@@ -29490,6 +29636,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                     "//discoveryengine.googleapis.com/{}",
                     var_site_search_engine,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.site_search_engine));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29518,6 +29665,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                     "//discoveryengine.googleapis.com/{}",
                     var_site_search_engine,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.site_search_engine));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29598,6 +29746,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_site_search_engine = try_match(
@@ -29621,6 +29770,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                     "//discoveryengine.googleapis.com/{}",
                     var_site_search_engine,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.site_search_engine));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29649,6 +29799,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                     "//discoveryengine.googleapis.com/{}",
                     var_site_search_engine,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.site_search_engine));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29729,6 +29880,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_site_search_engine = try_match(
@@ -29752,6 +29904,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                     "//discoveryengine.googleapis.com/{}",
                     var_site_search_engine,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.site_search_engine));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29780,6 +29933,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                     "//discoveryengine.googleapis.com/{}",
                     var_site_search_engine,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.site_search_engine));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -29862,6 +30016,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -29882,6 +30037,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                 let path_template = "/v1/{parent}:batchVerifyTargetSites";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -30834,6 +30990,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -30848,6 +31005,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -30873,6 +31031,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -30896,6 +31055,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -30919,6 +31079,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -31415,6 +31576,7 @@ impl super::stub::UserEventService for UserEventService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -31432,6 +31594,7 @@ impl super::stub::UserEventService for UserEventService {
                 let path_template = "/v1/{parent}/userEvents:purge";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31454,6 +31617,7 @@ impl super::stub::UserEventService for UserEventService {
                 let path_template = "/v1/{parent}/userEvents:purge";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31530,6 +31694,7 @@ impl super::stub::UserEventService for UserEventService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -31547,6 +31712,7 @@ impl super::stub::UserEventService for UserEventService {
                 let path_template = "/v1/{parent}/userEvents:import";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31569,6 +31735,7 @@ impl super::stub::UserEventService for UserEventService {
                 let path_template = "/v1/{parent}/userEvents:import";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -31587,6 +31754,7 @@ impl super::stub::UserEventService for UserEventService {
                 let path_template = "/v1/{parent}/userEvents:import";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -32482,6 +32650,7 @@ impl super::stub::UserEventService for UserEventService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -32496,6 +32665,7 @@ impl super::stub::UserEventService for UserEventService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -32521,6 +32691,7 @@ impl super::stub::UserEventService for UserEventService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -32544,6 +32715,7 @@ impl super::stub::UserEventService for UserEventService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -32567,6 +32739,7 @@ impl super::stub::UserEventService for UserEventService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -32814,6 +32987,7 @@ impl super::stub::UserLicenseService for UserLicenseService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -32831,6 +33005,7 @@ impl super::stub::UserLicenseService for UserLicenseService {
                 let path_template = "/v1/{parent}:batchUpdateUserLicenses";
 
                 let resource_name = format!("//discoveryengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -33690,6 +33865,7 @@ impl super::stub::UserLicenseService for UserLicenseService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -33704,6 +33880,7 @@ impl super::stub::UserLicenseService for UserLicenseService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -33729,6 +33906,7 @@ impl super::stub::UserLicenseService for UserLicenseService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -33752,6 +33930,7 @@ impl super::stub::UserLicenseService for UserLicenseService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -33775,6 +33954,7 @@ impl super::stub::UserLicenseService for UserLicenseService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/documentai/v1/src/transport.rs
+++ b/src/generated/cloud/documentai/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -73,6 +74,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 let path_template = "/v1/{name}:process";
 
                 let resource_name = format!("//documentai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -95,6 +97,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 let path_template = "/v1/{name}:process";
 
                 let resource_name = format!("//documentai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -171,6 +174,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -188,6 +192,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 let path_template = "/v1/{name}:batchProcess";
 
                 let resource_name = format!("//documentai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -210,6 +215,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 let path_template = "/v1/{name}:batchProcess";
 
                 let resource_name = format!("//documentai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -648,6 +654,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -665,6 +672,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 let path_template = "/v1/{parent}/processorVersions:train";
 
                 let resource_name = format!("//documentai.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -952,6 +960,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -971,6 +980,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 let path_template = "/v1/{name}:deploy";
 
                 let resource_name = format!("//documentai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1028,6 +1038,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1047,6 +1058,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 let path_template = "/v1/{name}:undeploy";
 
                 let resource_name = format!("//documentai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1248,6 +1260,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1265,6 +1278,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 let path_template = "/v1/{name}:enable";
 
                 let resource_name = format!("//documentai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1322,6 +1336,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1339,6 +1354,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 let path_template = "/v1/{name}:disable";
 
                 let resource_name = format!("//documentai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1396,6 +1412,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_processor = try_match(
@@ -1413,6 +1430,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 let path_template = "/v1/{processor}:setDefaultProcessorVersion";
 
                 let resource_name = format!("//documentai.googleapis.com/{}", var_processor,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.processor));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1468,6 +1486,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_human_review_config = try_match(
@@ -1489,6 +1508,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
 
                 let resource_name =
                     format!("//documentai.googleapis.com/{}", var_human_review_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.human_review_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1549,6 +1569,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_processor_version = try_match(
@@ -1569,6 +1590,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
 
                 let resource_name =
                     format!("//documentai.googleapis.com/{}", var_processor_version,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.processor_version));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/domains/v1/src/transport.rs
+++ b/src/generated/cloud/domains/v1/src/transport.rs
@@ -197,6 +197,7 @@ impl super::stub::Domains for Domains {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -212,6 +213,7 @@ impl super::stub::Domains for Domains {
                 let path_template = "/v1/{parent}/registrations:register";
 
                 let resource_name = format!("//domains.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -337,6 +339,7 @@ impl super::stub::Domains for Domains {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -352,6 +355,7 @@ impl super::stub::Domains for Domains {
                 let path_template = "/v1/{parent}/registrations:transfer";
 
                 let resource_name = format!("//domains.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -636,6 +640,7 @@ impl super::stub::Domains for Domains {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_registration = try_match(
@@ -653,6 +658,7 @@ impl super::stub::Domains for Domains {
                 let path_template = "/v1/{registration}:configureManagementSettings";
 
                 let resource_name = format!("//domains.googleapis.com/{}", var_registration,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.registration));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -708,6 +714,7 @@ impl super::stub::Domains for Domains {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_registration = try_match(
@@ -725,6 +732,7 @@ impl super::stub::Domains for Domains {
                 let path_template = "/v1/{registration}:configureDnsSettings";
 
                 let resource_name = format!("//domains.googleapis.com/{}", var_registration,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.registration));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -780,6 +788,7 @@ impl super::stub::Domains for Domains {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_registration = try_match(
@@ -797,6 +806,7 @@ impl super::stub::Domains for Domains {
                 let path_template = "/v1/{registration}:configureContactSettings";
 
                 let resource_name = format!("//domains.googleapis.com/{}", var_registration,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.registration));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -852,6 +862,7 @@ impl super::stub::Domains for Domains {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -869,6 +880,7 @@ impl super::stub::Domains for Domains {
                 let path_template = "/v1/{name}:export";
 
                 let resource_name = format!("//domains.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1068,6 +1080,7 @@ impl super::stub::Domains for Domains {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_registration = try_match(
@@ -1085,6 +1098,7 @@ impl super::stub::Domains for Domains {
                 let path_template = "/v1/{registration}:resetAuthorizationCode";
 
                 let resource_name = format!("//domains.googleapis.com/{}", var_registration,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.registration));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/edgecontainer/v1/src/transport.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/transport.rs
@@ -361,6 +361,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -378,6 +379,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
                 let path_template = "/v1/{name}:upgrade";
 
                 let resource_name = format!("//edgecontainer.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1900,6 +1902,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1916,6 +1919,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/edgenetwork/v1/src/transport.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -73,6 +74,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
                 let path_template = "/v1/{name}:initialize";
 
                 let resource_name = format!("//edgenetwork.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2401,6 +2403,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2417,6 +2420,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/essentialcontacts/v1/src/transport.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/transport.rs
@@ -866,6 +866,7 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -876,6 +877,7 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
                 let path_template = "/v1/{resource}/contacts:sendTestMessage";
 
                 let resource_name = format!("//essentialcontacts.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -889,6 +891,7 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
                 let path_template = "/v1/{resource}/contacts:sendTestMessage";
 
                 let resource_name = format!("//essentialcontacts.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -902,6 +905,7 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
                 let path_template = "/v1/{resource}/contacts:sendTestMessage";
 
                 let resource_name = format!("//essentialcontacts.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/eventarc/publishing/v1/src/transport.rs
+++ b/src/generated/cloud/eventarc/publishing/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::Publisher for Publisher {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_channel_connection = try_match(
@@ -74,6 +75,7 @@ impl super::stub::Publisher for Publisher {
                 let path = format!("/v1/{}:publishEvents", var_channel_connection,);
                 let path_template = "/v1/{channel_connection}:publishEvents";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.channel_connection));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -130,6 +132,7 @@ impl super::stub::Publisher for Publisher {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_channel = try_match(
@@ -146,6 +149,7 @@ impl super::stub::Publisher for Publisher {
                 let path = format!("/v1/{}:publishEvents", var_channel,);
                 let path_template = "/v1/{channel}:publishEvents";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.channel));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -200,6 +204,7 @@ impl super::stub::Publisher for Publisher {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_message_bus = try_match(
@@ -216,6 +221,7 @@ impl super::stub::Publisher for Publisher {
                 let path = format!("/v1/{}:publish", var_message_bus,);
                 let path_template = "/v1/{message_bus}:publish";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.message_bus));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/eventarc/v1/src/transport.rs
+++ b/src/generated/cloud/eventarc/v1/src/transport.rs
@@ -3108,6 +3108,7 @@ impl super::stub::Eventarc for Eventarc {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3125,6 +3126,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3145,6 +3147,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3165,6 +3168,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3185,6 +3189,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3205,6 +3210,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3225,6 +3231,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3245,6 +3252,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3265,6 +3273,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3866,6 +3875,7 @@ impl super::stub::Eventarc for Eventarc {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3883,6 +3893,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3903,6 +3914,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3923,6 +3935,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3943,6 +3956,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3963,6 +3977,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3983,6 +3998,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4003,6 +4019,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4023,6 +4040,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//eventarc.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4414,6 +4432,7 @@ impl super::stub::Eventarc for Eventarc {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4430,6 +4449,7 @@ impl super::stub::Eventarc for Eventarc {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/filestore/v1/src/transport.rs
+++ b/src/generated/cloud/filestore/v1/src/transport.rs
@@ -361,6 +361,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -378,6 +379,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
                 let path_template = "/v1/{name}:restore";
 
                 let resource_name = format!("//file.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -435,6 +437,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -452,6 +455,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
                 let path_template = "/v1/{name}:revert";
 
                 let resource_name = format!("//file.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1358,6 +1362,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1375,6 +1380,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
                 let path_template = "/v1/{name}:promoteReplica";
 
                 let resource_name = format!("//file.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1774,6 +1780,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1790,6 +1797,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/financialservices/v1/src/transport.rs
+++ b/src/generated/cloud/financialservices/v1/src/transport.rs
@@ -430,6 +430,7 @@ impl super::stub::Aml for Aml {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -447,6 +448,7 @@ impl super::stub::Aml for Aml {
                 let path_template = "/v1/{name}:importRegisteredParties";
 
                 let resource_name = format!("//financialservices.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -502,6 +504,7 @@ impl super::stub::Aml for Aml {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -519,6 +522,7 @@ impl super::stub::Aml for Aml {
                 let path_template = "/v1/{name}:exportRegisteredParties";
 
                 let resource_name = format!("//financialservices.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1289,6 +1293,7 @@ impl super::stub::Aml for Aml {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_model = try_match(
@@ -1308,6 +1313,7 @@ impl super::stub::Aml for Aml {
                 let path_template = "/v1/{model}:exportMetadata";
 
                 let resource_name = format!("//financialservices.googleapis.com/{}", var_model,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.model));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1761,6 +1767,7 @@ impl super::stub::Aml for Aml {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_engine_config = try_match(
@@ -1781,6 +1788,7 @@ impl super::stub::Aml for Aml {
 
                 let resource_name =
                     format!("//financialservices.googleapis.com/{}", var_engine_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.engine_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2388,6 +2396,7 @@ impl super::stub::Aml for Aml {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_prediction_result = try_match(
@@ -2410,6 +2419,7 @@ impl super::stub::Aml for Aml {
                     "//financialservices.googleapis.com/{}",
                     var_prediction_result,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.prediction_result));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2865,6 +2875,7 @@ impl super::stub::Aml for Aml {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_backtest_result = try_match(
@@ -2885,6 +2896,7 @@ impl super::stub::Aml for Aml {
 
                 let resource_name =
                     format!("//financialservices.googleapis.com/{}", var_backtest_result,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.backtest_result));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3363,6 +3375,7 @@ impl super::stub::Aml for Aml {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3379,6 +3392,7 @@ impl super::stub::Aml for Aml {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/ftp/v1/src/transport.rs
+++ b/src/generated/cloud/ftp/v1/src/transport.rs
@@ -830,6 +830,7 @@ impl super::stub::CloudFtp for CloudFtp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -847,6 +848,7 @@ impl super::stub::CloudFtp for CloudFtp {
                 let path_template = "/v1/{name}:start";
 
                 let resource_name = format!("//ftp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -902,6 +904,7 @@ impl super::stub::CloudFtp for CloudFtp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -919,6 +922,7 @@ impl super::stub::CloudFtp for CloudFtp {
                 let path_template = "/v1/{name}:stop";
 
                 let resource_name = format!("//ftp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1316,6 +1320,7 @@ impl super::stub::CloudFtp for CloudFtp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1332,6 +1337,7 @@ impl super::stub::CloudFtp for CloudFtp {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/functions/v2/src/transport.rs
+++ b/src/generated/cloud/functions/v2/src/transport.rs
@@ -430,6 +430,7 @@ impl super::stub::FunctionService for FunctionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -445,6 +446,7 @@ impl super::stub::FunctionService for FunctionService {
                 let path_template = "/v2/{parent}/functions:generateUploadUrl";
 
                 let resource_name = format!("//cloudfunctions.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -498,6 +500,7 @@ impl super::stub::FunctionService for FunctionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -515,6 +518,7 @@ impl super::stub::FunctionService for FunctionService {
                 let path_template = "/v2/{name}:generateDownloadUrl";
 
                 let resource_name = format!("//cloudfunctions.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -698,6 +702,7 @@ impl super::stub::FunctionService for FunctionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -715,6 +720,7 @@ impl super::stub::FunctionService for FunctionService {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudfunctions.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -854,6 +860,7 @@ impl super::stub::FunctionService for FunctionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -871,6 +878,7 @@ impl super::stub::FunctionService for FunctionService {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudfunctions.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/geminidataanalytics/v1/src/transport.rs
+++ b/src/generated/cloud/geminidataanalytics/v1/src/transport.rs
@@ -761,6 +761,7 @@ impl super::stub::DataAgentService for DataAgentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -779,6 +780,7 @@ impl super::stub::DataAgentService for DataAgentService {
 
                 let resource_name =
                     format!("//geminidataanalytics.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -836,6 +838,7 @@ impl super::stub::DataAgentService for DataAgentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -854,6 +857,7 @@ impl super::stub::DataAgentService for DataAgentService {
 
                 let resource_name =
                     format!("//geminidataanalytics.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1253,6 +1257,7 @@ impl super::stub::DataAgentService for DataAgentService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1269,6 +1274,7 @@ impl super::stub::DataAgentService for DataAgentService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2090,6 +2096,7 @@ impl super::stub::DataChatService for DataChatService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2106,6 +2113,7 @@ impl super::stub::DataChatService for DataChatService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/gkebackup/v1/src/transport.rs
+++ b/src/generated/cloud/gkebackup/v1/src/transport.rs
@@ -3175,6 +3175,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3192,6 +3193,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//gkebackup.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3214,6 +3216,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//gkebackup.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3238,6 +3241,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//gkebackup.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3258,6 +3262,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//gkebackup.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3280,6 +3285,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//gkebackup.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3304,6 +3310,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//gkebackup.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3809,6 +3816,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3826,6 +3834,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//gkebackup.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3848,6 +3857,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//gkebackup.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3872,6 +3882,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//gkebackup.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3892,6 +3903,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//gkebackup.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3914,6 +3926,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//gkebackup.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3938,6 +3951,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//gkebackup.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4307,6 +4321,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4323,6 +4338,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/gkehub/v1/src/transport.rs
+++ b/src/generated/cloud/gkehub/v1/src/transport.rs
@@ -3667,6 +3667,7 @@ impl super::stub::GkeHub for GkeHub {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3683,6 +3684,7 @@ impl super::stub::GkeHub for GkeHub {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/gkemulticloud/v1/src/transport.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/transport.rs
@@ -219,6 +219,7 @@ impl super::stub::AttachedClusters for AttachedClusters {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -234,6 +235,7 @@ impl super::stub::AttachedClusters for AttachedClusters {
                 let path_template = "/v1/{parent}/attachedClusters:import";
 
                 let resource_name = format!("//gkemulticloud.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -667,6 +669,7 @@ impl super::stub::AttachedClusters for AttachedClusters {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_attached_cluster = try_match(
@@ -688,6 +691,7 @@ impl super::stub::AttachedClusters for AttachedClusters {
 
                 let resource_name =
                     format!("//gkemulticloud.googleapis.com/{}", var_attached_cluster,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.attached_cluster));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -960,6 +964,7 @@ impl super::stub::AttachedClusters for AttachedClusters {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -976,6 +981,7 @@ impl super::stub::AttachedClusters for AttachedClusters {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1456,6 +1462,7 @@ impl super::stub::AwsClusters for AwsClusters {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_aws_cluster = try_match(
@@ -1473,6 +1480,7 @@ impl super::stub::AwsClusters for AwsClusters {
                 let path_template = "/v1/{aws_cluster}:generateAwsClusterAgentToken";
 
                 let resource_name = format!("//gkemulticloud.googleapis.com/{}", var_aws_cluster,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.aws_cluster));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1771,6 +1779,7 @@ impl super::stub::AwsClusters for AwsClusters {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1790,6 +1799,7 @@ impl super::stub::AwsClusters for AwsClusters {
                 let path_template = "/v1/{name}:rollback";
 
                 let resource_name = format!("//gkemulticloud.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2510,6 +2520,7 @@ impl super::stub::AwsClusters for AwsClusters {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2526,6 +2537,7 @@ impl super::stub::AwsClusters for AwsClusters {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3298,6 +3310,7 @@ impl super::stub::AzureClusters for AzureClusters {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_azure_cluster = try_match(
@@ -3316,6 +3329,7 @@ impl super::stub::AzureClusters for AzureClusters {
 
                 let resource_name =
                     format!("//gkemulticloud.googleapis.com/{}", var_azure_cluster,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.azure_cluster));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4290,6 +4304,7 @@ impl super::stub::AzureClusters for AzureClusters {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4306,6 +4321,7 @@ impl super::stub::AzureClusters for AzureClusters {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/gsuiteaddons/v1/src/transport.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/transport.rs
@@ -456,6 +456,7 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -471,6 +472,7 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
                 let path_template = "/v1/{name}:install";
 
                 let resource_name = format!("//gsuiteaddons.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -530,6 +532,7 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -545,6 +548,7 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
                 let path_template = "/v1/{name}:uninstall";
 
                 let resource_name = format!("//gsuiteaddons.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/hypercomputecluster/v1/src/transport.rs
+++ b/src/generated/cloud/hypercomputecluster/v1/src/transport.rs
@@ -784,6 +784,7 @@ impl super::stub::HypercomputeCluster for HypercomputeCluster {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -800,6 +801,7 @@ impl super::stub::HypercomputeCluster for HypercomputeCluster {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/iap/v1/src/transport.rs
+++ b/src/generated/cloud/iap/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -66,6 +67,7 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//iap.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -116,6 +118,7 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -126,6 +129,7 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//iap.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -176,6 +180,7 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -186,6 +191,7 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//iap.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1227,6 +1233,7 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1243,6 +1250,7 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
                 let path = format!("/v1/{}:resetSecret", var_name,);
                 let path_template = "/v1/{name}:resetSecret";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/ids/v1/src/transport.rs
+++ b/src/generated/cloud/ids/v1/src/transport.rs
@@ -558,6 +558,7 @@ impl super::stub::Ids for Ids {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -574,6 +575,7 @@ impl super::stub::Ids for Ids {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/kms/v1/src/transport.rs
+++ b/src/generated/cloud/kms/v1/src/transport.rs
@@ -393,6 +393,7 @@ impl super::stub::Autokey for Autokey {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -410,6 +411,7 @@ impl super::stub::Autokey for Autokey {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -432,6 +434,7 @@ impl super::stub::Autokey for Autokey {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -454,6 +457,7 @@ impl super::stub::Autokey for Autokey {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -473,6 +477,7 @@ impl super::stub::Autokey for Autokey {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -493,6 +498,7 @@ impl super::stub::Autokey for Autokey {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -905,6 +911,7 @@ impl super::stub::Autokey for Autokey {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -922,6 +929,7 @@ impl super::stub::Autokey for Autokey {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -944,6 +952,7 @@ impl super::stub::Autokey for Autokey {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -966,6 +975,7 @@ impl super::stub::Autokey for Autokey {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -985,6 +995,7 @@ impl super::stub::Autokey for Autokey {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1005,6 +1016,7 @@ impl super::stub::Autokey for Autokey {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1654,6 +1666,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1671,6 +1684,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1693,6 +1707,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1715,6 +1730,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1734,6 +1750,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1754,6 +1771,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2166,6 +2184,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2183,6 +2202,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2205,6 +2225,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2227,6 +2248,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2246,6 +2268,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2266,6 +2289,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3145,6 +3169,7 @@ impl super::stub::EkmService for EkmService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3162,6 +3187,7 @@ impl super::stub::EkmService for EkmService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3184,6 +3210,7 @@ impl super::stub::EkmService for EkmService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3206,6 +3233,7 @@ impl super::stub::EkmService for EkmService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3225,6 +3253,7 @@ impl super::stub::EkmService for EkmService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3245,6 +3274,7 @@ impl super::stub::EkmService for EkmService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3657,6 +3687,7 @@ impl super::stub::EkmService for EkmService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3674,6 +3705,7 @@ impl super::stub::EkmService for EkmService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3696,6 +3728,7 @@ impl super::stub::EkmService for EkmService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3718,6 +3751,7 @@ impl super::stub::EkmService for EkmService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3737,6 +3771,7 @@ impl super::stub::EkmService for EkmService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3757,6 +3792,7 @@ impl super::stub::EkmService for EkmService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4281,6 +4317,7 @@ impl super::stub::HsmManagement for HsmManagement {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4300,6 +4337,7 @@ impl super::stub::HsmManagement for HsmManagement {
                 let path_template = "/v1/{name}:approve";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4359,6 +4397,7 @@ impl super::stub::HsmManagement for HsmManagement {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4378,6 +4417,7 @@ impl super::stub::HsmManagement for HsmManagement {
                 let path_template = "/v1/{name}:execute";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4803,6 +4843,7 @@ impl super::stub::HsmManagement for HsmManagement {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4820,6 +4861,7 @@ impl super::stub::HsmManagement for HsmManagement {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4842,6 +4884,7 @@ impl super::stub::HsmManagement for HsmManagement {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4864,6 +4907,7 @@ impl super::stub::HsmManagement for HsmManagement {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4883,6 +4927,7 @@ impl super::stub::HsmManagement for HsmManagement {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4903,6 +4948,7 @@ impl super::stub::HsmManagement for HsmManagement {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5315,6 +5361,7 @@ impl super::stub::HsmManagement for HsmManagement {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -5332,6 +5379,7 @@ impl super::stub::HsmManagement for HsmManagement {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5354,6 +5402,7 @@ impl super::stub::HsmManagement for HsmManagement {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5376,6 +5425,7 @@ impl super::stub::HsmManagement for HsmManagement {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5395,6 +5445,7 @@ impl super::stub::HsmManagement for HsmManagement {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5415,6 +5466,7 @@ impl super::stub::HsmManagement for HsmManagement {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6874,6 +6926,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -6893,6 +6946,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{parent}/cryptoKeyVersions:import";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6952,6 +7006,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -6974,6 +7029,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template =
                     "/v1/{parent}/cryptoKeyVersions:importTrustedKeyWrappedCryptoKeyVersion";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -7375,6 +7431,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7394,6 +7451,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{name}:updatePrimaryVersion";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7453,6 +7511,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7474,6 +7533,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{name}:destroy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7535,6 +7595,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7556,6 +7617,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{name}:restore";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7617,6 +7679,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7636,6 +7699,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{name}:encrypt";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7693,6 +7757,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7712,6 +7777,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{name}:decrypt";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7769,6 +7835,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7789,6 +7856,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path = format!("/v1/{}:rawEncrypt", var_name,);
                 let path_template = "/v1/{name}:rawEncrypt";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -7847,6 +7915,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7867,6 +7936,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path = format!("/v1/{}:rawDecrypt", var_name,);
                 let path_template = "/v1/{name}:rawDecrypt";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -7925,6 +7995,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -7946,6 +8017,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{name}:asymmetricSign";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8005,6 +8077,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -8026,6 +8099,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{name}:asymmetricDecrypt";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8085,6 +8159,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -8106,6 +8181,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{name}:macSign";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8165,6 +8241,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -8186,6 +8263,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{name}:macVerify";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8245,6 +8323,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -8266,6 +8345,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{name}:decapsulate";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8325,6 +8405,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_location = try_match(
@@ -8339,6 +8420,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path = format!("/v1/{}:generateRandomBytes", var_location,);
                 let path_template = "/v1/{location}:generateRandomBytes";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.location));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -8516,6 +8598,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -8533,6 +8616,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8555,6 +8639,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8577,6 +8662,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8596,6 +8682,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8616,6 +8703,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9028,6 +9116,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -9045,6 +9134,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9067,6 +9157,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9089,6 +9180,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9108,6 +9200,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9128,6 +9221,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudkms.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/licensemanager/v1/src/transport.rs
+++ b/src/generated/cloud/licensemanager/v1/src/transport.rs
@@ -586,6 +586,7 @@ impl super::stub::LicenseManager for LicenseManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -603,6 +604,7 @@ impl super::stub::LicenseManager for LicenseManager {
                 let path_template = "/v1/{name}:deactivate";
 
                 let resource_name = format!("//licensemanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -660,6 +662,7 @@ impl super::stub::LicenseManager for LicenseManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -677,6 +680,7 @@ impl super::stub::LicenseManager for LicenseManager {
                 let path_template = "/v1/{name}:reactivate";
 
                 let resource_name = format!("//licensemanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1412,6 +1416,7 @@ impl super::stub::LicenseManager for LicenseManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1428,6 +1433,7 @@ impl super::stub::LicenseManager for LicenseManager {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/lustre/v1/src/transport.rs
+++ b/src/generated/cloud/lustre/v1/src/transport.rs
@@ -432,6 +432,7 @@ impl super::stub::Lustre for Lustre {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -449,6 +450,7 @@ impl super::stub::Lustre for Lustre {
                 let path_template = "/v1/{name}:importData";
 
                 let resource_name = format!("//lustre.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -504,6 +506,7 @@ impl super::stub::Lustre for Lustre {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -521,6 +524,7 @@ impl super::stub::Lustre for Lustre {
                 let path_template = "/v1/{name}:exportData";
 
                 let resource_name = format!("//lustre.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/managedidentities/v1/src/transport.rs
+++ b/src/generated/cloud/managedidentities/v1/src/transport.rs
@@ -123,6 +123,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -138,6 +139,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
                 let path_template = "/v1/{name}:resetAdminPassword";
 
                 let resource_name = format!("//managedidentities.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -489,6 +491,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -504,6 +507,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
                 let path_template = "/v1/{name}:attachTrust";
 
                 let resource_name = format!("//managedidentities.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -559,6 +563,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -574,6 +579,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
                 let path_template = "/v1/{name}:reconfigureTrust";
 
                 let resource_name = format!("//managedidentities.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -627,6 +633,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -642,6 +649,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
                 let path_template = "/v1/{name}:detachTrust";
 
                 let resource_name = format!("//managedidentities.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -697,6 +705,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -712,6 +721,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
                 let path_template = "/v1/{name}:validateTrust";
 
                 let resource_name = format!("//managedidentities.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -974,6 +984,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -988,6 +999,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/managedkafka/schemaregistry/v1/src/transport.rs
+++ b/src/generated/cloud/managedkafka/schemaregistry/v1/src/transport.rs
@@ -196,6 +196,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -211,6 +212,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
                 let path_template = "/v1/{parent}/schemaRegistries";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1393,6 +1395,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1412,6 +1415,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
                 let path_template = "/v1/{parent}";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1436,6 +1440,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
                 let path_template = "/v1/{parent}";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1817,6 +1822,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1836,6 +1842,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
                 let path_template = "/v1/{parent}/versions";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1860,6 +1867,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
                 let path_template = "/v1/{parent}/versions";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2110,6 +2118,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2129,6 +2138,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
                 let path_template = "/v1/{name}";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2153,6 +2163,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
                 let path_template = "/v1/{name}";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2358,6 +2369,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2377,6 +2389,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
                 let path_template = "/v1/{name}";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PUT, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PUT, path_template, resource_name)))
@@ -2401,6 +2414,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
                 let path_template = "/v1/{name}";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PUT, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PUT, path_template, resource_name)))
@@ -2721,6 +2735,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2740,6 +2755,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
                 let path_template = "/v1/{name}";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PUT, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PUT, path_template, resource_name)))
@@ -2764,6 +2780,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
                 let path_template = "/v1/{name}";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PUT, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PUT, path_template, resource_name)))
@@ -3305,6 +3322,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3321,6 +3339,7 @@ impl super::stub::ManagedSchemaRegistry for ManagedSchemaRegistry {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/managedkafka/v1/src/transport.rs
+++ b/src/generated/cloud/managedkafka/v1/src/transport.rs
@@ -2044,6 +2044,7 @@ impl super::stub::ManagedKafka for ManagedKafka {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2060,6 +2061,7 @@ impl super::stub::ManagedKafka for ManagedKafka {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2954,6 +2956,7 @@ impl super::stub::ManagedKafkaConnect for ManagedKafkaConnect {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2973,6 +2976,7 @@ impl super::stub::ManagedKafkaConnect for ManagedKafkaConnect {
                 let path_template = "/v1/{name}:pause";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3032,6 +3036,7 @@ impl super::stub::ManagedKafkaConnect for ManagedKafkaConnect {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3051,6 +3056,7 @@ impl super::stub::ManagedKafkaConnect for ManagedKafkaConnect {
                 let path_template = "/v1/{name}:resume";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3110,6 +3116,7 @@ impl super::stub::ManagedKafkaConnect for ManagedKafkaConnect {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3129,6 +3136,7 @@ impl super::stub::ManagedKafkaConnect for ManagedKafkaConnect {
                 let path_template = "/v1/{name}:restart";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3188,6 +3196,7 @@ impl super::stub::ManagedKafkaConnect for ManagedKafkaConnect {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3207,6 +3216,7 @@ impl super::stub::ManagedKafkaConnect for ManagedKafkaConnect {
                 let path_template = "/v1/{name}:stop";
 
                 let resource_name = format!("//managedkafka.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3608,6 +3618,7 @@ impl super::stub::ManagedKafkaConnect for ManagedKafkaConnect {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3624,6 +3635,7 @@ impl super::stub::ManagedKafkaConnect for ManagedKafkaConnect {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/memcache/v1/src/transport.rs
+++ b/src/generated/cloud/memcache/v1/src/transport.rs
@@ -357,6 +357,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -374,6 +375,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
                 let path_template = "/v1/{name}:updateParameters";
 
                 let resource_name = format!("//memcache.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -501,6 +503,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -518,6 +521,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
                 let path_template = "/v1/{name}:applyParameters";
 
                 let resource_name = format!("//memcache.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -573,6 +577,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_instance = try_match(
@@ -590,6 +595,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
                 let path_template = "/v1/{instance}:rescheduleMaintenance";
 
                 let resource_name = format!("//memcache.googleapis.com/{}", var_instance,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.instance));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -987,6 +993,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1003,6 +1010,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/memorystore/v1/src/transport.rs
+++ b/src/generated/cloud/memorystore/v1/src/transport.rs
@@ -576,6 +576,7 @@ impl super::stub::Memorystore for Memorystore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -593,6 +594,7 @@ impl super::stub::Memorystore for Memorystore {
                 let path_template = "/v1/{name}:rescheduleMaintenance";
 
                 let resource_name = format!("//memorystore.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1017,6 +1019,7 @@ impl super::stub::Memorystore for Memorystore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1036,6 +1039,7 @@ impl super::stub::Memorystore for Memorystore {
                 let path_template = "/v1/{name}:export";
 
                 let resource_name = format!("//memorystore.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1093,6 +1097,7 @@ impl super::stub::Memorystore for Memorystore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1110,6 +1115,7 @@ impl super::stub::Memorystore for Memorystore {
                 let path_template = "/v1/{name}:backup";
 
                 let resource_name = format!("//memorystore.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1165,6 +1171,7 @@ impl super::stub::Memorystore for Memorystore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1182,6 +1189,7 @@ impl super::stub::Memorystore for Memorystore {
                 let path_template = "/v1/{name}:startMigration";
 
                 let resource_name = format!("//memorystore.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1237,6 +1245,7 @@ impl super::stub::Memorystore for Memorystore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1254,6 +1263,7 @@ impl super::stub::Memorystore for Memorystore {
                 let path_template = "/v1/{name}:finishMigration";
 
                 let resource_name = format!("//memorystore.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1621,6 +1631,7 @@ impl super::stub::Memorystore for Memorystore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_instance = try_match(
@@ -1638,6 +1649,7 @@ impl super::stub::Memorystore for Memorystore {
                 let path_template = "/v1/{instance}:addTokenAuthUser";
 
                 let resource_name = format!("//memorystore.googleapis.com/{}", var_instance,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.instance));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1771,6 +1783,7 @@ impl super::stub::Memorystore for Memorystore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_token_auth_user = try_match(
@@ -1791,6 +1804,7 @@ impl super::stub::Memorystore for Memorystore {
 
                 let resource_name =
                     format!("//memorystore.googleapis.com/{}", var_token_auth_user,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.token_auth_user));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/metastore/v1/src/transport.rs
+++ b/src/generated/cloud/metastore/v1/src/transport.rs
@@ -757,6 +757,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_service = try_match(
@@ -774,6 +775,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 let path_template = "/v1/{service}:exportMetadata";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_service,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.service));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -829,6 +831,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_service = try_match(
@@ -846,6 +849,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 let path_template = "/v1/{service}:restore";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_service,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.service));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1204,6 +1208,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_service = try_match(
@@ -1221,6 +1226,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 let path_template = "/v1/{service}:queryMetadata";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_service,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.service));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1276,6 +1282,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_service = try_match(
@@ -1293,6 +1300,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 let path_template = "/v1/{service}:moveTableToDatabase";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_service,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.service));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1350,6 +1358,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_service = try_match(
@@ -1367,6 +1376,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 let path_template = "/v1/{service}:alterLocation";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_service,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.service));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1549,6 +1559,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1566,6 +1577,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1588,6 +1600,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1608,6 +1621,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1885,6 +1899,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1902,6 +1917,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1922,6 +1938,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2211,6 +2228,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2227,6 +2245,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2841,6 +2860,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2858,6 +2878,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2880,6 +2901,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2900,6 +2922,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3177,6 +3200,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3194,6 +3218,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3214,6 +3239,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//metastore.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3503,6 +3529,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3519,6 +3546,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/migrationcenter/v1/src/transport.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/transport.rs
@@ -291,6 +291,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -306,6 +307,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 let path_template = "/v1/{parent}/assets:batchUpdate";
 
                 let resource_name = format!("//migrationcenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -440,6 +442,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -455,6 +458,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 let path_template = "/v1/{parent}/assets:batchDelete";
 
                 let resource_name = format!("//migrationcenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -585,6 +589,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -599,6 +604,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 let path = format!("/v1/{}/assets:aggregateValues", var_parent,);
                 let path_template = "/v1/{parent}/assets:aggregateValues";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1040,6 +1046,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1057,6 +1064,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 let path_template = "/v1/{name}:validate";
 
                 let resource_name = format!("//migrationcenter.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1114,6 +1122,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1131,6 +1140,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 let path_template = "/v1/{name}:run";
 
                 let resource_name = format!("//migrationcenter.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1873,6 +1883,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_group = try_match(
@@ -1890,6 +1901,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 let path_template = "/v1/{group}:addAssets";
 
                 let resource_name = format!("//migrationcenter.googleapis.com/{}", var_group,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.group));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1947,6 +1959,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_group = try_match(
@@ -1964,6 +1977,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 let path_template = "/v1/{group}:removeAssets";
 
                 let resource_name = format!("//migrationcenter.googleapis.com/{}", var_group,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.group));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4038,6 +4052,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4054,6 +4069,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/modelarmor/v1/src/transport.rs
+++ b/src/generated/cloud/modelarmor/v1/src/transport.rs
@@ -768,6 +768,7 @@ impl super::stub::ModelArmor for ModelArmor {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -785,6 +786,7 @@ impl super::stub::ModelArmor for ModelArmor {
                 let path_template = "/v1/{name}:sanitizeUserPrompt";
 
                 let resource_name = format!("//modelarmor.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -840,6 +842,7 @@ impl super::stub::ModelArmor for ModelArmor {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -857,6 +860,7 @@ impl super::stub::ModelArmor for ModelArmor {
                 let path_template = "/v1/{name}:sanitizeModelResponse";
 
                 let resource_name = format!("//modelarmor.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/netapp/v1/src/transport.rs
+++ b/src/generated/cloud/netapp/v1/src/transport.rs
@@ -429,6 +429,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -446,6 +447,7 @@ impl super::stub::NetApp for NetApp {
                 let path_template = "/v1/{name}:validateDirectoryService";
 
                 let resource_name = format!("//netapp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -501,6 +503,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -518,6 +521,7 @@ impl super::stub::NetApp for NetApp {
                 let path_template = "/v1/{name}:switch";
 
                 let resource_name = format!("//netapp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -947,6 +951,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -964,6 +969,7 @@ impl super::stub::NetApp for NetApp {
                 let path_template = "/v1/{name}:revert";
 
                 let resource_name = format!("//netapp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1019,6 +1025,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1036,6 +1043,7 @@ impl super::stub::NetApp for NetApp {
                 let path_template = "/v1/{name}:establishPeering";
 
                 let resource_name = format!("//netapp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2158,6 +2166,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2175,6 +2184,7 @@ impl super::stub::NetApp for NetApp {
                 let path_template = "/v1/{name}:encrypt";
 
                 let resource_name = format!("//netapp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2230,6 +2240,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2247,6 +2258,7 @@ impl super::stub::NetApp for NetApp {
                 let path_template = "/v1/{name}:verify";
 
                 let resource_name = format!("//netapp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2767,6 +2779,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2786,6 +2799,7 @@ impl super::stub::NetApp for NetApp {
                 let path_template = "/v1/{name}:stop";
 
                 let resource_name = format!("//netapp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2843,6 +2857,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2862,6 +2877,7 @@ impl super::stub::NetApp for NetApp {
                 let path_template = "/v1/{name}:resume";
 
                 let resource_name = format!("//netapp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2919,6 +2935,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2938,6 +2955,7 @@ impl super::stub::NetApp for NetApp {
                 let path_template = "/v1/{name}:reverseDirection";
 
                 let resource_name = format!("//netapp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2995,6 +3013,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3014,6 +3033,7 @@ impl super::stub::NetApp for NetApp {
                 let path_template = "/v1/{name}:establishPeering";
 
                 let resource_name = format!("//netapp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3071,6 +3091,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3090,6 +3111,7 @@ impl super::stub::NetApp for NetApp {
                 let path_template = "/v1/{name}:sync";
 
                 let resource_name = format!("//netapp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4679,6 +4701,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4696,6 +4719,7 @@ impl super::stub::NetApp for NetApp {
                 let path_template = "/v1/{name}:restore";
 
                 let resource_name = format!("//netapp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5124,6 +5148,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_ontap_path = try_match(
@@ -5142,6 +5167,7 @@ impl super::stub::NetApp for NetApp {
                 let path = format!("/v1/{}", var_ontap_path,);
                 let path_template = "/v1/{ontap_path}";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.ontap_path));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5346,6 +5372,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_ontap_path = try_match(
@@ -5364,6 +5391,7 @@ impl super::stub::NetApp for NetApp {
                 let path = format!("/v1/{}", var_ontap_path,);
                 let path_template = "/v1/{ontap_path}";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.ontap_path));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template)))
@@ -5762,6 +5790,7 @@ impl super::stub::NetApp for NetApp {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5778,6 +5807,7 @@ impl super::stub::NetApp for NetApp {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/networkconnectivity/v1/src/transport.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/transport.rs
@@ -1547,6 +1547,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1563,6 +1564,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1584,6 +1586,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1605,6 +1608,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1624,6 +1628,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1645,6 +1650,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1666,6 +1672,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1687,6 +1694,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1708,6 +1716,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2305,6 +2314,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2321,6 +2331,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2342,6 +2353,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2363,6 +2375,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2382,6 +2395,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2403,6 +2417,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2424,6 +2439,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2445,6 +2461,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2466,6 +2483,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2853,6 +2871,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2869,6 +2888,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4031,6 +4051,7 @@ impl super::stub::DataTransferService for DataTransferService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4047,6 +4068,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4068,6 +4090,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4089,6 +4112,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4108,6 +4132,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4129,6 +4154,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4150,6 +4176,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4171,6 +4198,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4192,6 +4220,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4789,6 +4818,7 @@ impl super::stub::DataTransferService for DataTransferService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4805,6 +4835,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4826,6 +4857,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4847,6 +4879,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4866,6 +4899,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4887,6 +4921,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4908,6 +4943,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4929,6 +4965,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4950,6 +4987,7 @@ impl super::stub::DataTransferService for DataTransferService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5337,6 +5375,7 @@ impl super::stub::DataTransferService for DataTransferService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5353,6 +5392,7 @@ impl super::stub::DataTransferService for DataTransferService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6268,6 +6308,7 @@ impl super::stub::HubService for HubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6283,6 +6324,7 @@ impl super::stub::HubService for HubService {
                 let path_template = "/v1/{name}:rejectSpoke";
 
                 let resource_name = format!("//networkconnectivity.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6336,6 +6378,7 @@ impl super::stub::HubService for HubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6351,6 +6394,7 @@ impl super::stub::HubService for HubService {
                 let path_template = "/v1/{name}:acceptSpoke";
 
                 let resource_name = format!("//networkconnectivity.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6404,6 +6448,7 @@ impl super::stub::HubService for HubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6419,6 +6464,7 @@ impl super::stub::HubService for HubService {
                 let path_template = "/v1/{name}:acceptSpokeUpdate";
 
                 let resource_name = format!("//networkconnectivity.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6474,6 +6520,7 @@ impl super::stub::HubService for HubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6489,6 +6536,7 @@ impl super::stub::HubService for HubService {
                 let path_template = "/v1/{name}:rejectSpokeUpdate";
 
                 let resource_name = format!("//networkconnectivity.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7273,6 +7321,7 @@ impl super::stub::HubService for HubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -7289,6 +7338,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7310,6 +7360,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7331,6 +7382,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7350,6 +7402,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7371,6 +7424,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7392,6 +7446,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7413,6 +7468,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7434,6 +7490,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8031,6 +8088,7 @@ impl super::stub::HubService for HubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -8047,6 +8105,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8068,6 +8127,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8089,6 +8149,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8108,6 +8169,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8129,6 +8191,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8150,6 +8213,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8171,6 +8235,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8192,6 +8257,7 @@ impl super::stub::HubService for HubService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8579,6 +8645,7 @@ impl super::stub::HubService for HubService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -8595,6 +8662,7 @@ impl super::stub::HubService for HubService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -9201,6 +9269,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -9217,6 +9286,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9238,6 +9308,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9259,6 +9330,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9278,6 +9350,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9299,6 +9372,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9320,6 +9394,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9341,6 +9416,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9362,6 +9438,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9959,6 +10036,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -9975,6 +10053,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9996,6 +10075,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10017,6 +10097,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10036,6 +10117,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10057,6 +10139,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10078,6 +10161,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10099,6 +10183,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10120,6 +10205,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10507,6 +10593,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -10523,6 +10610,7 @@ impl super::stub::InternalRangeService for InternalRangeService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -11026,6 +11114,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -11042,6 +11131,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11063,6 +11153,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11084,6 +11175,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11103,6 +11195,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11124,6 +11217,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11145,6 +11239,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11166,6 +11261,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11187,6 +11283,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11784,6 +11881,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -11800,6 +11898,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11821,6 +11920,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11842,6 +11942,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11861,6 +11962,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11882,6 +11984,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11903,6 +12006,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11924,6 +12028,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11945,6 +12050,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
 
                 let resource_name =
                     format!("//networkconnectivity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -12332,6 +12438,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -12348,6 +12455,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/networkmanagement/v1/src/transport.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/transport.rs
@@ -347,6 +347,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -362,6 +363,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
                 let path_template = "/v1/{name}:rerun";
 
                 let resource_name = format!("//networkmanagement.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -665,6 +667,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -680,6 +683,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkmanagement.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -813,6 +817,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -828,6 +833,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkmanagement.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1187,6 +1193,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1201,6 +1208,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1218,6 +1226,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2041,6 +2050,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2056,6 +2066,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkmanagement.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2189,6 +2200,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2204,6 +2216,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkmanagement.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2563,6 +2576,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2577,6 +2591,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2594,6 +2609,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3266,6 +3282,7 @@ impl super::stub::OrganizationVpcFlowLogsService for OrganizationVpcFlowLogsServ
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3281,6 +3298,7 @@ impl super::stub::OrganizationVpcFlowLogsService for OrganizationVpcFlowLogsServ
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkmanagement.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3414,6 +3432,7 @@ impl super::stub::OrganizationVpcFlowLogsService for OrganizationVpcFlowLogsServ
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3429,6 +3448,7 @@ impl super::stub::OrganizationVpcFlowLogsService for OrganizationVpcFlowLogsServ
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkmanagement.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3788,6 +3808,7 @@ impl super::stub::OrganizationVpcFlowLogsService for OrganizationVpcFlowLogsServ
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3802,6 +3823,7 @@ impl super::stub::OrganizationVpcFlowLogsService for OrganizationVpcFlowLogsServ
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3819,6 +3841,7 @@ impl super::stub::OrganizationVpcFlowLogsService for OrganizationVpcFlowLogsServ
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/networksecurity/v1/src/transport.rs
+++ b/src/generated/cloud/networksecurity/v1/src/transport.rs
@@ -367,6 +367,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_address_group = try_match(
@@ -385,6 +386,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
 
                 let resource_name =
                     format!("//networksecurity.googleapis.com/{}", var_address_group,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.address_group));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -442,6 +444,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_address_group = try_match(
@@ -460,6 +463,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
 
                 let resource_name =
                     format!("//networksecurity.googleapis.com/{}", var_address_group,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.address_group));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -515,6 +519,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_address_group = try_match(
@@ -533,6 +538,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
 
                 let resource_name =
                     format!("//networksecurity.googleapis.com/{}", var_address_group,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.address_group));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -920,6 +926,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -937,6 +944,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -957,6 +965,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -977,6 +986,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -997,6 +1007,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1017,6 +1028,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1420,6 +1432,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1437,6 +1450,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1457,6 +1471,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1477,6 +1492,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1497,6 +1513,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1517,6 +1534,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1537,6 +1555,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2003,6 +2022,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2019,6 +2039,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2038,6 +2059,7 @@ impl super::stub::AddressGroupService for AddressGroupService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2461,6 +2483,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_address_group = try_match(
@@ -2479,6 +2502,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
 
                 let resource_name =
                     format!("//networksecurity.googleapis.com/{}", var_address_group,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.address_group));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2534,6 +2558,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_address_group = try_match(
@@ -2552,6 +2577,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
 
                 let resource_name =
                     format!("//networksecurity.googleapis.com/{}", var_address_group,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.address_group));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2607,6 +2633,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_address_group = try_match(
@@ -2625,6 +2652,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
 
                 let resource_name =
                     format!("//networksecurity.googleapis.com/{}", var_address_group,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.address_group));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3010,6 +3038,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3027,6 +3056,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3047,6 +3077,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3067,6 +3098,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3087,6 +3119,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3107,6 +3140,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3510,6 +3544,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3527,6 +3562,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3547,6 +3583,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3567,6 +3604,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3587,6 +3625,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3607,6 +3646,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3627,6 +3667,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4093,6 +4134,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4109,6 +4151,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4128,6 +4171,7 @@ impl super::stub::OrganizationAddressGroupService for OrganizationAddressGroupSe
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4808,6 +4852,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4825,6 +4870,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4845,6 +4891,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4865,6 +4912,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4885,6 +4933,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4905,6 +4954,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5308,6 +5358,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -5325,6 +5376,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5345,6 +5397,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5365,6 +5418,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5385,6 +5439,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5405,6 +5460,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5425,6 +5481,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5891,6 +5948,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5907,6 +5965,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5926,6 +5985,7 @@ impl super::stub::DnsThreatDetectorService for DnsThreatDetectorService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -7355,6 +7415,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -7372,6 +7433,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7392,6 +7454,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7412,6 +7475,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7432,6 +7496,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7452,6 +7517,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7855,6 +7921,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -7872,6 +7939,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7892,6 +7960,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7912,6 +7981,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7932,6 +8002,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7952,6 +8023,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7972,6 +8044,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8438,6 +8511,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -8454,6 +8528,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -8473,6 +8548,7 @@ impl super::stub::FirewallActivation for FirewallActivation {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -10317,6 +10393,7 @@ impl super::stub::Intercept for Intercept {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -10334,6 +10411,7 @@ impl super::stub::Intercept for Intercept {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10354,6 +10432,7 @@ impl super::stub::Intercept for Intercept {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10374,6 +10453,7 @@ impl super::stub::Intercept for Intercept {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10394,6 +10474,7 @@ impl super::stub::Intercept for Intercept {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10414,6 +10495,7 @@ impl super::stub::Intercept for Intercept {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10817,6 +10899,7 @@ impl super::stub::Intercept for Intercept {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -10834,6 +10917,7 @@ impl super::stub::Intercept for Intercept {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10854,6 +10938,7 @@ impl super::stub::Intercept for Intercept {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10874,6 +10959,7 @@ impl super::stub::Intercept for Intercept {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10894,6 +10980,7 @@ impl super::stub::Intercept for Intercept {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10914,6 +11001,7 @@ impl super::stub::Intercept for Intercept {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10934,6 +11022,7 @@ impl super::stub::Intercept for Intercept {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11400,6 +11489,7 @@ impl super::stub::Intercept for Intercept {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -11416,6 +11506,7 @@ impl super::stub::Intercept for Intercept {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -11435,6 +11526,7 @@ impl super::stub::Intercept for Intercept {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -13279,6 +13371,7 @@ impl super::stub::Mirroring for Mirroring {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -13296,6 +13389,7 @@ impl super::stub::Mirroring for Mirroring {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13316,6 +13410,7 @@ impl super::stub::Mirroring for Mirroring {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13336,6 +13431,7 @@ impl super::stub::Mirroring for Mirroring {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13356,6 +13452,7 @@ impl super::stub::Mirroring for Mirroring {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13376,6 +13473,7 @@ impl super::stub::Mirroring for Mirroring {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13779,6 +13877,7 @@ impl super::stub::Mirroring for Mirroring {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -13796,6 +13895,7 @@ impl super::stub::Mirroring for Mirroring {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13816,6 +13916,7 @@ impl super::stub::Mirroring for Mirroring {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13836,6 +13937,7 @@ impl super::stub::Mirroring for Mirroring {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13856,6 +13958,7 @@ impl super::stub::Mirroring for Mirroring {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13876,6 +13979,7 @@ impl super::stub::Mirroring for Mirroring {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13896,6 +14000,7 @@ impl super::stub::Mirroring for Mirroring {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14362,6 +14467,7 @@ impl super::stub::Mirroring for Mirroring {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -14378,6 +14484,7 @@ impl super::stub::Mirroring for Mirroring {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -14397,6 +14504,7 @@ impl super::stub::Mirroring for Mirroring {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -18128,6 +18236,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -18145,6 +18254,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18165,6 +18275,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18185,6 +18296,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18205,6 +18317,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18225,6 +18338,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18628,6 +18742,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -18645,6 +18760,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18665,6 +18781,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18685,6 +18802,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18705,6 +18823,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18725,6 +18844,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -18745,6 +18865,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -19211,6 +19332,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -19227,6 +19349,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -19246,6 +19369,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -20293,6 +20417,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -20310,6 +20435,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20330,6 +20456,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20350,6 +20477,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20370,6 +20498,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20390,6 +20519,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20793,6 +20923,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -20810,6 +20941,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20830,6 +20962,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20850,6 +20983,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20870,6 +21004,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20890,6 +21025,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -20910,6 +21046,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -21376,6 +21513,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -21392,6 +21530,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -21411,6 +21550,7 @@ impl super::stub::SecurityProfileGroupService for SecurityProfileGroupService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -22460,6 +22600,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -22477,6 +22618,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -22497,6 +22639,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -22517,6 +22660,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -22537,6 +22681,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -22557,6 +22702,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -22960,6 +23106,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -22977,6 +23124,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -22997,6 +23145,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23017,6 +23166,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23037,6 +23187,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23057,6 +23208,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23077,6 +23229,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -23543,6 +23696,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -23559,6 +23713,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -23578,6 +23733,7 @@ impl super::stub::OrganizationSecurityProfileGroupService
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -24466,6 +24622,7 @@ impl super::stub::SSERealmService for SSERealmService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -24483,6 +24640,7 @@ impl super::stub::SSERealmService for SSERealmService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24503,6 +24661,7 @@ impl super::stub::SSERealmService for SSERealmService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24523,6 +24682,7 @@ impl super::stub::SSERealmService for SSERealmService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24543,6 +24703,7 @@ impl super::stub::SSERealmService for SSERealmService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24563,6 +24724,7 @@ impl super::stub::SSERealmService for SSERealmService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -24966,6 +25128,7 @@ impl super::stub::SSERealmService for SSERealmService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -24983,6 +25146,7 @@ impl super::stub::SSERealmService for SSERealmService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25003,6 +25167,7 @@ impl super::stub::SSERealmService for SSERealmService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25023,6 +25188,7 @@ impl super::stub::SSERealmService for SSERealmService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25043,6 +25209,7 @@ impl super::stub::SSERealmService for SSERealmService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25063,6 +25230,7 @@ impl super::stub::SSERealmService for SSERealmService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25083,6 +25251,7 @@ impl super::stub::SSERealmService for SSERealmService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networksecurity.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -25549,6 +25718,7 @@ impl super::stub::SSERealmService for SSERealmService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -25565,6 +25735,7 @@ impl super::stub::SSERealmService for SSERealmService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -25584,6 +25755,7 @@ impl super::stub::SSERealmService for SSERealmService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/networkservices/v1/src/transport.rs
+++ b/src/generated/cloud/networkservices/v1/src/transport.rs
@@ -1722,6 +1722,7 @@ impl super::stub::DepService for DepService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1739,6 +1740,7 @@ impl super::stub::DepService for DepService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1759,6 +1761,7 @@ impl super::stub::DepService for DepService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1779,6 +1782,7 @@ impl super::stub::DepService for DepService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1799,6 +1803,7 @@ impl super::stub::DepService for DepService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1819,6 +1824,7 @@ impl super::stub::DepService for DepService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1839,6 +1845,7 @@ impl super::stub::DepService for DepService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1859,6 +1866,7 @@ impl super::stub::DepService for DepService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2394,6 +2402,7 @@ impl super::stub::DepService for DepService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2411,6 +2420,7 @@ impl super::stub::DepService for DepService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2431,6 +2441,7 @@ impl super::stub::DepService for DepService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2451,6 +2462,7 @@ impl super::stub::DepService for DepService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2471,6 +2483,7 @@ impl super::stub::DepService for DepService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2491,6 +2504,7 @@ impl super::stub::DepService for DepService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2511,6 +2525,7 @@ impl super::stub::DepService for DepService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2531,6 +2546,7 @@ impl super::stub::DepService for DepService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2905,6 +2921,7 @@ impl super::stub::DepService for DepService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2921,6 +2938,7 @@ impl super::stub::DepService for DepService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -7940,6 +7958,7 @@ impl super::stub::NetworkServices for NetworkServices {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -7957,6 +7976,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7977,6 +7997,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7997,6 +8018,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8017,6 +8039,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8037,6 +8060,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8057,6 +8081,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8077,6 +8102,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8612,6 +8638,7 @@ impl super::stub::NetworkServices for NetworkServices {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -8629,6 +8656,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8649,6 +8677,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8669,6 +8698,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8689,6 +8719,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8709,6 +8740,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8729,6 +8761,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8749,6 +8782,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//networkservices.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9123,6 +9157,7 @@ impl super::stub::NetworkServices for NetworkServices {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -9139,6 +9174,7 @@ impl super::stub::NetworkServices for NetworkServices {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/notebooks/v2/src/transport.rs
+++ b/src/generated/cloud/notebooks/v2/src/transport.rs
@@ -432,6 +432,7 @@ impl super::stub::NotebookService for NotebookService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -448,6 +449,7 @@ impl super::stub::NotebookService for NotebookService {
                 let path = format!("/v2/{}:start", var_name,);
                 let path_template = "/v2/{name}:start";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -502,6 +504,7 @@ impl super::stub::NotebookService for NotebookService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -518,6 +521,7 @@ impl super::stub::NotebookService for NotebookService {
                 let path = format!("/v2/{}:stop", var_name,);
                 let path_template = "/v2/{name}:stop";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -572,6 +576,7 @@ impl super::stub::NotebookService for NotebookService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -588,6 +593,7 @@ impl super::stub::NotebookService for NotebookService {
                 let path = format!("/v2/{}:reset", var_name,);
                 let path_template = "/v2/{name}:reset";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -714,6 +720,7 @@ impl super::stub::NotebookService for NotebookService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -730,6 +737,7 @@ impl super::stub::NotebookService for NotebookService {
                 let path = format!("/v2/{}:upgrade", var_name,);
                 let path_template = "/v2/{name}:upgrade";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -784,6 +792,7 @@ impl super::stub::NotebookService for NotebookService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -801,6 +810,7 @@ impl super::stub::NotebookService for NotebookService {
                 let path_template = "/v2/{name}:rollback";
 
                 let resource_name = format!("//notebooks.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -856,6 +866,7 @@ impl super::stub::NotebookService for NotebookService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -873,6 +884,7 @@ impl super::stub::NotebookService for NotebookService {
                 let path_template = "/v2/{name}:diagnose";
 
                 let resource_name = format!("//notebooks.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1053,6 +1065,7 @@ impl super::stub::NotebookService for NotebookService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1070,6 +1083,7 @@ impl super::stub::NotebookService for NotebookService {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//notebooks.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1209,6 +1223,7 @@ impl super::stub::NotebookService for NotebookService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1226,6 +1241,7 @@ impl super::stub::NotebookService for NotebookService {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//notebooks.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1498,6 +1514,7 @@ impl super::stub::NotebookService for NotebookService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1514,6 +1531,7 @@ impl super::stub::NotebookService for NotebookService {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/optimization/v1/src/transport.rs
+++ b/src/generated/cloud/optimization/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::FleetRouting for FleetRouting {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -70,6 +71,7 @@ impl super::stub::FleetRouting for FleetRouting {
                 let path = format!("/v1/{}:optimizeTours", var_parent,);
                 let path_template = "/v1/{parent}:optimizeTours";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -82,6 +84,7 @@ impl super::stub::FleetRouting for FleetRouting {
                 let path = format!("/v1/{}:optimizeTours", var_parent,);
                 let path_template = "/v1/{parent}:optimizeTours";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -144,6 +147,7 @@ impl super::stub::FleetRouting for FleetRouting {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -158,6 +162,7 @@ impl super::stub::FleetRouting for FleetRouting {
                 let path = format!("/v1/{}:batchOptimizeTours", var_parent,);
                 let path_template = "/v1/{parent}:batchOptimizeTours";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -170,6 +175,7 @@ impl super::stub::FleetRouting for FleetRouting {
                 let path = format!("/v1/{}:batchOptimizeTours", var_parent,);
                 let path_template = "/v1/{parent}:batchOptimizeTours";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/oracledatabase/v1/src/transport.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/transport.rs
@@ -347,6 +347,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -364,6 +365,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 let path_template = "/v1/{name}:configureExascale";
 
                 let resource_name = format!("//oracledatabase.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1581,6 +1583,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1598,6 +1601,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 let path_template = "/v1/{name}:restore";
 
                 let resource_name = format!("//oracledatabase.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1655,6 +1659,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1672,6 +1677,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 let path_template = "/v1/{name}:generateWallet";
 
                 let resource_name = format!("//oracledatabase.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1941,6 +1947,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1958,6 +1965,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 let path_template = "/v1/{name}:stop";
 
                 let resource_name = format!("//oracledatabase.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2015,6 +2023,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2032,6 +2041,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 let path_template = "/v1/{name}:start";
 
                 let resource_name = format!("//oracledatabase.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2089,6 +2099,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2106,6 +2117,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 let path_template = "/v1/{name}:restart";
 
                 let resource_name = format!("//oracledatabase.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2163,6 +2175,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2180,6 +2193,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 let path_template = "/v1/{name}:switchover";
 
                 let resource_name = format!("//oracledatabase.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2235,6 +2249,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2252,6 +2267,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 let path_template = "/v1/{name}:failover";
 
                 let resource_name = format!("//oracledatabase.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2309,6 +2325,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2326,6 +2343,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 let path_template = "/v1/{name}:refresh";
 
                 let resource_name = format!("//oracledatabase.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3435,6 +3453,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3452,6 +3471,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 let path_template = "/v1/{name}:removeVirtualMachine";
 
                 let resource_name = format!("//oracledatabase.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4744,6 +4764,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4761,6 +4782,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 let path_template = "/v1/{name}:stop";
 
                 let resource_name = format!("//oracledatabase.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4818,6 +4840,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4835,6 +4858,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 let path_template = "/v1/{name}:start";
 
                 let resource_name = format!("//oracledatabase.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5906,6 +5930,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5923,6 +5948,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 let path_template = "/v1/{name}:test";
 
                 let resource_name = format!("//oracledatabase.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6320,6 +6346,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6336,6 +6363,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/transport.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/transport.rs
@@ -414,6 +414,7 @@ impl super::stub::Environments for Environments {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_environment = try_match(
@@ -430,6 +431,7 @@ impl super::stub::Environments for Environments {
                 let path = format!("/v1/{}:executeAirflowCommand", var_environment,);
                 let path_template = "/v1/{environment}:executeAirflowCommand";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.environment));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -484,6 +486,7 @@ impl super::stub::Environments for Environments {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_environment = try_match(
@@ -500,6 +503,7 @@ impl super::stub::Environments for Environments {
                 let path = format!("/v1/{}:stopAirflowCommand", var_environment,);
                 let path_template = "/v1/{environment}:stopAirflowCommand";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.environment));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -554,6 +558,7 @@ impl super::stub::Environments for Environments {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_environment = try_match(
@@ -570,6 +575,7 @@ impl super::stub::Environments for Environments {
                 let path = format!("/v1/{}:pollAirflowCommand", var_environment,);
                 let path_template = "/v1/{environment}:pollAirflowCommand";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.environment));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -701,6 +707,7 @@ impl super::stub::Environments for Environments {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_environment = try_match(
@@ -717,6 +724,7 @@ impl super::stub::Environments for Environments {
                 let path = format!("/v1/{}:checkUpgrade", var_environment,);
                 let path_template = "/v1/{environment}:checkUpgrade";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.environment));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1541,6 +1549,7 @@ impl super::stub::Environments for Environments {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_environment = try_match(
@@ -1557,6 +1566,7 @@ impl super::stub::Environments for Environments {
                 let path = format!("/v1/{}:saveSnapshot", var_environment,);
                 let path_template = "/v1/{environment}:saveSnapshot";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.environment));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1613,6 +1623,7 @@ impl super::stub::Environments for Environments {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_environment = try_match(
@@ -1629,6 +1640,7 @@ impl super::stub::Environments for Environments {
                 let path = format!("/v1/{}:loadSnapshot", var_environment,);
                 let path_template = "/v1/{environment}:loadSnapshot";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.environment));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1685,6 +1697,7 @@ impl super::stub::Environments for Environments {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_environment = try_match(
@@ -1701,6 +1714,7 @@ impl super::stub::Environments for Environments {
                 let path = format!("/v1/{}:databaseFailover", var_environment,);
                 let path_template = "/v1/{environment}:databaseFailover";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.environment));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/osconfig/v1/src/transport.rs
+++ b/src/generated/cloud/osconfig/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::OsConfigService for OsConfigService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -66,6 +67,7 @@ impl super::stub::OsConfigService for OsConfigService {
                 let path_template = "/v1/{parent}/patchJobs:execute";
 
                 let resource_name = format!("//osconfig.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -182,6 +184,7 @@ impl super::stub::OsConfigService for OsConfigService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -197,6 +200,7 @@ impl super::stub::OsConfigService for OsConfigService {
                 let path_template = "/v1/{name}:cancel";
 
                 let resource_name = format!("//osconfig.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -735,6 +739,7 @@ impl super::stub::OsConfigService for OsConfigService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -750,6 +755,7 @@ impl super::stub::OsConfigService for OsConfigService {
                 let path_template = "/v1/{name}:pause";
 
                 let resource_name = format!("//osconfig.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -803,6 +809,7 @@ impl super::stub::OsConfigService for OsConfigService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -818,6 +825,7 @@ impl super::stub::OsConfigService for OsConfigService {
                 let path_template = "/v1/{name}:resume";
 
                 let resource_name = format!("//osconfig.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -947,6 +955,7 @@ impl super::stub::OsConfigService for OsConfigService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -965,6 +974,7 @@ impl super::stub::OsConfigService for OsConfigService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2049,6 +2059,7 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2067,6 +2078,7 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/parallelstore/v1/src/transport.rs
+++ b/src/generated/cloud/parallelstore/v1/src/transport.rs
@@ -432,6 +432,7 @@ impl super::stub::Parallelstore for Parallelstore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -449,6 +450,7 @@ impl super::stub::Parallelstore for Parallelstore {
                 let path_template = "/v1/{name}:importData";
 
                 let resource_name = format!("//parallelstore.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -504,6 +506,7 @@ impl super::stub::Parallelstore for Parallelstore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -521,6 +524,7 @@ impl super::stub::Parallelstore for Parallelstore {
                 let path_template = "/v1/{name}:exportData";
 
                 let resource_name = format!("//parallelstore.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -918,6 +922,7 @@ impl super::stub::Parallelstore for Parallelstore {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -934,6 +939,7 @@ impl super::stub::Parallelstore for Parallelstore {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/transport.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/transport.rs
@@ -1771,6 +1771,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1791,6 +1792,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
 
                 let resource_name =
                     format!("//privilegedaccessmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1814,6 +1816,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
 
                 let resource_name =
                     format!("//privilegedaccessmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1837,6 +1840,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
 
                 let resource_name =
                     format!("//privilegedaccessmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1932,6 +1936,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1952,6 +1957,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
 
                 let resource_name =
                     format!("//privilegedaccessmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1975,6 +1981,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
 
                 let resource_name =
                     format!("//privilegedaccessmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1998,6 +2005,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
 
                 let resource_name =
                     format!("//privilegedaccessmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2095,6 +2103,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2115,6 +2124,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
 
                 let resource_name =
                     format!("//privilegedaccessmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2138,6 +2148,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
 
                 let resource_name =
                     format!("//privilegedaccessmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2161,6 +2172,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
 
                 let resource_name =
                     format!("//privilegedaccessmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/transport.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/transport.rs
@@ -579,6 +579,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -597,6 +598,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
 
                 let resource_name =
                     format!("//rapidmigrationassessment.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -652,6 +654,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -670,6 +673,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
 
                 let resource_name =
                     format!("//rapidmigrationassessment.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -725,6 +729,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -743,6 +748,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
 
                 let resource_name =
                     format!("//rapidmigrationassessment.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1140,6 +1146,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1156,6 +1163,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/recaptchaenterprise/v1/src/transport.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/transport.rs
@@ -114,6 +114,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -129,6 +130,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 let path_template = "/v1/{name}:annotate";
 
                 let resource_name = format!("//recaptchaenterprise.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -604,6 +606,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -619,6 +622,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 let path_template = "/v1/{name}:migrate";
 
                 let resource_name = format!("//recaptchaenterprise.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -674,6 +678,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -689,6 +694,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 let path_template = "/v1/{name}:addIpOverride";
 
                 let resource_name = format!("//recaptchaenterprise.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -742,6 +748,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -757,6 +764,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 let path_template = "/v1/{name}:removeIpOverride";
 
                 let resource_name = format!("//recaptchaenterprise.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1454,6 +1462,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1464,6 +1473,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 let path_template = "/v1/{parent}/firewallpolicies:reorder";
 
                 let resource_name = format!("//recaptchaenterprise.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1642,6 +1652,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_project = try_match(
@@ -1653,6 +1664,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
 
                 let resource_name =
                     format!("//recaptchaenterprise.googleapis.com/{}", var_project,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/recommender/v1/src/transport.rs
+++ b/src/generated/cloud/recommender/v1/src/transport.rs
@@ -450,6 +450,7 @@ impl super::stub::Recommender for Recommender {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -469,6 +470,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markAccepted";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -491,6 +493,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markAccepted";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -513,6 +516,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markAccepted";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -535,6 +539,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markAccepted";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1043,6 +1048,7 @@ impl super::stub::Recommender for Recommender {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1062,6 +1068,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markDismissed";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1084,6 +1091,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markDismissed";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1106,6 +1114,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markDismissed";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1128,6 +1137,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markDismissed";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1244,6 +1254,7 @@ impl super::stub::Recommender for Recommender {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1263,6 +1274,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markClaimed";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1285,6 +1297,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markClaimed";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1307,6 +1320,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markClaimed";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1329,6 +1343,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markClaimed";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1445,6 +1460,7 @@ impl super::stub::Recommender for Recommender {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1464,6 +1480,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markSucceeded";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1486,6 +1503,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markSucceeded";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1508,6 +1526,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markSucceeded";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1530,6 +1549,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markSucceeded";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1646,6 +1666,7 @@ impl super::stub::Recommender for Recommender {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1665,6 +1686,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markFailed";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1687,6 +1709,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markFailed";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1709,6 +1732,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markFailed";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1731,6 +1755,7 @@ impl super::stub::Recommender for Recommender {
                 let path_template = "/v1/{name}:markFailed";
 
                 let resource_name = format!("//recommender.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/redis/cluster/v1/src/transport.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/transport.rs
@@ -574,6 +574,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -591,6 +592,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
                 let path_template = "/v1/{name}:rescheduleClusterMaintenance";
 
                 let resource_name = format!("//redis.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1019,6 +1021,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1038,6 +1041,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
                 let path_template = "/v1/{name}:export";
 
                 let resource_name = format!("//redis.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1095,6 +1099,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1112,6 +1117,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
                 let path_template = "/v1/{name}:backup";
 
                 let resource_name = format!("//redis.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/redis/v1/src/transport.rs
+++ b/src/generated/cloud/redis/v1/src/transport.rs
@@ -427,6 +427,7 @@ impl super::stub::CloudRedis for CloudRedis {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -444,6 +445,7 @@ impl super::stub::CloudRedis for CloudRedis {
                 let path_template = "/v1/{name}:upgrade";
 
                 let resource_name = format!("//redis.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -499,6 +501,7 @@ impl super::stub::CloudRedis for CloudRedis {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -515,6 +518,7 @@ impl super::stub::CloudRedis for CloudRedis {
                 let path = format!("/v1/{}:import", var_name,);
                 let path_template = "/v1/{name}:import";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -569,6 +573,7 @@ impl super::stub::CloudRedis for CloudRedis {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -585,6 +590,7 @@ impl super::stub::CloudRedis for CloudRedis {
                 let path = format!("/v1/{}:export", var_name,);
                 let path_template = "/v1/{name}:export";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -639,6 +645,7 @@ impl super::stub::CloudRedis for CloudRedis {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -656,6 +663,7 @@ impl super::stub::CloudRedis for CloudRedis {
                 let path_template = "/v1/{name}:failover";
 
                 let resource_name = format!("//redis.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -783,6 +791,7 @@ impl super::stub::CloudRedis for CloudRedis {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -800,6 +809,7 @@ impl super::stub::CloudRedis for CloudRedis {
                 let path_template = "/v1/{name}:rescheduleMaintenance";
 
                 let resource_name = format!("//redis.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/resourcemanager/v3/src/transport.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/transport.rs
@@ -327,6 +327,7 @@ impl super::stub::Folders for Folders {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -337,6 +338,7 @@ impl super::stub::Folders for Folders {
                 let path_template = "/v3/{name}:move";
 
                 let resource_name = format!("//cloudresourcemanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -443,6 +445,7 @@ impl super::stub::Folders for Folders {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -453,6 +456,7 @@ impl super::stub::Folders for Folders {
                 let path_template = "/v3/{name}:undelete";
 
                 let resource_name = format!("//cloudresourcemanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -501,6 +505,7 @@ impl super::stub::Folders for Folders {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -512,6 +517,7 @@ impl super::stub::Folders for Folders {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -560,6 +566,7 @@ impl super::stub::Folders for Folders {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -571,6 +578,7 @@ impl super::stub::Folders for Folders {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -619,6 +627,7 @@ impl super::stub::Folders for Folders {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -630,6 +639,7 @@ impl super::stub::Folders for Folders {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -890,6 +900,7 @@ impl super::stub::Organizations for Organizations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -901,6 +912,7 @@ impl super::stub::Organizations for Organizations {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -949,6 +961,7 @@ impl super::stub::Organizations for Organizations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -960,6 +973,7 @@ impl super::stub::Organizations for Organizations {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1008,6 +1022,7 @@ impl super::stub::Organizations for Organizations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1019,6 +1034,7 @@ impl super::stub::Organizations for Organizations {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1431,6 +1447,7 @@ impl super::stub::Projects for Projects {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1441,6 +1458,7 @@ impl super::stub::Projects for Projects {
                 let path_template = "/v3/{name}:move";
 
                 let resource_name = format!("//cloudresourcemanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1547,6 +1565,7 @@ impl super::stub::Projects for Projects {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1557,6 +1576,7 @@ impl super::stub::Projects for Projects {
                 let path_template = "/v3/{name}:undelete";
 
                 let resource_name = format!("//cloudresourcemanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1605,6 +1625,7 @@ impl super::stub::Projects for Projects {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1616,6 +1637,7 @@ impl super::stub::Projects for Projects {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1664,6 +1686,7 @@ impl super::stub::Projects for Projects {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1675,6 +1698,7 @@ impl super::stub::Projects for Projects {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1723,6 +1747,7 @@ impl super::stub::Projects for Projects {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1734,6 +1759,7 @@ impl super::stub::Projects for Projects {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2821,6 +2847,7 @@ impl super::stub::TagKeys for TagKeys {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2832,6 +2859,7 @@ impl super::stub::TagKeys for TagKeys {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2880,6 +2908,7 @@ impl super::stub::TagKeys for TagKeys {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2891,6 +2920,7 @@ impl super::stub::TagKeys for TagKeys {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2939,6 +2969,7 @@ impl super::stub::TagKeys for TagKeys {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2950,6 +2981,7 @@ impl super::stub::TagKeys for TagKeys {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3435,6 +3467,7 @@ impl super::stub::TagValues for TagValues {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3446,6 +3479,7 @@ impl super::stub::TagValues for TagValues {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3494,6 +3528,7 @@ impl super::stub::TagValues for TagValues {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3505,6 +3540,7 @@ impl super::stub::TagValues for TagValues {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3553,6 +3589,7 @@ impl super::stub::TagValues for TagValues {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3564,6 +3601,7 @@ impl super::stub::TagValues for TagValues {
 
                 let resource_name =
                     format!("//cloudresourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/retail/v2/src/transport.rs
+++ b/src/generated/cloud/retail/v2/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::AnalyticsService for AnalyticsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_catalog = try_match(
@@ -72,6 +73,7 @@ impl super::stub::AnalyticsService for AnalyticsService {
                 let path = format!("/v2/{}:exportAnalyticsMetrics", var_catalog,);
                 let path_template = "/v2/{catalog}:exportAnalyticsMetrics";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.catalog));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -654,6 +656,7 @@ impl super::stub::CatalogService for CatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_catalog = try_match(
@@ -671,6 +674,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v2/{catalog}:setDefaultBranch";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_catalog,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.catalog));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1132,6 +1136,7 @@ impl super::stub::CatalogService for CatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_attributes_config = try_match(
@@ -1150,6 +1155,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v2/{attributes_config}:addCatalogAttribute";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_attributes_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.attributes_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1206,6 +1212,7 @@ impl super::stub::CatalogService for CatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_attributes_config = try_match(
@@ -1224,6 +1231,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v2/{attributes_config}:removeCatalogAttribute";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_attributes_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.attributes_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1280,6 +1288,7 @@ impl super::stub::CatalogService for CatalogService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_attributes_config = try_match(
@@ -1298,6 +1307,7 @@ impl super::stub::CatalogService for CatalogService {
                 let path_template = "/v2/{attributes_config}:replaceCatalogAttribute";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_attributes_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.attributes_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1794,6 +1804,7 @@ impl super::stub::CompletionService for CompletionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1811,6 +1822,7 @@ impl super::stub::CompletionService for CompletionService {
                 let path_template = "/v2/{parent}/completionData:import";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3667,6 +3679,7 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -3684,6 +3697,7 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
                 let path_template = "/v2/{parent}/generativeQuestion:batchUpdate";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4242,6 +4256,7 @@ impl super::stub::ModelService for ModelService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4261,6 +4276,7 @@ impl super::stub::ModelService for ModelService {
                 let path_template = "/v2/{name}:pause";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4318,6 +4334,7 @@ impl super::stub::ModelService for ModelService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4336,6 +4353,7 @@ impl super::stub::ModelService for ModelService {
                 let path = format!("/v2/{}:resume", var_name,);
                 let path_template = "/v2/{name}:resume";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4640,6 +4658,7 @@ impl super::stub::ModelService for ModelService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4659,6 +4678,7 @@ impl super::stub::ModelService for ModelService {
                 let path_template = "/v2/{name}:tune";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5084,6 +5104,7 @@ impl super::stub::PredictionService for PredictionService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_placement = try_match(
@@ -5102,6 +5123,7 @@ impl super::stub::PredictionService for PredictionService {
                 let path = format!("/v2/{}:predict", var_placement,);
                 let path_template = "/v2/{placement}:predict";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.placement));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5123,6 +5145,7 @@ impl super::stub::PredictionService for PredictionService {
                 let path = format!("/v2/{}:predict", var_placement,);
                 let path_template = "/v2/{placement}:predict";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.placement));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5983,6 +6006,7 @@ impl super::stub::ProductService for ProductService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -6002,6 +6026,7 @@ impl super::stub::ProductService for ProductService {
                 let path_template = "/v2/{parent}/products:purge";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6059,6 +6084,7 @@ impl super::stub::ProductService for ProductService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -6078,6 +6104,7 @@ impl super::stub::ProductService for ProductService {
                 let path_template = "/v2/{parent}/products:import";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6135,6 +6162,7 @@ impl super::stub::ProductService for ProductService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_inventory_name = try_match(
@@ -6158,6 +6186,9 @@ impl super::stub::ProductService for ProductService {
                 let path = format!("/v2/{}:setInventory", var_inventory_name,);
                 let path_template = "/v2/{inventory.name}:setInventory";
 
+                let _ = Some(&mut req)
+                    .and_then(|m| m.inventory.as_mut())
+                    .map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6219,6 +6250,7 @@ impl super::stub::ProductService for ProductService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_product = try_match(
@@ -6240,6 +6272,7 @@ impl super::stub::ProductService for ProductService {
                 let path_template = "/v2/{product}:addFulfillmentPlaces";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_product,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.product));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6299,6 +6332,7 @@ impl super::stub::ProductService for ProductService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_product = try_match(
@@ -6320,6 +6354,7 @@ impl super::stub::ProductService for ProductService {
                 let path_template = "/v2/{product}:removeFulfillmentPlaces";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_product,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.product));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6379,6 +6414,7 @@ impl super::stub::ProductService for ProductService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_product = try_match(
@@ -6400,6 +6436,7 @@ impl super::stub::ProductService for ProductService {
                 let path_template = "/v2/{product}:addLocalInventories";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_product,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.product));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6459,6 +6496,7 @@ impl super::stub::ProductService for ProductService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_product = try_match(
@@ -6480,6 +6518,7 @@ impl super::stub::ProductService for ProductService {
                 let path_template = "/v2/{product}:removeLocalInventories";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_product,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.product));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6907,6 +6946,7 @@ impl super::stub::SearchService for SearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_placement = try_match(
@@ -6925,6 +6965,7 @@ impl super::stub::SearchService for SearchService {
                 let path = format!("/v2/{}:search", var_placement,);
                 let path_template = "/v2/{placement}:search";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.placement));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6946,6 +6987,7 @@ impl super::stub::SearchService for SearchService {
                 let path = format!("/v2/{}:search", var_placement,);
                 let path_template = "/v2/{placement}:search";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.placement));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -7780,6 +7822,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_serving_config = try_match(
@@ -7799,6 +7842,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
                 let path_template = "/v2/{serving_config}:addControl";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_serving_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.serving_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7856,6 +7900,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_serving_config = try_match(
@@ -7875,6 +7920,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
                 let path_template = "/v2/{serving_config}:removeControl";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_serving_config,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.serving_config));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8471,6 +8517,7 @@ impl super::stub::UserEventService for UserEventService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -8488,6 +8535,7 @@ impl super::stub::UserEventService for UserEventService {
                 let path_template = "/v2/{parent}/userEvents:purge";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8543,6 +8591,7 @@ impl super::stub::UserEventService for UserEventService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -8560,6 +8609,7 @@ impl super::stub::UserEventService for UserEventService {
                 let path_template = "/v2/{parent}/userEvents:import";
 
                 let resource_name = format!("//retail.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8615,6 +8665,7 @@ impl super::stub::UserEventService for UserEventService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -8631,6 +8682,7 @@ impl super::stub::UserEventService for UserEventService {
                 let path = format!("/v2/{}/userEvents:rejoin", var_parent,);
                 let path_template = "/v2/{parent}/userEvents:rejoin";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/run/v2/src/transport.rs
+++ b/src/generated/cloud/run/v2/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::Builds for Builds {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -70,6 +71,7 @@ impl super::stub::Builds for Builds {
                 let path = format!("/v2/{}/builds:submit", var_parent,);
                 let path_template = "/v2/{parent}/builds:submit";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -339,6 +341,7 @@ impl super::stub::Builds for Builds {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -355,6 +358,7 @@ impl super::stub::Builds for Builds {
                 let path = format!("/v2/{}:wait", var_name,);
                 let path_template = "/v2/{name}:wait";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -667,6 +671,7 @@ impl super::stub::Executions for Executions {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -686,6 +691,7 @@ impl super::stub::Executions for Executions {
                 let path_template = "/v2/{name}:cancel";
 
                 let resource_name = format!("//run.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -960,6 +966,7 @@ impl super::stub::Executions for Executions {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -976,6 +983,7 @@ impl super::stub::Executions for Executions {
                 let path = format!("/v2/{}:wait", var_name,);
                 let path_template = "/v2/{name}:wait";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1360,6 +1368,7 @@ impl super::stub::Instances for Instances {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1377,6 +1386,7 @@ impl super::stub::Instances for Instances {
                 let path_template = "/v2/{name}:stop";
 
                 let resource_name = format!("//run.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1432,6 +1442,7 @@ impl super::stub::Instances for Instances {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1449,6 +1460,7 @@ impl super::stub::Instances for Instances {
                 let path_template = "/v2/{name}:start";
 
                 let resource_name = format!("//run.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1721,6 +1733,7 @@ impl super::stub::Instances for Instances {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1737,6 +1750,7 @@ impl super::stub::Instances for Instances {
                 let path = format!("/v2/{}:wait", var_name,);
                 let path_template = "/v2/{name}:wait";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2197,6 +2211,7 @@ impl super::stub::Jobs for Jobs {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2214,6 +2229,7 @@ impl super::stub::Jobs for Jobs {
                 let path_template = "/v2/{name}:run";
 
                 let resource_name = format!("//run.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2353,6 +2369,7 @@ impl super::stub::Jobs for Jobs {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2370,6 +2387,7 @@ impl super::stub::Jobs for Jobs {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//run.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2425,6 +2443,7 @@ impl super::stub::Jobs for Jobs {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2442,6 +2461,7 @@ impl super::stub::Jobs for Jobs {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//run.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2714,6 +2734,7 @@ impl super::stub::Jobs for Jobs {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2730,6 +2751,7 @@ impl super::stub::Jobs for Jobs {
                 let path = format!("/v2/{}:wait", var_name,);
                 let path_template = "/v2/{name}:wait";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3397,6 +3419,7 @@ impl super::stub::Revisions for Revisions {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3413,6 +3436,7 @@ impl super::stub::Revisions for Revisions {
                 let path = format!("/v2/{}:wait", var_name,);
                 let path_template = "/v2/{name}:wait";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3971,6 +3995,7 @@ impl super::stub::Services for Services {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3988,6 +4013,7 @@ impl super::stub::Services for Services {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//run.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4043,6 +4069,7 @@ impl super::stub::Services for Services {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4060,6 +4087,7 @@ impl super::stub::Services for Services {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//run.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4332,6 +4360,7 @@ impl super::stub::Services for Services {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4348,6 +4377,7 @@ impl super::stub::Services for Services {
                 let path = format!("/v2/{}:wait", var_name,);
                 let path_template = "/v2/{name}:wait";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -4819,6 +4849,7 @@ impl super::stub::Tasks for Tasks {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4835,6 +4866,7 @@ impl super::stub::Tasks for Tasks {
                 let path = format!("/v2/{}:wait", var_name,);
                 let path_template = "/v2/{name}:wait";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5380,6 +5412,7 @@ impl super::stub::WorkerPools for WorkerPools {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -5397,6 +5430,7 @@ impl super::stub::WorkerPools for WorkerPools {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//run.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5452,6 +5486,7 @@ impl super::stub::WorkerPools for WorkerPools {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -5469,6 +5504,7 @@ impl super::stub::WorkerPools for WorkerPools {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//run.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5741,6 +5777,7 @@ impl super::stub::WorkerPools for WorkerPools {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5757,6 +5794,7 @@ impl super::stub::WorkerPools for WorkerPools {
                 let path = format!("/v2/{}:wait", var_name,);
                 let path_template = "/v2/{name}:wait";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/scheduler/v1/src/transport.rs
+++ b/src/generated/cloud/scheduler/v1/src/transport.rs
@@ -432,6 +432,7 @@ impl super::stub::CloudScheduler for CloudScheduler {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -449,6 +450,7 @@ impl super::stub::CloudScheduler for CloudScheduler {
                 let path_template = "/v1/{name}:pause";
 
                 let resource_name = format!("//cloudscheduler.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -504,6 +506,7 @@ impl super::stub::CloudScheduler for CloudScheduler {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -521,6 +524,7 @@ impl super::stub::CloudScheduler for CloudScheduler {
                 let path_template = "/v1/{name}:resume";
 
                 let resource_name = format!("//cloudscheduler.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -576,6 +580,7 @@ impl super::stub::CloudScheduler for CloudScheduler {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -593,6 +598,7 @@ impl super::stub::CloudScheduler for CloudScheduler {
                 let path_template = "/v1/{name}:run";
 
                 let resource_name = format!("//cloudscheduler.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/secretmanager/v1/src/transport.rs
+++ b/src/generated/cloud/secretmanager/v1/src/transport.rs
@@ -250,6 +250,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -265,6 +266,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{parent}:addVersion";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -285,6 +287,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{parent}:addVersion";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1060,6 +1063,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1077,6 +1081,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{name}:disable";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1099,6 +1104,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{name}:disable";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1175,6 +1181,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1192,6 +1199,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{name}:enable";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1214,6 +1222,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{name}:enable";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1290,6 +1299,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1307,6 +1317,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{name}:destroy";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1329,6 +1340,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{name}:destroy";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1405,6 +1417,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1420,6 +1433,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1440,6 +1454,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1643,6 +1658,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1658,6 +1674,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1678,6 +1695,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1750,6 +1768,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1765,6 +1784,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{parent}:enableManagedRotation";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1785,6 +1805,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{parent}:enableManagedRotation";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1857,6 +1878,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1872,6 +1894,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{parent}:rotateSecret";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1892,6 +1915,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 let path_template = "/v1/{parent}:rotateSecret";
 
                 let resource_name = format!("//secretmanager.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/securesourcemanager/v1/src/transport.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/transport.rs
@@ -1225,6 +1225,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1243,6 +1244,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
 
                 let resource_name =
                     format!("//securesourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1300,6 +1302,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1318,6 +1321,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
 
                 let resource_name =
                     format!("//securesourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2098,6 +2102,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2117,6 +2122,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
                 let path_template = "/v1/{name}:merge";
 
                 let resource_name = format!("//securesourcemanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2176,6 +2182,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2195,6 +2202,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
                 let path_template = "/v1/{name}:open";
 
                 let resource_name = format!("//securesourcemanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2254,6 +2262,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2273,6 +2282,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
                 let path_template = "/v1/{name}:close";
 
                 let resource_name = format!("//securesourcemanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2967,6 +2977,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2986,6 +2997,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
                 let path_template = "/v1/{name}:open";
 
                 let resource_name = format!("//securesourcemanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3045,6 +3057,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3064,6 +3077,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
                 let path_template = "/v1/{name}:close";
 
                 let resource_name = format!("//securesourcemanager.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3455,6 +3469,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -3474,6 +3489,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
                 let path_template = "/v1/{parent}/pullRequestComments:batchCreate";
 
                 let resource_name = format!("//securesourcemanager.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3531,6 +3547,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -3550,6 +3567,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
                 let path_template = "/v1/{parent}/pullRequestComments:resolve";
 
                 let resource_name = format!("//securesourcemanager.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3607,6 +3625,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -3626,6 +3645,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
                 let path_template = "/v1/{parent}/pullRequestComments:unresolve";
 
                 let resource_name = format!("//securesourcemanager.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4222,6 +4242,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4240,6 +4261,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
 
                 let resource_name =
                     format!("//securesourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4380,6 +4402,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4398,6 +4421,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
 
                 let resource_name =
                     format!("//securesourcemanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4670,6 +4694,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4686,6 +4711,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/security/privateca/v1/src/transport.rs
+++ b/src/generated/cloud/security/privateca/v1/src/transport.rs
@@ -287,6 +287,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -306,6 +307,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 let path_template = "/v1/{name}:revoke";
 
                 let resource_name = format!("//privateca.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -456,6 +458,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -475,6 +478,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 let path_template = "/v1/{name}:activate";
 
                 let resource_name = format!("//privateca.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -607,6 +611,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -626,6 +631,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 let path_template = "/v1/{name}:disable";
 
                 let resource_name = format!("//privateca.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -683,6 +689,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -702,6 +709,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 let path_template = "/v1/{name}:enable";
 
                 let resource_name = format!("//privateca.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -987,6 +995,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1006,6 +1015,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 let path_template = "/v1/{name}:undelete";
 
                 let resource_name = format!("//privateca.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1618,6 +1628,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_ca_pool = try_match(
@@ -1635,6 +1646,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 let path_template = "/v1/{ca_pool}:fetchCaCerts";
 
                 let resource_name = format!("//privateca.googleapis.com/{}", var_ca_pool,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.ca_pool));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2391,6 +2403,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
         .or_else(|| {
             let var_resource = try_match(Some(&req).map(|m| &m.resource).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/caPools/"), Segment::SingleWildcard])?;
@@ -2404,6 +2417,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 "//privateca.googleapis.com/{}",
                 var_resource,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2420,6 +2434,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 "//privateca.googleapis.com/{}",
                 var_resource,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2436,6 +2451,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 "//privateca.googleapis.com/{}",
                 var_resource,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2620,6 +2636,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
         .or_else(|| {
             let var_resource = try_match(Some(&req).map(|m| &m.resource).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/caPools/"), Segment::SingleWildcard])?;
@@ -2633,6 +2650,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 "//privateca.googleapis.com/{}",
                 var_resource,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2649,6 +2667,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 "//privateca.googleapis.com/{}",
                 var_resource,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2665,6 +2684,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 "//privateca.googleapis.com/{}",
                 var_resource,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2947,6 +2967,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2963,6 +2984,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/securitycenter/v2/src/transport.rs
+++ b/src/generated/cloud/securitycenter/v2/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -66,6 +67,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{parent}/resourceValueConfigs:batchCreate";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -84,6 +86,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{parent}/resourceValueConfigs:batchCreate";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -147,6 +150,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -157,6 +161,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{parent}/findings:bulkMute";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -175,6 +180,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{parent}/findings:bulkMute";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -188,6 +194,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{parent}/findings:bulkMute";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -206,6 +213,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{parent}/findings:bulkMute";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -219,6 +227,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{parent}/findings:bulkMute";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -237,6 +246,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{parent}/findings:bulkMute";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2048,6 +2058,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2063,6 +2074,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{resource}:getIamPolicy";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2684,6 +2696,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2699,6 +2712,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{parent}/findings:group";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2719,6 +2733,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{parent}/findings:group";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2737,6 +2752,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{parent}/findings:group";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2757,6 +2773,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{parent}/findings:group";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2775,6 +2792,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{parent}/findings:group";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2795,6 +2813,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{parent}/findings:group";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4383,6 +4402,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4400,6 +4420,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{name}:setState";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4422,6 +4443,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{name}:setState";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4442,6 +4464,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{name}:setState";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4464,6 +4487,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{name}:setState";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4484,6 +4508,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{name}:setState";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4506,6 +4531,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{name}:setState";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4652,6 +4678,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -4667,6 +4694,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4720,6 +4748,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4737,6 +4766,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{name}:setMute";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4759,6 +4789,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{name}:setMute";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4779,6 +4810,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{name}:setMute";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4801,6 +4833,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{name}:setMute";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4821,6 +4854,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{name}:setMute";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4843,6 +4877,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{name}:setMute";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4989,6 +5024,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -5004,6 +5040,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//securitycenter.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/securitycentermanagement/v1/src/transport.rs
+++ b/src/generated/cloud/securitycentermanagement/v1/src/transport.rs
@@ -1268,6 +1268,7 @@ impl super::stub::SecurityCenterManagement for SecurityCenterManagement {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1285,6 +1286,7 @@ impl super::stub::SecurityCenterManagement for SecurityCenterManagement {
                 );
                 let path_template = "/v1/{parent}/securityHealthAnalyticsCustomModules:simulate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1305,6 +1307,7 @@ impl super::stub::SecurityCenterManagement for SecurityCenterManagement {
                 );
                 let path_template = "/v1/{parent}/securityHealthAnalyticsCustomModules:simulate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1325,6 +1328,7 @@ impl super::stub::SecurityCenterManagement for SecurityCenterManagement {
                 );
                 let path_template = "/v1/{parent}/securityHealthAnalyticsCustomModules:simulate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2653,6 +2657,7 @@ impl super::stub::SecurityCenterManagement for SecurityCenterManagement {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2672,6 +2677,7 @@ impl super::stub::SecurityCenterManagement for SecurityCenterManagement {
 
                 let resource_name =
                     format!("//securitycentermanagement.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2694,6 +2700,7 @@ impl super::stub::SecurityCenterManagement for SecurityCenterManagement {
 
                 let resource_name =
                     format!("//securitycentermanagement.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2716,6 +2723,7 @@ impl super::stub::SecurityCenterManagement for SecurityCenterManagement {
 
                 let resource_name =
                     format!("//securitycentermanagement.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/securityposture/v1/src/transport.rs
+++ b/src/generated/cloud/securityposture/v1/src/transport.rs
@@ -506,6 +506,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -521,6 +522,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
                 let path_template = "/v1/{parent}/postures:extract";
 
                 let resource_name = format!("//securityposture.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1449,6 +1451,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1465,6 +1468,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/servicedirectory/v1/src/transport.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::LookupService for LookupService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -75,6 +76,7 @@ impl super::stub::LookupService for LookupService {
                 let path_template = "/v1/{name}:resolve";
 
                 let resource_name = format!("//servicedirectory.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1513,6 +1515,7 @@ impl super::stub::RegistrationService for RegistrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1530,6 +1533,7 @@ impl super::stub::RegistrationService for RegistrationService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//servicedirectory.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1552,6 +1556,7 @@ impl super::stub::RegistrationService for RegistrationService {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//servicedirectory.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1628,6 +1633,7 @@ impl super::stub::RegistrationService for RegistrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1645,6 +1651,7 @@ impl super::stub::RegistrationService for RegistrationService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//servicedirectory.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1667,6 +1674,7 @@ impl super::stub::RegistrationService for RegistrationService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//servicedirectory.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1743,6 +1751,7 @@ impl super::stub::RegistrationService for RegistrationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1760,6 +1769,7 @@ impl super::stub::RegistrationService for RegistrationService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//servicedirectory.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1782,6 +1792,7 @@ impl super::stub::RegistrationService for RegistrationService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//servicedirectory.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/shell/v1/src/transport.rs
+++ b/src/generated/cloud/shell/v1/src/transport.rs
@@ -124,6 +124,7 @@ impl super::stub::CloudShellService for CloudShellService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -138,6 +139,7 @@ impl super::stub::CloudShellService for CloudShellService {
                 let path = format!("/v1/{}:start", var_name,);
                 let path_template = "/v1/{name}:start";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -190,6 +192,7 @@ impl super::stub::CloudShellService for CloudShellService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -204,6 +207,7 @@ impl super::stub::CloudShellService for CloudShellService {
                 let path = format!("/v1/{}:authorize", var_name,);
                 let path_template = "/v1/{name}:authorize";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -256,6 +260,7 @@ impl super::stub::CloudShellService for CloudShellService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_environment = try_match(
@@ -270,6 +275,7 @@ impl super::stub::CloudShellService for CloudShellService {
                 let path = format!("/v1/{}:addPublicKey", var_environment,);
                 let path_template = "/v1/{environment}:addPublicKey";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.environment));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -322,6 +328,7 @@ impl super::stub::CloudShellService for CloudShellService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_environment = try_match(
@@ -336,6 +343,7 @@ impl super::stub::CloudShellService for CloudShellService {
                 let path = format!("/v1/{}:removePublicKey", var_environment,);
                 let path_template = "/v1/{environment}:removePublicKey";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.environment));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/speech/v2/src/transport.rs
+++ b/src/generated/cloud/speech/v2/src/transport.rs
@@ -433,6 +433,7 @@ impl super::stub::Speech for Speech {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -450,6 +451,7 @@ impl super::stub::Speech for Speech {
                 let path_template = "/v2/{name}:undelete";
 
                 let resource_name = format!("//speech.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -505,6 +507,7 @@ impl super::stub::Speech for Speech {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_recognizer = try_match(
@@ -522,6 +525,7 @@ impl super::stub::Speech for Speech {
                 let path_template = "/v2/{recognizer}:recognize";
 
                 let resource_name = format!("//speech.googleapis.com/{}", var_recognizer,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.recognizer));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -577,6 +581,7 @@ impl super::stub::Speech for Speech {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_recognizer = try_match(
@@ -594,6 +599,7 @@ impl super::stub::Speech for Speech {
                 let path_template = "/v2/{recognizer}:batchRecognize";
 
                 let resource_name = format!("//speech.googleapis.com/{}", var_recognizer,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.recognizer));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1182,6 +1188,7 @@ impl super::stub::Speech for Speech {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1199,6 +1206,7 @@ impl super::stub::Speech for Speech {
                 let path_template = "/v2/{name}:undelete";
 
                 let resource_name = format!("//speech.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1631,6 +1639,7 @@ impl super::stub::Speech for Speech {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1648,6 +1657,7 @@ impl super::stub::Speech for Speech {
                 let path_template = "/v2/{name}:undelete";
 
                 let resource_name = format!("//speech.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2045,6 +2055,7 @@ impl super::stub::Speech for Speech {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2061,6 +2072,7 @@ impl super::stub::Speech for Speech {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/sql/v1/src/transport.rs
+++ b/src/generated/cloud/sql/v1/src/transport.rs
@@ -926,6 +926,7 @@ impl super::stub::SqlConnectService for SqlConnectService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_project = try_match(
@@ -947,6 +948,8 @@ impl super::stub::SqlConnectService for SqlConnectService {
                     "//sqladmin.googleapis.com/projects/{}/instances/{}",
                     var_project, var_instance,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.instance));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4015,6 +4018,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_project = try_match(
@@ -4036,6 +4040,8 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
                     "//sqladmin.googleapis.com/projects/{}/instances/{}",
                     var_project, var_instance,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.instance));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4092,6 +4098,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_project = try_match(
@@ -4112,6 +4119,8 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
                     "//sqladmin.googleapis.com/projects/{}/instances/{}",
                     var_project, var_instance,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.instance));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4315,6 +4324,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_project = try_match(
@@ -4335,6 +4345,8 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
                     "//sqladmin.googleapis.com/projects/{}/instances/{}",
                     var_project, var_instance,
                 );
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.instance));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/storagebatchoperations/v1/src/transport.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/transport.rs
@@ -362,6 +362,7 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -380,6 +381,7 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
 
                 let resource_name =
                     format!("//storagebatchoperations.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -933,6 +935,7 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -949,6 +952,7 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/storageinsights/v1/src/transport.rs
+++ b/src/generated/cloud/storageinsights/v1/src/transport.rs
@@ -990,6 +990,7 @@ impl super::stub::StorageInsights for StorageInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1007,6 +1008,7 @@ impl super::stub::StorageInsights for StorageInsights {
                 let path_template = "/v1/{name}:linkDataset";
 
                 let resource_name = format!("//storageinsights.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1062,6 +1064,7 @@ impl super::stub::StorageInsights for StorageInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1079,6 +1082,7 @@ impl super::stub::StorageInsights for StorageInsights {
                 let path_template = "/v1/{name}:unlinkDataset";
 
                 let resource_name = format!("//storageinsights.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1476,6 +1480,7 @@ impl super::stub::StorageInsights for StorageInsights {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1492,6 +1497,7 @@ impl super::stub::StorageInsights for StorageInsights {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/support/v2/src/transport.rs
+++ b/src/generated/cloud/support/v2/src/transport.rs
@@ -751,6 +751,7 @@ impl super::stub::CaseService for CaseService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -766,6 +767,7 @@ impl super::stub::CaseService for CaseService {
                 let path_template = "/v2/{name}:escalate";
 
                 let resource_name = format!("//cloudsupport.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -784,6 +786,7 @@ impl super::stub::CaseService for CaseService {
                 let path_template = "/v2/{name}:escalate";
 
                 let resource_name = format!("//cloudsupport.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -852,6 +855,7 @@ impl super::stub::CaseService for CaseService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -867,6 +871,7 @@ impl super::stub::CaseService for CaseService {
                 let path_template = "/v2/{name}:close";
 
                 let resource_name = format!("//cloudsupport.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -885,6 +890,7 @@ impl super::stub::CaseService for CaseService {
                 let path_template = "/v2/{name}:close";
 
                 let resource_name = format!("//cloudsupport.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1678,6 +1684,7 @@ impl super::stub::SupportEventSubscriptionService for SupportEventSubscriptionSe
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1693,6 +1700,7 @@ impl super::stub::SupportEventSubscriptionService for SupportEventSubscriptionSe
                 let path_template = "/v2/{name}:undelete";
 
                 let resource_name = format!("//cloudsupport.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1746,6 +1754,7 @@ impl super::stub::SupportEventSubscriptionService for SupportEventSubscriptionSe
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1761,6 +1770,7 @@ impl super::stub::SupportEventSubscriptionService for SupportEventSubscriptionSe
                 let path_template = "/v2/{name}:expunge";
 
                 let resource_name = format!("//cloudsupport.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/talent/v4/src/transport.rs
+++ b/src/generated/cloud/talent/v4/src/transport.rs
@@ -931,6 +931,7 @@ impl super::stub::JobService for JobService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -946,6 +947,7 @@ impl super::stub::JobService for JobService {
                 let path_template = "/v4/{parent}/jobs:batchCreate";
 
                 let resource_name = format!("//jobs.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1159,6 +1161,7 @@ impl super::stub::JobService for JobService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1174,6 +1177,7 @@ impl super::stub::JobService for JobService {
                 let path_template = "/v4/{parent}/jobs:batchUpdate";
 
                 let resource_name = format!("//jobs.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1305,6 +1309,7 @@ impl super::stub::JobService for JobService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1320,6 +1325,7 @@ impl super::stub::JobService for JobService {
                 let path_template = "/v4/{parent}/jobs:batchDelete";
 
                 let resource_name = format!("//jobs.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1445,6 +1451,7 @@ impl super::stub::JobService for JobService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1460,6 +1467,7 @@ impl super::stub::JobService for JobService {
                 let path_template = "/v4/{parent}/jobs:search";
 
                 let resource_name = format!("//jobs.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1513,6 +1521,7 @@ impl super::stub::JobService for JobService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1528,6 +1537,7 @@ impl super::stub::JobService for JobService {
                 let path_template = "/v4/{parent}/jobs:searchForAlert";
 
                 let resource_name = format!("//jobs.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/tasks/v2/src/transport.rs
+++ b/src/generated/cloud/tasks/v2/src/transport.rs
@@ -433,6 +433,7 @@ impl super::stub::CloudTasks for CloudTasks {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -450,6 +451,7 @@ impl super::stub::CloudTasks for CloudTasks {
                 let path_template = "/v2/{name}:purge";
 
                 let resource_name = format!("//cloudtasks.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -505,6 +507,7 @@ impl super::stub::CloudTasks for CloudTasks {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -522,6 +525,7 @@ impl super::stub::CloudTasks for CloudTasks {
                 let path_template = "/v2/{name}:pause";
 
                 let resource_name = format!("//cloudtasks.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -577,6 +581,7 @@ impl super::stub::CloudTasks for CloudTasks {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -594,6 +599,7 @@ impl super::stub::CloudTasks for CloudTasks {
                 let path_template = "/v2/{name}:resume";
 
                 let resource_name = format!("//cloudtasks.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -649,6 +655,7 @@ impl super::stub::CloudTasks for CloudTasks {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -666,6 +673,7 @@ impl super::stub::CloudTasks for CloudTasks {
                 let path_template = "/v2/{resource}:getIamPolicy";
 
                 let resource_name = format!("//cloudtasks.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -721,6 +729,7 @@ impl super::stub::CloudTasks for CloudTasks {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -738,6 +747,7 @@ impl super::stub::CloudTasks for CloudTasks {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudtasks.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -793,6 +803,7 @@ impl super::stub::CloudTasks for CloudTasks {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -810,6 +821,7 @@ impl super::stub::CloudTasks for CloudTasks {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudtasks.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1017,6 +1029,7 @@ impl super::stub::CloudTasks for CloudTasks {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1034,6 +1047,7 @@ impl super::stub::CloudTasks for CloudTasks {
                 let path_template = "/v2/{parent}/tasks";
 
                 let resource_name = format!("//cloudtasks.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1171,6 +1185,7 @@ impl super::stub::CloudTasks for CloudTasks {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1190,6 +1205,7 @@ impl super::stub::CloudTasks for CloudTasks {
                 let path_template = "/v2/{name}:run";
 
                 let resource_name = format!("//cloudtasks.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/telcoautomation/v1/src/transport.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/transport.rs
@@ -1042,6 +1042,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1061,6 +1062,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 let path_template = "/v1/{name}:approve";
 
                 let resource_name = format!("//telcoautomation.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1120,6 +1122,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1139,6 +1142,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 let path_template = "/v1/{name}:propose";
 
                 let resource_name = format!("//telcoautomation.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1198,6 +1202,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1217,6 +1222,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 let path_template = "/v1/{name}:reject";
 
                 let resource_name = format!("//telcoautomation.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1510,6 +1516,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1529,6 +1536,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 let path_template = "/v1/{name}:discard";
 
                 let resource_name = format!("//telcoautomation.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1980,6 +1988,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1999,6 +2008,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 let path_template = "/v1/{name}:remove";
 
                 let resource_name = format!("//telcoautomation.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2221,6 +2231,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2240,6 +2251,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 let path_template = "/v1/{name}:discard";
 
                 let resource_name = format!("//telcoautomation.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2299,6 +2311,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2318,6 +2331,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 let path_template = "/v1/{name}:apply";
 
                 let resource_name = format!("//telcoautomation.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2455,6 +2469,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2474,6 +2489,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 let path_template = "/v1/{name}:rollback";
 
                 let resource_name = format!("//telcoautomation.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2735,6 +2751,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
         .or_else(|| {
             let var_name = try_match(Some(&req).map(|m| &m.name).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/orchestrationClusters/"), Segment::SingleWildcard, Segment::Literal("/deployments/"), Segment::SingleWildcard, Segment::Literal("/hydratedDeployments/"), Segment::SingleWildcard])?;
@@ -2748,6 +2765,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 "//telcoautomation.googleapis.com/{}",
                 var_name,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3149,6 +3167,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3165,6 +3184,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/texttospeech/v1/src/transport.rs
+++ b/src/generated/cloud/texttospeech/v1/src/transport.rs
@@ -315,6 +315,7 @@ impl super::stub::TextToSpeechLongAudioSynthesize for TextToSpeechLongAudioSynth
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -329,6 +330,7 @@ impl super::stub::TextToSpeechLongAudioSynthesize for TextToSpeechLongAudioSynth
                 let path = format!("/v1/{}:synthesizeLongAudio", var_parent,);
                 let path_template = "/v1/{parent}:synthesizeLongAudio";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/timeseriesinsights/v1/src/transport.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/transport.rs
@@ -353,6 +353,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_dataset = try_match(
@@ -370,6 +371,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
                 let path_template = "/v1/{dataset}:appendEvents";
 
                 let resource_name = format!("//timeseriesinsights.googleapis.com/{}", var_dataset,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.dataset));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -388,6 +390,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
                 let path_template = "/v1/{dataset}:appendEvents";
 
                 let resource_name = format!("//timeseriesinsights.googleapis.com/{}", var_dataset,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.dataset));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -458,6 +461,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -475,6 +479,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
                 let path_template = "/v1/{name}:query";
 
                 let resource_name = format!("//timeseriesinsights.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -493,6 +498,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
                 let path_template = "/v1/{name}:query";
 
                 let resource_name = format!("//timeseriesinsights.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -563,6 +569,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_dataset = try_match(
@@ -580,6 +587,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
                 let path_template = "/v1/{dataset}:evaluateSlice";
 
                 let resource_name = format!("//timeseriesinsights.googleapis.com/{}", var_dataset,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.dataset));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -598,6 +606,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
                 let path_template = "/v1/{dataset}:evaluateSlice";
 
                 let resource_name = format!("//timeseriesinsights.googleapis.com/{}", var_dataset,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.dataset));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -668,6 +677,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -683,6 +693,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
                 let path_template = "/v1/{parent}/datasets:evaluateTimeseries";
 
                 let resource_name = format!("//timeseriesinsights.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -696,6 +707,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
                 let path_template = "/v1/{parent}/datasets:evaluateTimeseries";
 
                 let resource_name = format!("//timeseriesinsights.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/tpu/v2/src/transport.rs
+++ b/src/generated/cloud/tpu/v2/src/transport.rs
@@ -337,6 +337,7 @@ impl super::stub::Tpu for Tpu {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -354,6 +355,7 @@ impl super::stub::Tpu for Tpu {
                 let path_template = "/v2/{name}:stop";
 
                 let resource_name = format!("//tpu.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -409,6 +411,7 @@ impl super::stub::Tpu for Tpu {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -426,6 +429,7 @@ impl super::stub::Tpu for Tpu {
                 let path_template = "/v2/{name}:start";
 
                 let resource_name = format!("//tpu.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -855,6 +859,7 @@ impl super::stub::Tpu for Tpu {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -872,6 +877,7 @@ impl super::stub::Tpu for Tpu {
                 let path_template = "/v2/{name}:reset";
 
                 let resource_name = format!("//tpu.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -927,6 +933,7 @@ impl super::stub::Tpu for Tpu {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -942,6 +949,7 @@ impl super::stub::Tpu for Tpu {
                 let path_template = "/v2/{parent}:generateServiceIdentity";
 
                 let resource_name = format!("//tpu.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1283,6 +1291,7 @@ impl super::stub::Tpu for Tpu {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1300,6 +1309,7 @@ impl super::stub::Tpu for Tpu {
                 let path_template = "/v2/{name}:getGuestAttributes";
 
                 let resource_name = format!("//tpu.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/translate/v3/src/transport.rs
+++ b/src/generated/cloud/translate/v3/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::TranslationService for TranslationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -71,6 +72,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path_template = "/v3/{parent}:translateText";
 
                 let resource_name = format!("//translate.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -84,6 +86,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path_template = "/v3/{parent}:translateText";
 
                 let resource_name = format!("//translate.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -147,6 +150,7 @@ impl super::stub::TranslationService for TranslationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -162,6 +166,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path_template = "/v3/{parent}:romanizeText";
 
                 let resource_name = format!("//translate.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -175,6 +180,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path_template = "/v3/{parent}:romanizeText";
 
                 let resource_name = format!("//translate.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -238,6 +244,7 @@ impl super::stub::TranslationService for TranslationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -253,6 +260,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path_template = "/v3/{parent}:detectLanguage";
 
                 let resource_name = format!("//translate.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -266,6 +274,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path_template = "/v3/{parent}:detectLanguage";
 
                 let resource_name = format!("//translate.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -426,6 +435,7 @@ impl super::stub::TranslationService for TranslationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -440,6 +450,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path = format!("/v3/{}:translateDocument", var_parent,);
                 let path_template = "/v3/{parent}:translateDocument";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -494,6 +505,7 @@ impl super::stub::TranslationService for TranslationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -509,6 +521,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path_template = "/v3/{parent}:batchTranslateText";
 
                 let resource_name = format!("//translate.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -564,6 +577,7 @@ impl super::stub::TranslationService for TranslationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -579,6 +593,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path_template = "/v3/{parent}:batchTranslateDocument";
 
                 let resource_name = format!("//translate.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1978,6 +1993,7 @@ impl super::stub::TranslationService for TranslationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1993,6 +2009,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path_template = "/v3/{parent}:adaptiveMtTranslate";
 
                 let resource_name = format!("//translate.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2210,6 +2227,7 @@ impl super::stub::TranslationService for TranslationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2227,6 +2245,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path_template = "/v3/{parent}:importAdaptiveMtFile";
 
                 let resource_name = format!("//translate.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2479,6 +2498,7 @@ impl super::stub::TranslationService for TranslationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_dataset = try_match(
@@ -2495,6 +2515,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path = format!("/v3/{}:importData", var_dataset,);
                 let path_template = "/v3/{dataset}:importData";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.dataset));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2549,6 +2570,7 @@ impl super::stub::TranslationService for TranslationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_dataset = try_match(
@@ -2565,6 +2587,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path = format!("/v3/{}:exportData", var_dataset,);
                 let path_template = "/v3/{dataset}:exportData";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.dataset));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3319,6 +3342,7 @@ impl super::stub::TranslationService for TranslationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3335,6 +3359,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path = format!("/v3/{}:cancel", var_name,);
                 let path_template = "/v3/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3395,6 +3420,7 @@ impl super::stub::TranslationService for TranslationService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3411,6 +3437,7 @@ impl super::stub::TranslationService for TranslationService {
                 let path = format!("/v3/{}:wait", var_name,);
                 let path_template = "/v3/{name}:wait";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/vectorsearch/v1/src/transport.rs
+++ b/src/generated/cloud/vectorsearch/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::DataObjectSearchService for DataObjectSearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -73,6 +74,7 @@ impl super::stub::DataObjectSearchService for DataObjectSearchService {
                 let path_template = "/v1/{parent}/dataObjects:search";
 
                 let resource_name = format!("//vectorsearch.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -130,6 +132,7 @@ impl super::stub::DataObjectSearchService for DataObjectSearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -147,6 +150,7 @@ impl super::stub::DataObjectSearchService for DataObjectSearchService {
                 let path_template = "/v1/{parent}/dataObjects:query";
 
                 let resource_name = format!("//vectorsearch.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -204,6 +208,7 @@ impl super::stub::DataObjectSearchService for DataObjectSearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -221,6 +226,7 @@ impl super::stub::DataObjectSearchService for DataObjectSearchService {
                 let path_template = "/v1/{parent}/dataObjects:aggregate";
 
                 let resource_name = format!("//vectorsearch.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -278,6 +284,7 @@ impl super::stub::DataObjectSearchService for DataObjectSearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -295,6 +302,7 @@ impl super::stub::DataObjectSearchService for DataObjectSearchService {
                 let path_template = "/v1/{parent}/dataObjects:batchSearch";
 
                 let resource_name = format!("//vectorsearch.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -692,6 +700,7 @@ impl super::stub::DataObjectSearchService for DataObjectSearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -708,6 +717,7 @@ impl super::stub::DataObjectSearchService for DataObjectSearchService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -872,6 +882,7 @@ impl super::stub::DataObjectService for DataObjectService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -889,6 +900,7 @@ impl super::stub::DataObjectService for DataObjectService {
                 let path_template = "/v1/{parent}/dataObjects:batchCreate";
 
                 let resource_name = format!("//vectorsearch.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1116,6 +1128,7 @@ impl super::stub::DataObjectService for DataObjectService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1133,6 +1146,7 @@ impl super::stub::DataObjectService for DataObjectService {
                 let path_template = "/v1/{parent}/dataObjects:batchUpdate";
 
                 let resource_name = format!("//vectorsearch.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1275,6 +1289,7 @@ impl super::stub::DataObjectService for DataObjectService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1292,6 +1307,7 @@ impl super::stub::DataObjectService for DataObjectService {
                 let path_template = "/v1/{parent}/dataObjects:batchDelete";
 
                 let resource_name = format!("//vectorsearch.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1697,6 +1713,7 @@ impl super::stub::DataObjectService for DataObjectService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1713,6 +1730,7 @@ impl super::stub::DataObjectService for DataObjectService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2585,6 +2603,7 @@ impl super::stub::VectorSearchService for VectorSearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2602,6 +2621,7 @@ impl super::stub::VectorSearchService for VectorSearchService {
                 let path_template = "/v1/{name}:importDataObjects";
 
                 let resource_name = format!("//vectorsearch.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2659,6 +2679,7 @@ impl super::stub::VectorSearchService for VectorSearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2676,6 +2697,7 @@ impl super::stub::VectorSearchService for VectorSearchService {
                 let path_template = "/v1/{name}:exportDataObjects";
 
                 let resource_name = format!("//vectorsearch.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3075,6 +3097,7 @@ impl super::stub::VectorSearchService for VectorSearchService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3091,6 +3114,7 @@ impl super::stub::VectorSearchService for VectorSearchService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/video/livestream/v1/src/transport.rs
+++ b/src/generated/cloud/video/livestream/v1/src/transport.rs
@@ -441,6 +441,7 @@ impl super::stub::LivestreamService for LivestreamService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -458,6 +459,7 @@ impl super::stub::LivestreamService for LivestreamService {
                 let path_template = "/v1/{name}:start";
 
                 let resource_name = format!("//livestream.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -515,6 +517,7 @@ impl super::stub::LivestreamService for LivestreamService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -532,6 +535,7 @@ impl super::stub::LivestreamService for LivestreamService {
                 let path_template = "/v1/{name}:stop";
 
                 let resource_name = format!("//livestream.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -589,6 +593,7 @@ impl super::stub::LivestreamService for LivestreamService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -606,6 +611,7 @@ impl super::stub::LivestreamService for LivestreamService {
                 let path_template = "/v1/{name}:startdistribution";
 
                 let resource_name = format!("//livestream.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -663,6 +669,7 @@ impl super::stub::LivestreamService for LivestreamService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -680,6 +687,7 @@ impl super::stub::LivestreamService for LivestreamService {
                 let path_template = "/v1/{name}:stopdistribution";
 
                 let resource_name = format!("//livestream.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1119,6 +1127,7 @@ impl super::stub::LivestreamService for LivestreamService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1136,6 +1145,7 @@ impl super::stub::LivestreamService for LivestreamService {
                 let path_template = "/v1/{name}:preview";
 
                 let resource_name = format!("//livestream.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3009,6 +3019,7 @@ impl super::stub::LivestreamService for LivestreamService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3025,6 +3036,7 @@ impl super::stub::LivestreamService for LivestreamService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/video/stitcher/v1/src/transport.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/transport.rs
@@ -2554,6 +2554,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2570,6 +2571,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/videointelligence/v1/src/transport.rs
+++ b/src/generated/cloud/videointelligence/v1/src/transport.rs
@@ -391,6 +391,7 @@ impl super::stub::VideoIntelligenceService for VideoIntelligenceService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -407,6 +408,7 @@ impl super::stub::VideoIntelligenceService for VideoIntelligenceService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -426,6 +428,7 @@ impl super::stub::VideoIntelligenceService for VideoIntelligenceService {
                 let path = format!("/v1/operations/{}:cancel", var_name,);
                 let path_template = "/v1/operations/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/vision/v1/src/transport.rs
+++ b/src/generated/cloud/vision/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let path = "/v1/images:annotate".to_string();
@@ -78,6 +79,7 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
                 let path = format!("/v1/{}/images:annotate", var_parent,);
                 let path_template = "/v1/{parent}/images:annotate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -90,6 +92,7 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
                 let path = format!("/v1/{}/images:annotate", var_parent,);
                 let path_template = "/v1/{parent}/images:annotate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -156,6 +159,7 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let path = "/v1/files:annotate".to_string();
@@ -178,6 +182,7 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
                 let path = format!("/v1/{}/files:annotate", var_parent,);
                 let path_template = "/v1/{parent}/files:annotate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -190,6 +195,7 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
                 let path = format!("/v1/{}/files:annotate", var_parent,);
                 let path_template = "/v1/{parent}/files:annotate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -256,6 +262,7 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let path = "/v1/images:asyncBatchAnnotate".to_string();
@@ -278,6 +285,7 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
                 let path = format!("/v1/{}/images:asyncBatchAnnotate", var_parent,);
                 let path_template = "/v1/{parent}/images:asyncBatchAnnotate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -290,6 +298,7 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
                 let path = format!("/v1/{}/images:asyncBatchAnnotate", var_parent,);
                 let path_template = "/v1/{parent}/images:asyncBatchAnnotate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -358,6 +367,7 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let path = "/v1/files:asyncBatchAnnotate".to_string();
@@ -380,6 +390,7 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
                 let path = format!("/v1/{}/files:asyncBatchAnnotate", var_parent,);
                 let path_template = "/v1/{parent}/files:asyncBatchAnnotate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -392,6 +403,7 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
                 let path = format!("/v1/{}/files:asyncBatchAnnotate", var_parent,);
                 let path_template = "/v1/{parent}/files:asyncBatchAnnotate";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1716,6 +1728,7 @@ impl super::stub::ProductSearch for ProductSearch {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1733,6 +1746,7 @@ impl super::stub::ProductSearch for ProductSearch {
                 let path_template = "/v1/{name}:addProduct";
 
                 let resource_name = format!("//vision.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1794,6 +1808,7 @@ impl super::stub::ProductSearch for ProductSearch {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1811,6 +1826,7 @@ impl super::stub::ProductSearch for ProductSearch {
                 let path_template = "/v1/{name}:removeProduct";
 
                 let resource_name = format!("//vision.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1948,6 +1964,7 @@ impl super::stub::ProductSearch for ProductSearch {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1963,6 +1980,7 @@ impl super::stub::ProductSearch for ProductSearch {
                 let path_template = "/v1/{parent}/productSets:import";
 
                 let resource_name = format!("//vision.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2016,6 +2034,7 @@ impl super::stub::ProductSearch for ProductSearch {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2031,6 +2050,7 @@ impl super::stub::ProductSearch for ProductSearch {
                 let path_template = "/v1/{parent}/products:purge";
 
                 let resource_name = format!("//vision.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/visionai/v1/src/transport.rs
+++ b/src/generated/cloud/visionai/v1/src/transport.rs
@@ -762,6 +762,7 @@ impl super::stub::HealthCheckService for HealthCheckService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -778,6 +779,7 @@ impl super::stub::HealthCheckService for HealthCheckService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -941,6 +943,7 @@ impl super::stub::LiveVideoAnalytics for LiveVideoAnalytics {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -956,6 +959,7 @@ impl super::stub::LiveVideoAnalytics for LiveVideoAnalytics {
                 let path_template = "/v1/{parent}:resolveOperatorInfo";
 
                 let resource_name = format!("//visionai.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2179,6 +2183,7 @@ impl super::stub::LiveVideoAnalytics for LiveVideoAnalytics {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2196,6 +2201,7 @@ impl super::stub::LiveVideoAnalytics for LiveVideoAnalytics {
                 let path_template = "/v1/{parent}/processes:batchRun";
 
                 let resource_name = format!("//visionai.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2885,6 +2891,7 @@ impl super::stub::LiveVideoAnalytics for LiveVideoAnalytics {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2901,6 +2908,7 @@ impl super::stub::LiveVideoAnalytics for LiveVideoAnalytics {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3381,6 +3389,7 @@ impl super::stub::AppPlatform for AppPlatform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3398,6 +3407,7 @@ impl super::stub::AppPlatform for AppPlatform {
                 let path_template = "/v1/{name}:deploy";
 
                 let resource_name = format!("//visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3453,6 +3463,7 @@ impl super::stub::AppPlatform for AppPlatform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3470,6 +3481,7 @@ impl super::stub::AppPlatform for AppPlatform {
                 let path_template = "/v1/{name}:undeploy";
 
                 let resource_name = format!("//visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3525,6 +3537,7 @@ impl super::stub::AppPlatform for AppPlatform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3542,6 +3555,7 @@ impl super::stub::AppPlatform for AppPlatform {
                 let path_template = "/v1/{name}:addStreamInput";
 
                 let resource_name = format!("//visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3599,6 +3613,7 @@ impl super::stub::AppPlatform for AppPlatform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3616,6 +3631,7 @@ impl super::stub::AppPlatform for AppPlatform {
                 let path_template = "/v1/{name}:removeStreamInput";
 
                 let resource_name = format!("//visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3673,6 +3689,7 @@ impl super::stub::AppPlatform for AppPlatform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3690,6 +3707,7 @@ impl super::stub::AppPlatform for AppPlatform {
                 let path_template = "/v1/{name}:updateStreamInput";
 
                 let resource_name = format!("//visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3899,6 +3917,7 @@ impl super::stub::AppPlatform for AppPlatform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3916,6 +3935,7 @@ impl super::stub::AppPlatform for AppPlatform {
                 let path_template = "/v1/{name}:createApplicationInstances";
 
                 let resource_name = format!("//visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3973,6 +3993,7 @@ impl super::stub::AppPlatform for AppPlatform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3990,6 +4011,7 @@ impl super::stub::AppPlatform for AppPlatform {
                 let path_template = "/v1/{name}:deleteApplicationInstances";
 
                 let resource_name = format!("//visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4047,6 +4069,7 @@ impl super::stub::AppPlatform for AppPlatform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4064,6 +4087,7 @@ impl super::stub::AppPlatform for AppPlatform {
                 let path_template = "/v1/{name}:updateApplicationInstances";
 
                 let resource_name = format!("//visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4590,6 +4614,7 @@ impl super::stub::AppPlatform for AppPlatform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -4605,6 +4630,7 @@ impl super::stub::AppPlatform for AppPlatform {
                 let path_template = "/v1/{parent}/processors:prebuilt";
 
                 let resource_name = format!("//visionai.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5596,6 +5622,7 @@ impl super::stub::AppPlatform for AppPlatform {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5612,6 +5639,7 @@ impl super::stub::AppPlatform for AppPlatform {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5715,6 +5743,7 @@ impl super::stub::StreamingService for StreamingService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_series = try_match(
@@ -5733,6 +5762,7 @@ impl super::stub::StreamingService for StreamingService {
                 let path = format!("/v1/{}:acquireLease", var_series,);
                 let path_template = "/v1/{series}:acquireLease";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.series));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5789,6 +5819,7 @@ impl super::stub::StreamingService for StreamingService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_series = try_match(
@@ -5807,6 +5838,7 @@ impl super::stub::StreamingService for StreamingService {
                 let path = format!("/v1/{}:renewLease", var_series,);
                 let path_template = "/v1/{series}:renewLease";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.series));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -5863,6 +5895,7 @@ impl super::stub::StreamingService for StreamingService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_series = try_match(
@@ -5881,6 +5914,7 @@ impl super::stub::StreamingService for StreamingService {
                 let path = format!("/v1/{}:releaseLease", var_series,);
                 let path_template = "/v1/{series}:releaseLease";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.series));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -6571,6 +6605,7 @@ impl super::stub::StreamingService for StreamingService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6587,6 +6622,7 @@ impl super::stub::StreamingService for StreamingService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -7448,6 +7484,7 @@ impl super::stub::StreamsService for StreamsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_stream = try_match(
@@ -7466,6 +7503,7 @@ impl super::stub::StreamsService for StreamsService {
                 let path = format!("/v1/{}:getThumbnail", var_stream,);
                 let path_template = "/v1/{stream}:getThumbnail";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.stream));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -7522,6 +7560,7 @@ impl super::stub::StreamsService for StreamsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_stream = try_match(
@@ -7540,6 +7579,7 @@ impl super::stub::StreamsService for StreamsService {
                 let path = format!("/v1/{}:generateStreamHlsToken", var_stream,);
                 let path_template = "/v1/{stream}:generateStreamHlsToken";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.stream));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -9098,6 +9138,7 @@ impl super::stub::StreamsService for StreamsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -9114,6 +9155,7 @@ impl super::stub::StreamsService for StreamsService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -9612,6 +9654,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -9631,6 +9674,7 @@ impl super::stub::Warehouse for Warehouse {
                 let path_template = "/v1/{name}:upload";
 
                 let resource_name = format!("//warehouse-visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9688,6 +9732,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -9707,6 +9752,7 @@ impl super::stub::Warehouse for Warehouse {
                 let path_template = "/v1/{name}:generateRetrievalUrl";
 
                 let resource_name = format!("//warehouse-visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9764,6 +9810,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -9783,6 +9830,7 @@ impl super::stub::Warehouse for Warehouse {
                 let path_template = "/v1/{name}:analyze";
 
                 let resource_name = format!("//warehouse-visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9840,6 +9888,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -9859,6 +9908,7 @@ impl super::stub::Warehouse for Warehouse {
                 let path_template = "/v1/{name}:index";
 
                 let resource_name = format!("//warehouse-visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -9916,6 +9966,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -9935,6 +9986,7 @@ impl super::stub::Warehouse for Warehouse {
                 let path_template = "/v1/{name}:removeIndex";
 
                 let resource_name = format!("//warehouse-visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -10835,6 +10887,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -10852,6 +10905,7 @@ impl super::stub::Warehouse for Warehouse {
                 let path_template = "/v1/{name}:analyze";
 
                 let resource_name = format!("//warehouse-visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11724,6 +11778,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -11743,6 +11798,7 @@ impl super::stub::Warehouse for Warehouse {
                 let path_template = "/v1/{name}:clip";
 
                 let resource_name = format!("//warehouse-visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11800,6 +11856,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -11819,6 +11876,7 @@ impl super::stub::Warehouse for Warehouse {
                 let path_template = "/v1/{name}:generateHlsUri";
 
                 let resource_name = format!("//warehouse-visionai.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -11876,6 +11934,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -11893,6 +11952,7 @@ impl super::stub::Warehouse for Warehouse {
                 let path_template = "/v1/{parent}/assets:import";
 
                 let resource_name = format!("//warehouse-visionai.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -12744,6 +12804,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_corpus = try_match(
@@ -12761,6 +12822,7 @@ impl super::stub::Warehouse for Warehouse {
                 let path_template = "/v1/{corpus}:searchAssets";
 
                 let resource_name = format!("//warehouse-visionai.googleapis.com/{}", var_corpus,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.corpus));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -12816,6 +12878,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_index_endpoint = try_match(
@@ -12834,6 +12897,7 @@ impl super::stub::Warehouse for Warehouse {
 
                 let resource_name =
                     format!("//warehouse-visionai.googleapis.com/{}", var_index_endpoint,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.index_endpoint));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13261,6 +13325,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_index_endpoint = try_match(
@@ -13279,6 +13344,7 @@ impl super::stub::Warehouse for Warehouse {
 
                 let resource_name =
                     format!("//warehouse-visionai.googleapis.com/{}", var_index_endpoint,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.index_endpoint));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13334,6 +13400,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_index_endpoint = try_match(
@@ -13352,6 +13419,7 @@ impl super::stub::Warehouse for Warehouse {
 
                 let resource_name =
                     format!("//warehouse-visionai.googleapis.com/{}", var_index_endpoint,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.index_endpoint));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13801,6 +13869,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_item_collection = try_match(
@@ -13826,6 +13895,9 @@ impl super::stub::Warehouse for Warehouse {
                     "//warehouse-visionai.googleapis.com/{}",
                     var_item_collection,
                 );
+                let _ = Some(&mut req)
+                    .and_then(|m| m.item.as_mut())
+                    .map(|m| std::mem::take(&mut m.collection));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -13886,6 +13958,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_item_collection = try_match(
@@ -13911,6 +13984,9 @@ impl super::stub::Warehouse for Warehouse {
                     "//warehouse-visionai.googleapis.com/{}",
                     var_item_collection,
                 );
+                let _ = Some(&mut req)
+                    .and_then(|m| m.item.as_mut())
+                    .map(|m| std::mem::take(&mut m.collection));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -14684,6 +14760,7 @@ impl super::stub::Warehouse for Warehouse {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -14700,6 +14777,7 @@ impl super::stub::Warehouse for Warehouse {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/vmmigration/v1/src/transport.rs
+++ b/src/generated/cloud/vmmigration/v1/src/transport.rs
@@ -1204,6 +1204,7 @@ impl super::stub::VmMigration for VmMigration {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_datacenter_connector = try_match(
@@ -1226,6 +1227,7 @@ impl super::stub::VmMigration for VmMigration {
 
                 let resource_name =
                     format!("//vmmigration.googleapis.com/{}", var_datacenter_connector,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.datacenter_connector));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1682,6 +1684,7 @@ impl super::stub::VmMigration for VmMigration {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_migrating_vm = try_match(
@@ -1701,6 +1704,7 @@ impl super::stub::VmMigration for VmMigration {
                 let path_template = "/v1/{migrating_vm}:startMigration";
 
                 let resource_name = format!("//vmmigration.googleapis.com/{}", var_migrating_vm,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.migrating_vm));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1758,6 +1762,7 @@ impl super::stub::VmMigration for VmMigration {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_migrating_vm = try_match(
@@ -1777,6 +1782,7 @@ impl super::stub::VmMigration for VmMigration {
                 let path_template = "/v1/{migrating_vm}:resumeMigration";
 
                 let resource_name = format!("//vmmigration.googleapis.com/{}", var_migrating_vm,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.migrating_vm));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1834,6 +1840,7 @@ impl super::stub::VmMigration for VmMigration {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_migrating_vm = try_match(
@@ -1853,6 +1860,7 @@ impl super::stub::VmMigration for VmMigration {
                 let path_template = "/v1/{migrating_vm}:pauseMigration";
 
                 let resource_name = format!("//vmmigration.googleapis.com/{}", var_migrating_vm,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.migrating_vm));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1910,6 +1918,7 @@ impl super::stub::VmMigration for VmMigration {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_migrating_vm = try_match(
@@ -1929,6 +1938,7 @@ impl super::stub::VmMigration for VmMigration {
                 let path_template = "/v1/{migrating_vm}:finalizeMigration";
 
                 let resource_name = format!("//vmmigration.googleapis.com/{}", var_migrating_vm,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.migrating_vm));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1986,6 +1996,7 @@ impl super::stub::VmMigration for VmMigration {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_migrating_vm = try_match(
@@ -2005,6 +2016,7 @@ impl super::stub::VmMigration for VmMigration {
                 let path_template = "/v1/{migrating_vm}:extendMigration";
 
                 let resource_name = format!("//vmmigration.googleapis.com/{}", var_migrating_vm,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.migrating_vm));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2140,6 +2152,7 @@ impl super::stub::VmMigration for VmMigration {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2161,6 +2174,7 @@ impl super::stub::VmMigration for VmMigration {
                 let path_template = "/v1/{name}:cancel";
 
                 let resource_name = format!("//vmmigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2458,6 +2472,7 @@ impl super::stub::VmMigration for VmMigration {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2479,6 +2494,7 @@ impl super::stub::VmMigration for VmMigration {
                 let path_template = "/v1/{name}:cancel";
 
                 let resource_name = format!("//vmmigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3074,6 +3090,7 @@ impl super::stub::VmMigration for VmMigration {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_group = try_match(
@@ -3091,6 +3108,7 @@ impl super::stub::VmMigration for VmMigration {
                 let path_template = "/v1/{group}:addGroupMigration";
 
                 let resource_name = format!("//vmmigration.googleapis.com/{}", var_group,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.group));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3146,6 +3164,7 @@ impl super::stub::VmMigration for VmMigration {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_group = try_match(
@@ -3163,6 +3182,7 @@ impl super::stub::VmMigration for VmMigration {
                 let path_template = "/v1/{group}:removeGroupMigration";
 
                 let resource_name = format!("//vmmigration.googleapis.com/{}", var_group,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.group));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4193,6 +4213,7 @@ impl super::stub::VmMigration for VmMigration {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4212,6 +4233,7 @@ impl super::stub::VmMigration for VmMigration {
                 let path_template = "/v1/{name}:cancel";
 
                 let resource_name = format!("//vmmigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4670,6 +4692,7 @@ impl super::stub::VmMigration for VmMigration {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4689,6 +4712,7 @@ impl super::stub::VmMigration for VmMigration {
                 let path_template = "/v1/{name}:run";
 
                 let resource_name = format!("//vmmigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4746,6 +4770,7 @@ impl super::stub::VmMigration for VmMigration {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4765,6 +4790,7 @@ impl super::stub::VmMigration for VmMigration {
                 let path_template = "/v1/{name}:cancel";
 
                 let resource_name = format!("//vmmigration.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5166,6 +5192,7 @@ impl super::stub::VmMigration for VmMigration {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5182,6 +5209,7 @@ impl super::stub::VmMigration for VmMigration {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/vmwareengine/v1/src/transport.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/transport.rs
@@ -438,6 +438,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -455,6 +456,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 let path_template = "/v1/{name}:undelete";
 
                 let resource_name = format!("//vmwareengine.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2882,6 +2884,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_private_cloud = try_match(
@@ -2899,6 +2902,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 let path_template = "/v1/{private_cloud}:resetNsxCredentials";
 
                 let resource_name = format!("//vmwareengine.googleapis.com/{}", var_private_cloud,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.private_cloud));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2954,6 +2958,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_private_cloud = try_match(
@@ -2971,6 +2976,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 let path_template = "/v1/{private_cloud}:resetVcenterCredentials";
 
                 let resource_name = format!("//vmwareengine.googleapis.com/{}", var_private_cloud,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.private_cloud));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4663,6 +4669,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4682,6 +4689,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 let path_template = "/v1/{name}:repair";
 
                 let resource_name = format!("//vmwareengine.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5589,6 +5597,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5605,6 +5614,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 let path_template = "/v1/{name}:grant";
 
                 let resource_name = format!("//vmwareengine.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5733,6 +5743,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -5749,6 +5760,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 let path_template = "/v1/{name}:revoke";
 
                 let resource_name = format!("//vmwareengine.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5930,6 +5942,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -5947,6 +5960,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//vmwareengine.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5969,6 +5983,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//vmwareengine.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5991,6 +6006,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//vmwareengine.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6274,6 +6290,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -6291,6 +6308,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//vmwareengine.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6313,6 +6331,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//vmwareengine.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6335,6 +6354,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//vmwareengine.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/webrisk/v1/src/transport.rs
+++ b/src/generated/cloud/webrisk/v1/src/transport.rs
@@ -270,6 +270,7 @@ impl super::stub::WebRiskService for WebRiskService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -280,6 +281,7 @@ impl super::stub::WebRiskService for WebRiskService {
                 let path_template = "/v1/{parent}/uris:submit";
 
                 let resource_name = format!("//webrisk.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -527,6 +529,7 @@ impl super::stub::WebRiskService for WebRiskService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -541,6 +544,7 @@ impl super::stub::WebRiskService for WebRiskService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/websecurityscanner/v1/src/transport.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/transport.rs
@@ -402,6 +402,7 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -416,6 +417,7 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
                 let path = format!("/v1/{}:start", var_name,);
                 let path_template = "/v1/{name}:start";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -612,6 +614,7 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -628,6 +631,7 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
                 let path = format!("/v1/{}:stop", var_name,);
                 let path_template = "/v1/{name}:stop";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/workflows/executions/v1/src/transport.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/transport.rs
@@ -286,6 +286,7 @@ impl super::stub::Executions for Executions {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -305,6 +306,7 @@ impl super::stub::Executions for Executions {
                 let path_template = "/v1/{name}:cancel";
 
                 let resource_name = format!("//workflowexecutions.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/cloud/workloadidentity/v1/src/transport.rs
+++ b/src/generated/cloud/workloadidentity/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::WorkloadIdentity for WorkloadIdentity {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -73,6 +74,7 @@ impl super::stub::WorkloadIdentity for WorkloadIdentity {
                 let path_template = "/v1/{parent}:generateServiceAgents";
 
                 let resource_name = format!("//workloadidentity.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -93,6 +95,7 @@ impl super::stub::WorkloadIdentity for WorkloadIdentity {
                 let path_template = "/v1/{parent}:generateServiceAgents";
 
                 let resource_name = format!("//workloadidentity.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -113,6 +116,7 @@ impl super::stub::WorkloadIdentity for WorkloadIdentity {
                 let path_template = "/v1/{parent}:generateServiceAgents";
 
                 let resource_name = format!("//workloadidentity.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -878,6 +882,7 @@ impl super::stub::WorkloadIdentity for WorkloadIdentity {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -894,6 +899,7 @@ impl super::stub::WorkloadIdentity for WorkloadIdentity {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -913,6 +919,7 @@ impl super::stub::WorkloadIdentity for WorkloadIdentity {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -932,6 +939,7 @@ impl super::stub::WorkloadIdentity for WorkloadIdentity {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/cloud/workstations/v1/src/transport.rs
+++ b/src/generated/cloud/workstations/v1/src/transport.rs
@@ -1348,6 +1348,7 @@ impl super::stub::Workstations for Workstations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
         .or_else(|| {
             let var_name = try_match(Some(&req).map(|m| &m.name).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/workstationClusters/"), Segment::SingleWildcard, Segment::Literal("/workstationConfigs/"), Segment::SingleWildcard, Segment::Literal("/workstations/"), Segment::SingleWildcard])?;
@@ -1361,6 +1362,7 @@ impl super::stub::Workstations for Workstations {
                 "//workstations.googleapis.com/{}",
                 var_name,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1408,6 +1410,7 @@ impl super::stub::Workstations for Workstations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
         .or_else(|| {
             let var_name = try_match(Some(&req).map(|m| &m.name).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/workstationClusters/"), Segment::SingleWildcard, Segment::Literal("/workstationConfigs/"), Segment::SingleWildcard, Segment::Literal("/workstations/"), Segment::SingleWildcard])?;
@@ -1421,6 +1424,7 @@ impl super::stub::Workstations for Workstations {
                 "//workstations.googleapis.com/{}",
                 var_name,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1468,6 +1472,7 @@ impl super::stub::Workstations for Workstations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
         .or_else(|| {
             let var_workstation = try_match(Some(&req).map(|m| &m.workstation).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/workstationClusters/"), Segment::SingleWildcard, Segment::Literal("/workstationConfigs/"), Segment::SingleWildcard, Segment::Literal("/workstations/"), Segment::SingleWildcard])?;
@@ -1481,6 +1486,7 @@ impl super::stub::Workstations for Workstations {
                 "//workstations.googleapis.com/{}",
                 var_workstation,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.workstation));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1528,6 +1534,7 @@ impl super::stub::Workstations for Workstations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
         .or_else(|| {
             let var_resource = try_match(Some(&req).map(|m| &m.resource).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/workstationClusters/"), Segment::SingleWildcard, Segment::Literal("/workstationConfigs/"), Segment::SingleWildcard])?;
@@ -1541,6 +1548,7 @@ impl super::stub::Workstations for Workstations {
                 "//workstations.googleapis.com/{}",
                 var_resource,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1557,6 +1565,7 @@ impl super::stub::Workstations for Workstations {
                 "//workstations.googleapis.com/{}",
                 var_resource,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1704,6 +1713,7 @@ impl super::stub::Workstations for Workstations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
         .or_else(|| {
             let var_resource = try_match(Some(&req).map(|m| &m.resource).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/workstationClusters/"), Segment::SingleWildcard, Segment::Literal("/workstationConfigs/"), Segment::SingleWildcard])?;
@@ -1717,6 +1727,7 @@ impl super::stub::Workstations for Workstations {
                 "//workstations.googleapis.com/{}",
                 var_resource,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1733,6 +1744,7 @@ impl super::stub::Workstations for Workstations {
                 "//workstations.googleapis.com/{}",
                 var_resource,
             );
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2006,6 +2018,7 @@ impl super::stub::Workstations for Workstations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2022,6 +2035,7 @@ impl super::stub::Workstations for Workstations {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/container/v1/src/transport.rs
+++ b/src/generated/container/v1/src/transport.rs
@@ -279,6 +279,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -293,6 +294,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}/clusters", var_parent,);
                 let path_template = "/v1/{parent}/clusters";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -312,6 +314,8 @@ impl super::stub::ClusterManager for ClusterManager {
                 );
                 let path_template = "/v1/projects/{project_id}/zones/{zone}/clusters";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -380,6 +384,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -396,6 +401,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}", var_name,);
                 let path_template = "/v1/{name}";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PUT, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PUT, path_template)))
@@ -419,6 +425,9 @@ impl super::stub::ClusterManager for ClusterManager {
                 );
                 let path_template = "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
                 let builder = self.inner.builder(Method::PUT, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PUT, path_template)))
@@ -495,6 +504,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
         .or_else(|| {
             let var_name = try_match(Some(&req).map(|m| &m.name).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/clusters/"), Segment::SingleWildcard, Segment::Literal("/nodePools/"), Segment::SingleWildcard])?;
@@ -504,6 +514,7 @@ impl super::stub::ClusterManager for ClusterManager {
             );
             let path_template = "/v1/{name}";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
             let builder = self.inner.builder(Method::PUT, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::PUT, path_template)))
@@ -522,6 +533,10 @@ impl super::stub::ClusterManager for ClusterManager {
             );
             let path_template = "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools/{node_pool_id}/update";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.node_pool_id));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -592,6 +607,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
         .or_else(|| {
             let var_name = try_match(Some(&req).map(|m| &m.name).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/clusters/"), Segment::SingleWildcard, Segment::Literal("/nodePools/"), Segment::SingleWildcard])?;
@@ -601,6 +617,7 @@ impl super::stub::ClusterManager for ClusterManager {
             );
             let path_template = "/v1/{name}:setAutoscaling";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -619,6 +636,10 @@ impl super::stub::ClusterManager for ClusterManager {
             );
             let path_template = "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools/{node_pool_id}/autoscaling";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.node_pool_id));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -689,6 +710,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -705,6 +727,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}:setLogging", var_name,);
                 let path_template = "/v1/{name}:setLogging";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -729,6 +752,9 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path_template =
                     "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/logging";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -805,6 +831,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -821,6 +848,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}:setMonitoring", var_name,);
                 let path_template = "/v1/{name}:setMonitoring";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -845,6 +873,9 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path_template =
                     "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/monitoring";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -921,6 +952,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -937,6 +969,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}:setAddons", var_name,);
                 let path_template = "/v1/{name}:setAddons";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -961,6 +994,9 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path_template =
                     "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/addons";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1037,6 +1073,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1053,6 +1090,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}:setLocations", var_name,);
                 let path_template = "/v1/{name}:setLocations";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1077,6 +1115,9 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path_template =
                     "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/locations";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1153,6 +1194,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1169,6 +1211,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}:updateMaster", var_name,);
                 let path_template = "/v1/{name}:updateMaster";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1193,6 +1236,9 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path_template =
                     "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/master";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1269,6 +1315,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1285,6 +1332,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}:setMasterAuth", var_name,);
                 let path_template = "/v1/{name}:setMasterAuth";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1309,6 +1357,9 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path_template =
                     "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}:setMasterAuth";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1728,6 +1779,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1744,6 +1796,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1768,6 +1821,9 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path_template =
                     "/v1/projects/{project_id}/zones/{zone}/operations/{operation_id}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.operation_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2246,6 +2302,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2262,6 +2319,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}/nodePools", var_parent,);
                 let path_template = "/v1/{parent}/nodePools";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2286,6 +2344,9 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path_template =
                     "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2464,6 +2525,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2482,6 +2544,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}:completeUpgrade", var_name,);
                 let path_template = "/v1/{name}:completeUpgrade";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2544,6 +2607,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
         .or_else(|| {
             let var_name = try_match(Some(&req).map(|m| &m.name).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/clusters/"), Segment::SingleWildcard, Segment::Literal("/nodePools/"), Segment::SingleWildcard])?;
@@ -2553,6 +2617,7 @@ impl super::stub::ClusterManager for ClusterManager {
             );
             let path_template = "/v1/{name}:rollback";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2571,6 +2636,10 @@ impl super::stub::ClusterManager for ClusterManager {
             );
             let path_template = "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools/{node_pool_id}:rollback";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.node_pool_id));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2641,6 +2710,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
         .or_else(|| {
             let var_name = try_match(Some(&req).map(|m| &m.name).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/clusters/"), Segment::SingleWildcard, Segment::Literal("/nodePools/"), Segment::SingleWildcard])?;
@@ -2650,6 +2720,7 @@ impl super::stub::ClusterManager for ClusterManager {
             );
             let path_template = "/v1/{name}:setManagement";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2668,6 +2739,10 @@ impl super::stub::ClusterManager for ClusterManager {
             );
             let path_template = "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools/{node_pool_id}/setManagement";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.node_pool_id));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2738,6 +2813,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2754,6 +2830,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}:setResourceLabels", var_name,);
                 let path_template = "/v1/{name}:setResourceLabels";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2778,6 +2855,9 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path_template =
                     "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/resourceLabels";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2854,6 +2934,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2870,6 +2951,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}:setLegacyAbac", var_name,);
                 let path_template = "/v1/{name}:setLegacyAbac";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2894,6 +2976,9 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path_template =
                     "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/legacyAbac";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2970,6 +3055,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2986,6 +3072,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}:startIpRotation", var_name,);
                 let path_template = "/v1/{name}:startIpRotation";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3010,6 +3097,9 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path_template =
                     "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}:startIpRotation";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3086,6 +3176,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
         .or_else(|| {
             let var_name = try_match(Some(&req).map(|m| &m.name).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/clusters/"), Segment::SingleWildcard])?;
@@ -3095,6 +3186,7 @@ impl super::stub::ClusterManager for ClusterManager {
             );
             let path_template = "/v1/{name}:completeIpRotation";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3111,6 +3203,9 @@ impl super::stub::ClusterManager for ClusterManager {
             );
             let path_template = "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}:completeIpRotation";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3176,6 +3271,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
         .or_else(|| {
             let var_name = try_match(Some(&req).map(|m| &m.name).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/clusters/"), Segment::SingleWildcard, Segment::Literal("/nodePools/"), Segment::SingleWildcard])?;
@@ -3185,6 +3281,7 @@ impl super::stub::ClusterManager for ClusterManager {
             );
             let path_template = "/v1/{name}:setSize";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3203,6 +3300,10 @@ impl super::stub::ClusterManager for ClusterManager {
             );
             let path_template = "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools/{node_pool_id}/setSize";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.node_pool_id));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3273,6 +3374,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3289,6 +3391,7 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path = format!("/v1/{}:setNetworkPolicy", var_name,);
                 let path_template = "/v1/{name}:setNetworkPolicy";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3313,6 +3416,9 @@ impl super::stub::ClusterManager for ClusterManager {
                 let path_template =
                     "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}:setNetworkPolicy";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3389,6 +3495,7 @@ impl super::stub::ClusterManager for ClusterManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
         .or_else(|| {
             let var_name = try_match(Some(&req).map(|m| &m.name).map(|s| s.as_str()), &[Segment::Literal("projects/"), Segment::SingleWildcard, Segment::Literal("/locations/"), Segment::SingleWildcard, Segment::Literal("/clusters/"), Segment::SingleWildcard])?;
@@ -3398,6 +3505,7 @@ impl super::stub::ClusterManager for ClusterManager {
             );
             let path_template = "/v1/{name}:setMaintenancePolicy";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3414,6 +3522,9 @@ impl super::stub::ClusterManager for ClusterManager {
             );
             let path_template = "/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}:setMaintenancePolicy";
 
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.zone));
+            let _ = Some(&mut req).map(|m| std::mem::take(&mut m.cluster_id));
             let builder = self.inner.builder(Method::POST, path);
             let builder = Ok(builder);
             Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/datastore/admin/v1/src/transport.rs
+++ b/src/generated/datastore/admin/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_project_id = try_match(
@@ -65,6 +66,7 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
                 let path = format!("/v1/projects/{}:export", var_project_id,);
                 let path_template = "/v1/projects/{project_id}:export";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -112,6 +114,7 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_project_id = try_match(
@@ -121,6 +124,7 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
                 let path = format!("/v1/projects/{}:import", var_project_id,);
                 let path_template = "/v1/projects/{project_id}:import";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/devicesandservices/health/v4/src/transport.rs
+++ b/src/generated/devicesandservices/health/v4/src/transport.rs
@@ -351,6 +351,7 @@ impl super::stub::DataPointsService for DataPointsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -366,6 +367,7 @@ impl super::stub::DataPointsService for DataPointsService {
                 let path_template = "/v4/{parent}/dataPoints:batchDelete";
 
                 let resource_name = format!("//health.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -491,6 +493,7 @@ impl super::stub::DataPointsService for DataPointsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -506,6 +509,7 @@ impl super::stub::DataPointsService for DataPointsService {
                 let path_template = "/v4/{parent}/dataPoints:rollUp";
 
                 let resource_name = format!("//health.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -561,6 +565,7 @@ impl super::stub::DataPointsService for DataPointsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -576,6 +581,7 @@ impl super::stub::DataPointsService for DataPointsService {
                 let path_template = "/v4/{parent}/dataPoints:dailyRollUp";
 
                 let resource_name = format!("//health.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/devtools/artifactregistry/v1/src/transport.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/transport.rs
@@ -671,6 +671,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -687,6 +688,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 let path = format!("/v1/{}/aptArtifacts:import", var_parent,);
                 let path_template = "/v1/{parent}/aptArtifacts:import";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -743,6 +745,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -759,6 +762,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 let path = format!("/v1/{}/yumArtifacts:import", var_parent,);
                 let path_template = "/v1/{parent}/yumArtifacts:import";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1675,6 +1679,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1694,6 +1699,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 let path_template = "/v1/{parent}/versions:batchDelete";
 
                 let resource_name = format!("//artifactregistry.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2998,6 +3004,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3015,6 +3022,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//artifactregistry.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3158,6 +3166,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3175,6 +3184,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//artifactregistry.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3944,6 +3954,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_repository = try_match(
@@ -3962,6 +3973,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
 
                 let resource_name =
                     format!("//artifactregistry.googleapis.com/{}", var_repository,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.repository));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/devtools/cloudbuild/v1/src/transport.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/transport.rs
@@ -356,6 +356,7 @@ impl super::stub::CloudBuild for CloudBuild {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_project_id = try_match(
@@ -370,6 +371,8 @@ impl super::stub::CloudBuild for CloudBuild {
                 let path_template = "/v1/projects/{project_id}/builds/{id}:cancel";
 
                 let resource_name = String::new();
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -390,6 +393,7 @@ impl super::stub::CloudBuild for CloudBuild {
                 let path_template = "/v1/{name}:cancel";
 
                 let resource_name = format!("//cloudbuild.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -461,6 +465,7 @@ impl super::stub::CloudBuild for CloudBuild {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_project_id = try_match(
@@ -475,6 +480,8 @@ impl super::stub::CloudBuild for CloudBuild {
                 let path_template = "/v1/projects/{project_id}/builds/{id}:retry";
 
                 let resource_name = String::new();
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.project_id));
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.id));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -495,6 +502,7 @@ impl super::stub::CloudBuild for CloudBuild {
                 let path_template = "/v1/{name}:retry";
 
                 let resource_name = format!("//cloudbuild.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -566,6 +574,7 @@ impl super::stub::CloudBuild for CloudBuild {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -580,6 +589,7 @@ impl super::stub::CloudBuild for CloudBuild {
                 let path = format!("/v1/{}:approve", var_name,);
                 let path_template = "/v1/{name}:approve";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -599,6 +609,7 @@ impl super::stub::CloudBuild for CloudBuild {
                 let path = format!("/v1/{}:approve", var_name,);
                 let path_template = "/v1/{name}:approve";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1990,6 +2001,7 @@ impl super::stub::CloudBuild for CloudBuild {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2002,6 +2014,7 @@ impl super::stub::CloudBuild for CloudBuild {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -2021,6 +2034,7 @@ impl super::stub::CloudBuild for CloudBuild {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/devtools/cloudbuild/v2/src/transport.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/transport.rs
@@ -514,6 +514,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -531,6 +532,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
                 let path_template = "/v2/{parent}/repositories:batchCreate";
 
                 let resource_name = format!("//cloudbuild.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -821,6 +823,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_repository = try_match(
@@ -840,6 +843,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
                 let path_template = "/v2/{repository}:accessReadWriteToken";
 
                 let resource_name = format!("//cloudbuild.googleapis.com/{}", var_repository,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.repository));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -899,6 +903,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_repository = try_match(
@@ -918,6 +923,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
                 let path_template = "/v2/{repository}:accessReadToken";
 
                 let resource_name = format!("//cloudbuild.googleapis.com/{}", var_repository,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.repository));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1130,6 +1136,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1147,6 +1154,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
                 let path_template = "/v2/{resource}:setIamPolicy";
 
                 let resource_name = format!("//cloudbuild.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1286,6 +1294,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1303,6 +1312,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
                 let path_template = "/v2/{resource}:testIamPermissions";
 
                 let resource_name = format!("//cloudbuild.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1428,6 +1438,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1444,6 +1455,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/devtools/cloudprofiler/v2/src/transport.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::ProfilerService for ProfilerService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -66,6 +67,7 @@ impl super::stub::ProfilerService for ProfilerService {
                 let path_template = "/v2/{parent}/profiles";
 
                 let resource_name = format!("//cloudprofiler.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/devtools/cloudtrace/v2/src/transport.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::TraceService for TraceService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -66,6 +67,7 @@ impl super::stub::TraceService for TraceService {
                 let path_template = "/v2/{name}/traces:batchWrite";
 
                 let resource_name = format!("//cloudtrace.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -120,6 +122,7 @@ impl super::stub::TraceService for TraceService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -136,6 +139,7 @@ impl super::stub::TraceService for TraceService {
                 let path = format!("/v2/{}", var_name,);
                 let path_template = "/v2/{name}";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/devtools/containeranalysis/v1/src/transport.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -71,6 +72,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -89,6 +91,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -109,6 +112,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -129,6 +133,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -233,6 +238,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -248,6 +254,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -266,6 +273,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -286,6 +294,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -306,6 +315,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -410,6 +420,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -425,6 +436,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -443,6 +455,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -463,6 +476,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -483,6 +497,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -680,6 +695,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -694,6 +710,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 let path = format!("/v1/{}:exportSBOM", var_name,);
                 let path_template = "/v1/{name}:exportSBOM";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -713,6 +730,7 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 let path = format!("/v1/{}:exportSBOM", var_name,);
                 let path_template = "/v1/{name}:exportSBOM";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/firestore/admin/v1/src/transport.rs
+++ b/src/generated/firestore/admin/v1/src/transport.rs
@@ -604,6 +604,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -619,6 +620,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 let path_template = "/v1/{name}:exportDocuments";
 
                 let resource_name = format!("//firestore.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -672,6 +674,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -687,6 +690,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 let path_template = "/v1/{name}:importDocuments";
 
                 let resource_name = format!("//firestore.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -740,6 +744,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -755,6 +760,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 let path_template = "/v1/{name}:bulkDeleteDocuments";
 
                 let resource_name = format!("//firestore.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1356,6 +1362,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1373,6 +1380,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 let path_template = "/v1/{name}:enable";
 
                 let resource_name = format!("//firestore.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1428,6 +1436,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1445,6 +1454,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 let path_template = "/v1/{name}:disable";
 
                 let resource_name = format!("//firestore.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1500,6 +1510,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1517,6 +1528,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 let path_template = "/v1/{name}:resetPassword";
 
                 let resource_name = format!("//firestore.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1869,6 +1881,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1879,6 +1892,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 let path_template = "/v1/{parent}/databases:restore";
 
                 let resource_name = format!("//firestore.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2301,6 +2315,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2311,6 +2326,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 let path_template = "/v1/{parent}/databases:clone";
 
                 let resource_name = format!("//firestore.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2576,6 +2592,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2592,6 +2609,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/grafeas/v1/src/transport.rs
+++ b/src/generated/grafeas/v1/src/transport.rs
@@ -464,6 +464,7 @@ impl super::stub::Grafeas for Grafeas {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -474,6 +475,7 @@ impl super::stub::Grafeas for Grafeas {
                 let path_template = "/v1/{parent}/occurrences:batchCreate";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -492,6 +494,7 @@ impl super::stub::Grafeas for Grafeas {
                 let path_template = "/v1/{parent}/occurrences:batchCreate";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1199,6 +1202,7 @@ impl super::stub::Grafeas for Grafeas {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1209,6 +1213,7 @@ impl super::stub::Grafeas for Grafeas {
                 let path_template = "/v1/{parent}/notes:batchCreate";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1227,6 +1232,7 @@ impl super::stub::Grafeas for Grafeas {
                 let path_template = "/v1/{parent}/notes:batchCreate";
 
                 let resource_name = format!("//containeranalysis.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/iam/admin/v1/src/transport.rs
+++ b/src/generated/iam/admin/v1/src/transport.rs
@@ -182,6 +182,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -192,6 +193,7 @@ impl super::stub::Iam for Iam {
                 let path_template = "/v1/{name}/serviceAccounts";
 
                 let resource_name = format!("//iam.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -240,6 +242,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -254,6 +257,7 @@ impl super::stub::Iam for Iam {
                 let path = format!("/v1/{}", var_name,);
                 let path_template = "/v1/{name}";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PUT, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PUT, path_template)))
@@ -306,6 +310,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_service_account_name = try_match(
@@ -323,6 +328,9 @@ impl super::stub::Iam for Iam {
                 let path = format!("/v1/{}", var_service_account_name,);
                 let path_template = "/v1/{service_account.name}";
 
+                let _ = Some(&mut req)
+                    .and_then(|m| m.service_account.as_mut())
+                    .map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template)))
@@ -452,6 +460,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -466,6 +475,7 @@ impl super::stub::Iam for Iam {
                 let path = format!("/v1/{}:undelete", var_name,);
                 let path_template = "/v1/{name}:undelete";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -518,6 +528,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -532,6 +543,7 @@ impl super::stub::Iam for Iam {
                 let path = format!("/v1/{}:enable", var_name,);
                 let path_template = "/v1/{name}:enable";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -590,6 +602,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -604,6 +617,7 @@ impl super::stub::Iam for Iam {
                 let path = format!("/v1/{}:disable", var_name,);
                 let path_template = "/v1/{name}:disable";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -807,6 +821,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -822,6 +837,7 @@ impl super::stub::Iam for Iam {
                 let path_template = "/v1/{name}/keys";
 
                 let resource_name = format!("//iam.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -875,6 +891,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -889,6 +906,7 @@ impl super::stub::Iam for Iam {
                 let path = format!("/v1/{}/keys:upload", var_name,);
                 let path_template = "/v1/{name}/keys:upload";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1019,6 +1037,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1036,6 +1055,7 @@ impl super::stub::Iam for Iam {
                 let path_template = "/v1/{name}:disable";
 
                 let resource_name = format!("//iam.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1097,6 +1117,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1114,6 +1135,7 @@ impl super::stub::Iam for Iam {
                 let path_template = "/v1/{name}:enable";
 
                 let resource_name = format!("//iam.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1175,6 +1197,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1190,6 +1213,7 @@ impl super::stub::Iam for Iam {
                 let path_template = "/v1/{name}:signBlob";
 
                 let resource_name = format!("//iam.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1243,6 +1267,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1258,6 +1283,7 @@ impl super::stub::Iam for Iam {
                 let path_template = "/v1/{name}:signJwt";
 
                 let resource_name = format!("//iam.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1391,6 +1417,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1406,6 +1433,7 @@ impl super::stub::Iam for Iam {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//iam.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1459,6 +1487,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1474,6 +1503,7 @@ impl super::stub::Iam for Iam {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//iam.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1802,6 +1832,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1812,6 +1843,7 @@ impl super::stub::Iam for Iam {
                 let path_template = "/v1/{parent}/roles";
 
                 let resource_name = format!("//iam.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1825,6 +1857,7 @@ impl super::stub::Iam for Iam {
                 let path_template = "/v1/{parent}/roles";
 
                 let resource_name = format!("//iam.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2111,6 +2144,7 @@ impl super::stub::Iam for Iam {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2126,6 +2160,7 @@ impl super::stub::Iam for Iam {
                 let path_template = "/v1/{name}:undelete";
 
                 let resource_name = format!("//iam.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2144,6 +2179,7 @@ impl super::stub::Iam for Iam {
                 let path_template = "/v1/{name}:undelete";
 
                 let resource_name = format!("//iam.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/iam/credentials/v1/src/transport.rs
+++ b/src/generated/iam/credentials/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::IAMCredentials for IAMCredentials {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -71,6 +72,7 @@ impl super::stub::IAMCredentials for IAMCredentials {
                 let path_template = "/v1/{name}:generateAccessToken";
 
                 let resource_name = format!("//iamcredentials.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -124,6 +126,7 @@ impl super::stub::IAMCredentials for IAMCredentials {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -139,6 +142,7 @@ impl super::stub::IAMCredentials for IAMCredentials {
                 let path_template = "/v1/{name}:generateIdToken";
 
                 let resource_name = format!("//iamcredentials.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -192,6 +196,7 @@ impl super::stub::IAMCredentials for IAMCredentials {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -207,6 +212,7 @@ impl super::stub::IAMCredentials for IAMCredentials {
                 let path_template = "/v1/{name}:signBlob";
 
                 let resource_name = format!("//iamcredentials.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -260,6 +266,7 @@ impl super::stub::IAMCredentials for IAMCredentials {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -275,6 +282,7 @@ impl super::stub::IAMCredentials for IAMCredentials {
                 let path_template = "/v1/{name}:signJwt";
 
                 let resource_name = format!("//iamcredentials.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/iam/v1/src/transport.rs
+++ b/src/generated/iam/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::IAMPolicy for IAMPolicy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -66,6 +67,7 @@ impl super::stub::IAMPolicy for IAMPolicy {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//iam-meta-api.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -114,6 +116,7 @@ impl super::stub::IAMPolicy for IAMPolicy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -124,6 +127,7 @@ impl super::stub::IAMPolicy for IAMPolicy {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//iam-meta-api.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -172,6 +176,7 @@ impl super::stub::IAMPolicy for IAMPolicy {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -182,6 +187,7 @@ impl super::stub::IAMPolicy for IAMPolicy {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//iam-meta-api.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/identity/accesscontextmanager/v1/src/transport.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/transport.rs
@@ -679,6 +679,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -690,6 +691,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
 
                 let resource_name =
                     format!("//accesscontextmanager.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1078,6 +1080,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1089,6 +1092,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
 
                 let resource_name =
                     format!("//accesscontextmanager.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1137,6 +1141,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1148,6 +1153,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
 
                 let resource_name =
                     format!("//accesscontextmanager.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1536,6 +1542,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1547,6 +1554,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
 
                 let resource_name =
                     format!("//accesscontextmanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1597,6 +1605,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1608,6 +1617,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
 
                 let resource_name =
                     format!("//accesscontextmanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1658,6 +1668,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1669,6 +1680,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
 
                 let resource_name =
                     format!("//accesscontextmanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1688,6 +1700,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
 
                 let resource_name =
                     format!("//accesscontextmanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1707,6 +1720,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
 
                 let resource_name =
                     format!("//accesscontextmanager.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/logging/v2/src/transport.rs
+++ b/src/generated/logging/v2/src/transport.rs
@@ -1219,6 +1219,7 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1236,6 +1237,7 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1255,6 +1257,7 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1274,6 +1277,7 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1293,6 +1297,7 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1312,6 +1317,7 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -3110,6 +3116,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3128,6 +3135,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 let path_template = "/v2/{name}:undelete";
 
                 let resource_name = format!("//logging.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3148,6 +3156,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 let path_template = "/v2/{name}:undelete";
 
                 let resource_name = format!("//logging.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3168,6 +3177,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 let path_template = "/v2/{name}:undelete";
 
                 let resource_name = format!("//logging.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3188,6 +3198,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 let path_template = "/v2/{name}:undelete";
 
                 let resource_name = format!("//logging.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3208,6 +3219,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 let path_template = "/v2/{name}:undelete";
 
                 let resource_name = format!("//logging.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8805,6 +8817,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -8822,6 +8835,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -8841,6 +8855,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -8860,6 +8875,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -8879,6 +8895,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -8898,6 +8915,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -9835,6 +9853,7 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -9852,6 +9871,7 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -9871,6 +9891,7 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -9890,6 +9911,7 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -9909,6 +9931,7 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -9928,6 +9951,7 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
                 let path = format!("/v2/{}:cancel", var_name,);
                 let path_template = "/v2/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/longrunning/src/transport.rs
+++ b/src/generated/longrunning/src/transport.rs
@@ -247,6 +247,7 @@ impl super::stub::Operations for Operations {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -259,6 +260,7 @@ impl super::stub::Operations for Operations {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/maps/fleetengine/delivery/v1/src/transport.rs
+++ b/src/generated/maps/fleetengine/delivery/v1/src/transport.rs
@@ -393,6 +393,7 @@ impl super::stub::DeliveryService for DeliveryService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -403,6 +404,7 @@ impl super::stub::DeliveryService for DeliveryService {
                 let path_template = "/v1/{parent}/tasks:batchCreate";
 
                 let resource_name = format!("//fleetengine.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/maps/fleetengine/v1/src/transport.rs
+++ b/src/generated/maps/fleetengine/v1/src/transport.rs
@@ -335,6 +335,7 @@ impl super::stub::TripService for TripService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -349,6 +350,7 @@ impl super::stub::TripService for TripService {
                 let path = format!("/v1/{}:report", var_name,);
                 let path_template = "/v1/{name}:report";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -407,6 +409,7 @@ impl super::stub::TripService for TripService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -416,6 +419,7 @@ impl super::stub::TripService for TripService {
                 let path = format!("/v1/{}/trips:search", var_parent,);
                 let path_template = "/v1/{parent}/trips:search";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -923,6 +927,7 @@ impl super::stub::VehicleService for VehicleService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -937,6 +942,7 @@ impl super::stub::VehicleService for VehicleService {
                 let path = format!("/v1/{}:updateAttributes", var_name,);
                 let path_template = "/v1/{name}:updateAttributes";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1117,6 +1123,7 @@ impl super::stub::VehicleService for VehicleService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1126,6 +1133,7 @@ impl super::stub::VehicleService for VehicleService {
                 let path = format!("/v1/{}/vehicles:search", var_parent,);
                 let path_template = "/v1/{parent}/vehicles:search";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/maps/routeoptimization/v1/src/transport.rs
+++ b/src/generated/maps/routeoptimization/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::RouteOptimization for RouteOptimization {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -70,6 +71,7 @@ impl super::stub::RouteOptimization for RouteOptimization {
                 let path = format!("/v1/{}:optimizeTours", var_parent,);
                 let path_template = "/v1/{parent}:optimizeTours";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -82,6 +84,7 @@ impl super::stub::RouteOptimization for RouteOptimization {
                 let path = format!("/v1/{}:optimizeTours", var_parent,);
                 let path_template = "/v1/{parent}:optimizeTours";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -146,6 +149,7 @@ impl super::stub::RouteOptimization for RouteOptimization {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -160,6 +164,7 @@ impl super::stub::RouteOptimization for RouteOptimization {
                 let path = format!("/v1/{}:batchOptimizeTours", var_parent,);
                 let path_template = "/v1/{parent}:batchOptimizeTours";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -172,6 +177,7 @@ impl super::stub::RouteOptimization for RouteOptimization {
                 let path = format!("/v1/{}:batchOptimizeTours", var_parent,);
                 let path_template = "/v1/{parent}:batchOptimizeTours";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -236,6 +242,7 @@ impl super::stub::RouteOptimization for RouteOptimization {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -250,6 +257,7 @@ impl super::stub::RouteOptimization for RouteOptimization {
                 let path = format!("/v1/{}:optimizeToursLongRunning", var_parent,);
                 let path_template = "/v1/{parent}:optimizeToursLongRunning";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -262,6 +270,7 @@ impl super::stub::RouteOptimization for RouteOptimization {
                 let path = format!("/v1/{}:optimizeToursLongRunning", var_parent,);
                 let path_template = "/v1/{parent}:optimizeToursLongRunning";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -324,6 +333,7 @@ impl super::stub::RouteOptimization for RouteOptimization {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -338,6 +348,7 @@ impl super::stub::RouteOptimization for RouteOptimization {
                 let path = format!("/v1/{}:OptimizeToursUri", var_parent,);
                 let path_template = "/v1/{parent}:OptimizeToursUri";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -350,6 +361,7 @@ impl super::stub::RouteOptimization for RouteOptimization {
                 let path = format!("/v1/{}:OptimizeToursUri", var_parent,);
                 let path_template = "/v1/{parent}:OptimizeToursUri";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/monitoring/v3/src/transport.rs
+++ b/src/generated/monitoring/v3/src/transport.rs
@@ -1500,6 +1500,7 @@ impl super::stub::MetricService for MetricService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1510,6 +1511,7 @@ impl super::stub::MetricService for MetricService {
                 let path_template = "/v3/{name}/timeSeries";
 
                 let resource_name = format!("//monitoring.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1564,6 +1566,7 @@ impl super::stub::MetricService for MetricService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1574,6 +1577,7 @@ impl super::stub::MetricService for MetricService {
                 let path_template = "/v3/{name}/timeSeries:createService";
 
                 let resource_name = format!("//monitoring.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2142,6 +2146,7 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2157,6 +2162,7 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
                 let path_template = "/v3/{name}:sendVerificationCode";
 
                 let resource_name = format!("//monitoring.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2216,6 +2222,7 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2231,6 +2238,7 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
                 let path_template = "/v3/{name}:getVerificationCode";
 
                 let resource_name = format!("//monitoring.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2284,6 +2292,7 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2299,6 +2308,7 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
                 let path_template = "/v3/{name}:verify";
 
                 let resource_name = format!("//monitoring.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2383,6 +2393,7 @@ impl super::stub::QueryService for QueryService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2392,6 +2403,7 @@ impl super::stub::QueryService for QueryService {
                 let path = format!("/v3/{}/timeSeries:query", var_name,);
                 let path_template = "/v3/{name}/timeSeries:query";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/privacy/dlp/v2/src/transport.rs
+++ b/src/generated/privacy/dlp/v2/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -66,6 +67,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/content:inspect";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -84,6 +86,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/content:inspect";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -147,6 +150,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -157,6 +161,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/image:redact";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -175,6 +180,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/image:redact";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -238,6 +244,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -248,6 +255,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/content:deidentify";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -266,6 +274,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/content:deidentify";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -329,6 +338,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -339,6 +349,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/content:reidentify";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -357,6 +368,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/content:reidentify";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -565,6 +577,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -580,6 +593,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/inspectTemplates";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -598,6 +612,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/inspectTemplates";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -611,6 +626,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/inspectTemplates";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -624,6 +640,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/inspectTemplates";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -712,6 +729,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -729,6 +747,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -749,6 +768,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -767,6 +787,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -785,6 +806,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -1406,6 +1428,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1416,6 +1439,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/deidentifyTemplates";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1434,6 +1458,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/deidentifyTemplates";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1447,6 +1472,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/deidentifyTemplates";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1465,6 +1491,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/deidentifyTemplates";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1553,6 +1580,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1568,6 +1596,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -1588,6 +1617,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -1606,6 +1636,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -1626,6 +1657,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -2247,6 +2279,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2257,6 +2290,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/jobTriggers";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2275,6 +2309,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/jobTriggers";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2293,6 +2328,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/jobTriggers";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2371,6 +2407,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2386,6 +2423,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -2406,6 +2444,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -2426,6 +2465,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -2513,6 +2553,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -2530,6 +2571,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}:hybridInspect";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3017,6 +3059,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3032,6 +3075,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}:activate";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3052,6 +3096,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}:activate";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3122,6 +3167,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -3137,6 +3183,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/discoveryConfigs";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3155,6 +3202,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/discoveryConfigs";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3223,6 +3271,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -3240,6 +3289,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -3260,6 +3310,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -3663,6 +3714,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -3673,6 +3725,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/dlpJobs";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3691,6 +3744,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/dlpJobs";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4112,6 +4166,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4127,6 +4182,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}:cancel";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4147,6 +4203,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}:cancel";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4223,6 +4280,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -4233,6 +4291,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/storedInfoTypes";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4251,6 +4310,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/storedInfoTypes";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4264,6 +4324,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/storedInfoTypes";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4282,6 +4343,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/storedInfoTypes";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4370,6 +4432,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -4385,6 +4448,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -4405,6 +4469,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -4423,6 +4488,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -4443,6 +4509,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -6166,6 +6233,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6183,6 +6251,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}:hybridInspect";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6238,6 +6307,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6255,6 +6325,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}:finish";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6316,6 +6387,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -6331,6 +6403,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/connections";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6349,6 +6422,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{parent}/connections";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6855,6 +6929,7 @@ impl super::stub::DlpService for DlpService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6872,6 +6947,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -6892,6 +6968,7 @@ impl super::stub::DlpService for DlpService {
                 let path_template = "/v2/{name}";
 
                 let resource_name = format!("//dlp.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))

--- a/src/generated/shopping/css/v1/src/transport.rs
+++ b/src/generated/shopping/css/v1/src/transport.rs
@@ -186,6 +186,7 @@ impl super::stub::AccountsService for AccountsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -196,6 +197,7 @@ impl super::stub::AccountsService for AccountsService {
                 let path_template = "/v1/{name}:updateLabels";
 
                 let resource_name = format!("//css.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/shopping/merchant/conversions/v1/src/transport.rs
+++ b/src/generated/shopping/merchant/conversions/v1/src/transport.rs
@@ -274,6 +274,7 @@ impl super::stub::ConversionSourcesService for ConversionSourcesService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -290,6 +291,7 @@ impl super::stub::ConversionSourcesService for ConversionSourcesService {
 
                 let resource_name =
                     format!("//merchantapi.googleapis.com/conversions/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/shopping/merchant/promotions/v1/src/transport.rs
+++ b/src/generated/shopping/merchant/promotions/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::PromotionsService for PromotionsService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -65,6 +66,7 @@ impl super::stub::PromotionsService for PromotionsService {
                 let path = format!("/promotions/v1/{}/promotions:insert", var_parent,);
                 let path_template = "/promotions/v1/{parent}/promotions:insert";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/shopping/merchant/reports/v1/src/transport.rs
+++ b/src/generated/shopping/merchant/reports/v1/src/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::ReportService for ReportService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -65,6 +66,7 @@ impl super::stub::ReportService for ReportService {
                 let path = format!("/reports/v1/{}/reports:search", var_parent,);
                 let path_template = "/reports/v1/{parent}/reports:search";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -896,6 +896,7 @@ impl super::stub::Compliance for Compliance {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -906,6 +907,7 @@ impl super::stub::Compliance for Compliance {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -919,6 +921,7 @@ impl super::stub::Compliance for Compliance {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -937,6 +940,7 @@ impl super::stub::Compliance for Compliance {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -950,6 +954,7 @@ impl super::stub::Compliance for Compliance {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1218,6 +1223,7 @@ impl super::stub::Compliance for Compliance {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1228,6 +1234,7 @@ impl super::stub::Compliance for Compliance {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1241,6 +1248,7 @@ impl super::stub::Compliance for Compliance {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1259,6 +1267,7 @@ impl super::stub::Compliance for Compliance {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1272,6 +1281,7 @@ impl super::stub::Compliance for Compliance {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2188,6 +2198,7 @@ impl super::stub::Echo for Echo {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2198,6 +2209,7 @@ impl super::stub::Echo for Echo {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2211,6 +2223,7 @@ impl super::stub::Echo for Echo {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2229,6 +2242,7 @@ impl super::stub::Echo for Echo {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2242,6 +2256,7 @@ impl super::stub::Echo for Echo {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2510,6 +2525,7 @@ impl super::stub::Echo for Echo {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2520,6 +2536,7 @@ impl super::stub::Echo for Echo {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2533,6 +2550,7 @@ impl super::stub::Echo for Echo {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2551,6 +2569,7 @@ impl super::stub::Echo for Echo {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2564,6 +2583,7 @@ impl super::stub::Echo for Echo {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3349,6 +3369,7 @@ impl super::stub::Identity for Identity {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3359,6 +3380,7 @@ impl super::stub::Identity for Identity {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3372,6 +3394,7 @@ impl super::stub::Identity for Identity {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3390,6 +3413,7 @@ impl super::stub::Identity for Identity {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3403,6 +3427,7 @@ impl super::stub::Identity for Identity {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3671,6 +3696,7 @@ impl super::stub::Identity for Identity {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -3681,6 +3707,7 @@ impl super::stub::Identity for Identity {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3694,6 +3721,7 @@ impl super::stub::Identity for Identity {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3712,6 +3740,7 @@ impl super::stub::Identity for Identity {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -3725,6 +3754,7 @@ impl super::stub::Identity for Identity {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4390,6 +4420,7 @@ impl super::stub::Messaging for Messaging {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -4400,6 +4431,7 @@ impl super::stub::Messaging for Messaging {
                 let path_template = "/v1beta1/{parent}/blurbs";
 
                 let resource_name = format!("//localhost:7469/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4417,6 +4449,7 @@ impl super::stub::Messaging for Messaging {
                 let path_template = "/v1beta1/{parent}/blurbs";
 
                 let resource_name = format!("//localhost:7469/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4914,6 +4947,7 @@ impl super::stub::Messaging for Messaging {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -4924,6 +4958,7 @@ impl super::stub::Messaging for Messaging {
                 let path_template = "/v1beta1/{parent}/blurbs:search";
 
                 let resource_name = format!("//localhost:7469/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4941,6 +4976,7 @@ impl super::stub::Messaging for Messaging {
                 let path_template = "/v1beta1/{parent}/blurbs:search";
 
                 let resource_name = format!("//localhost:7469/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = builder.query(&[("query", &req.query)]);
                 let builder = builder.query(&[("pageSize", &req.page_size)]);
@@ -5167,6 +5203,7 @@ impl super::stub::Messaging for Messaging {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -5177,6 +5214,7 @@ impl super::stub::Messaging for Messaging {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5190,6 +5228,7 @@ impl super::stub::Messaging for Messaging {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5208,6 +5247,7 @@ impl super::stub::Messaging for Messaging {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5221,6 +5261,7 @@ impl super::stub::Messaging for Messaging {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5489,6 +5530,7 @@ impl super::stub::Messaging for Messaging {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -5499,6 +5541,7 @@ impl super::stub::Messaging for Messaging {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5512,6 +5555,7 @@ impl super::stub::Messaging for Messaging {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5530,6 +5574,7 @@ impl super::stub::Messaging for Messaging {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -5543,6 +5588,7 @@ impl super::stub::Messaging for Messaging {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6141,6 +6187,7 @@ impl super::stub::SequenceService for SequenceService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -6151,6 +6198,7 @@ impl super::stub::SequenceService for SequenceService {
                 let path_template = "/v1beta1/{name}";
 
                 let resource_name = format!("//localhost:7469/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6330,6 +6378,7 @@ impl super::stub::SequenceService for SequenceService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -6340,6 +6389,7 @@ impl super::stub::SequenceService for SequenceService {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6353,6 +6403,7 @@ impl super::stub::SequenceService for SequenceService {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6371,6 +6422,7 @@ impl super::stub::SequenceService for SequenceService {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6384,6 +6436,7 @@ impl super::stub::SequenceService for SequenceService {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6652,6 +6705,7 @@ impl super::stub::SequenceService for SequenceService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -6662,6 +6716,7 @@ impl super::stub::SequenceService for SequenceService {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6675,6 +6730,7 @@ impl super::stub::SequenceService for SequenceService {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6693,6 +6749,7 @@ impl super::stub::SequenceService for SequenceService {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -6706,6 +6763,7 @@ impl super::stub::SequenceService for SequenceService {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7668,6 +7726,7 @@ impl super::stub::Testing for Testing {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -7678,6 +7737,7 @@ impl super::stub::Testing for Testing {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7691,6 +7751,7 @@ impl super::stub::Testing for Testing {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7709,6 +7770,7 @@ impl super::stub::Testing for Testing {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7722,6 +7784,7 @@ impl super::stub::Testing for Testing {
                 let path_template = "/v1beta1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -7990,6 +8053,7 @@ impl super::stub::Testing for Testing {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -8000,6 +8064,7 @@ impl super::stub::Testing for Testing {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8013,6 +8078,7 @@ impl super::stub::Testing for Testing {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8031,6 +8097,7 @@ impl super::stub::Testing for Testing {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -8044,6 +8111,7 @@ impl super::stub::Testing for Testing {
                 let path_template = "/v1beta1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//localhost:7469/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/spanner/admin/database/v1/src/transport.rs
+++ b/src/generated/spanner/admin/database/v1/src/transport.rs
@@ -126,6 +126,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -141,6 +142,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{parent}/databases";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -354,6 +356,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_database = try_match(
@@ -371,6 +374,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{database}/ddl";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_database,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.database));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template, resource_name)))
@@ -578,6 +582,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -595,6 +600,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -615,6 +621,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -637,6 +644,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -728,6 +736,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -745,6 +754,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -765,6 +775,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -787,6 +798,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -878,6 +890,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -895,6 +908,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -915,6 +929,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -937,6 +952,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -959,6 +975,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1152,6 +1169,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1167,6 +1185,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{parent}/backups:copy";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1529,6 +1548,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1544,6 +1564,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{parent}/databases:restore";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1821,6 +1842,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_database = try_match(
@@ -1838,6 +1860,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 let path_template = "/v1/{database}:addSplitPoints";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_database,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.database));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/spanner/admin/instance/v1/src/transport.rs
+++ b/src/generated/spanner/admin/instance/v1/src/transport.rs
@@ -188,6 +188,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -198,6 +199,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 let path_template = "/v1/{parent}/instanceConfigs";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -248,6 +250,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_instance_config_name = try_match(
@@ -265,6 +268,9 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 let path = format!("/v1/{}", var_instance_config_name,);
                 let path_template = "/v1/{instance_config.name}";
 
+                let _ = Some(&mut req)
+                    .and_then(|m| m.instance_config.as_mut())
+                    .map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template)))
@@ -698,6 +704,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -708,6 +715,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 let path_template = "/v1/{parent}/instances";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -756,6 +764,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_instance_name = try_match(
@@ -773,6 +782,9 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 let path = format!("/v1/{}", var_instance_name,);
                 let path_template = "/v1/{instance.name}";
 
+                let _ = Some(&mut req)
+                    .and_then(|m| m.instance.as_mut())
+                    .map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template)))
@@ -902,6 +914,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -917,6 +930,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -970,6 +984,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -985,6 +1000,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 let path_template = "/v1/{resource}:getIamPolicy";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1038,6 +1054,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -1053,6 +1070,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1182,6 +1200,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -1197,6 +1216,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 let path_template = "/v1/{parent}/instancePartitions";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1333,6 +1353,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_instance_partition_name = try_match(
@@ -1352,6 +1373,9 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 let path = format!("/v1/{}", var_instance_partition_name,);
                 let path_template = "/v1/{instance_partition.name}";
 
+                let _ = Some(&mut req)
+                    .and_then(|m| m.instance_partition.as_mut())
+                    .map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template)))
@@ -1494,6 +1518,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1509,6 +1534,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 let path_template = "/v1/{name}:move";
 
                 let resource_name = format!("//spanner.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/src/generated/storagetransfer/v1/src/transport.rs
+++ b/src/generated/storagetransfer/v1/src/transport.rs
@@ -160,6 +160,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_job_name = try_match(
@@ -172,6 +173,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
                 let path = format!("/v1/{}", var_job_name,);
                 let path_template = "/v1/{job_name}";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.job_name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template)))
@@ -338,6 +340,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -350,6 +353,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
                 let path = format!("/v1/{}:pause", var_name,);
                 let path_template = "/v1/{name}:pause";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -408,6 +412,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -420,6 +425,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
                 let path = format!("/v1/{}:resume", var_name,);
                 let path_template = "/v1/{name}:resume";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -478,6 +484,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_job_name = try_match(
@@ -490,6 +497,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
                 let path = format!("/v1/{}:run", var_job_name,);
                 let path_template = "/v1/{job_name}:run";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.job_name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))
@@ -1082,6 +1090,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1094,6 +1103,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
                 let path = format!("/v1/{}:cancel", var_name,);
                 let path_template = "/v1/{name}:cancel";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template)))

--- a/src/pubsub/src/generated/gapic/transport.rs
+++ b/src/pubsub/src/generated/gapic/transport.rs
@@ -56,6 +56,7 @@ impl super::stub::TopicAdmin for TopicAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -70,6 +71,7 @@ impl super::stub::TopicAdmin for TopicAdmin {
                 let path = format!("/v1/{}", var_name,);
                 let path_template = "/v1/{name}";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PUT, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PUT, path_template)))
@@ -122,6 +124,7 @@ impl super::stub::TopicAdmin for TopicAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_topic_name = try_match(
@@ -139,6 +142,9 @@ impl super::stub::TopicAdmin for TopicAdmin {
                 let path = format!("/v1/{}", var_topic_name,);
                 let path_template = "/v1/{topic.name}";
 
+                let _ = Some(&mut req)
+                    .and_then(|m| m.topic.as_mut())
+                    .map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template)))
@@ -633,6 +639,7 @@ impl super::stub::SubscriptionAdmin for SubscriptionAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -647,6 +654,7 @@ impl super::stub::SubscriptionAdmin for SubscriptionAdmin {
                 let path = format!("/v1/{}", var_name,);
                 let path_template = "/v1/{name}";
 
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PUT, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PUT, path_template)))
@@ -767,6 +775,7 @@ impl super::stub::SubscriptionAdmin for SubscriptionAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_subscription_name = try_match(
@@ -784,6 +793,9 @@ impl super::stub::SubscriptionAdmin for SubscriptionAdmin {
                 let path = format!("/v1/{}", var_subscription_name,);
                 let path_template = "/v1/{subscription.name}";
 
+                let _ = Some(&mut req)
+                    .and_then(|m| m.subscription.as_mut())
+                    .map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template)))
@@ -973,6 +985,7 @@ impl super::stub::SubscriptionAdmin for SubscriptionAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_subscription = try_match(
@@ -988,6 +1001,7 @@ impl super::stub::SubscriptionAdmin for SubscriptionAdmin {
                 let path_template = "/v1/{subscription}:modifyPushConfig";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_subscription,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.subscription));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1175,6 +1189,7 @@ impl super::stub::SubscriptionAdmin for SubscriptionAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1190,6 +1205,7 @@ impl super::stub::SubscriptionAdmin for SubscriptionAdmin {
                 let path_template = "/v1/{name}";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PUT, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PUT, path_template, resource_name)))
@@ -1243,6 +1259,7 @@ impl super::stub::SubscriptionAdmin for SubscriptionAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template) = None
             .or_else(|| {
                 let var_snapshot_name = try_match(
@@ -1260,6 +1277,9 @@ impl super::stub::SubscriptionAdmin for SubscriptionAdmin {
                 let path = format!("/v1/{}", var_snapshot_name,);
                 let path_template = "/v1/{snapshot.name}";
 
+                let _ = Some(&mut req)
+                    .and_then(|m| m.snapshot.as_mut())
+                    .map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::PATCH, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::PATCH, path_template)))
@@ -1389,6 +1409,7 @@ impl super::stub::SubscriptionAdmin for SubscriptionAdmin {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_subscription = try_match(
@@ -1404,6 +1425,7 @@ impl super::stub::SubscriptionAdmin for SubscriptionAdmin {
                 let path_template = "/v1/{subscription}:seek";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_subscription,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.subscription));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1746,6 +1768,7 @@ impl super::stub::SchemaService for SchemaService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1761,6 +1784,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path_template = "/v1/{name}:commit";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -1814,6 +1838,7 @@ impl super::stub::SchemaService for SchemaService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
@@ -1829,6 +1854,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path_template = "/v1/{name}:rollback";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_name,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.name));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2025,6 +2051,7 @@ impl super::stub::SchemaService for SchemaService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2035,6 +2062,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path_template = "/v1/{parent}/schemas:validate";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2083,6 +2111,7 @@ impl super::stub::SchemaService for SchemaService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
@@ -2093,6 +2122,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path_template = "/v1/{parent}/schemas:validateMessage";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_parent,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.parent));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2141,6 +2171,7 @@ impl super::stub::SchemaService for SchemaService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2156,6 +2187,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2174,6 +2206,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2192,6 +2225,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2210,6 +2244,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path_template = "/v1/{resource}:setIamPolicy";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2523,6 +2558,7 @@ impl super::stub::SchemaService for SchemaService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
+        let mut req = req;
         let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
@@ -2538,6 +2574,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2556,6 +2593,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2574,6 +2612,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -2592,6 +2631,7 @@ impl super::stub::SchemaService for SchemaService {
                 let path_template = "/v1/{resource}:testIamPermissions";
 
                 let resource_name = format!("//pubsub.googleapis.com/{}", var_resource,);
+                let _ = Some(&mut req).map(|m| std::mem::take(&mut m.resource));
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))

--- a/tests/integration/tests/requests.rs
+++ b/tests/integration/tests/requests.rs
@@ -23,7 +23,23 @@ mod requests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn post_with_empty_body() -> anyhow::Result<()> {
-        let server = start();
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(all_of![
+                request::method("POST"),
+                request::path(matches("^/ui/")),
+            ])
+            .times(0) // should not be called
+            .respond_with(json_encoded(json! {"missing content-length"})),
+        );
+        server.expect(
+            Expectation::matching(all_of![
+                request::method("POST"),
+                request::path(matches("^/ui/")),
+                request::headers(contains(key("content-length"))),
+            ])
+            .respond_with(json_encoded(json!({}))),
+        );
         let endpoint = server.url_str("/ui");
 
         let client = PredictionService::builder()
@@ -40,27 +56,48 @@ mod requests {
         Ok(())
     }
 
-    fn start() -> Server {
+    // This is a regression test for [#6515]
+    //
+    // The EmbedContent RPC is defined as follows:
+    //
+    // ```
+    // rpc EmbedContent(EmbedContentRequest) returns (EmbedContentResponse) {
+    //   option (google.api.http) = {
+    //     post: "/v1/{model=projects/*/locations/*/publishers/*/models/*}:embedContent"
+    //     body: "*"
+    //   };
+    //   option (google.api.method_signature) = "model,content";
+    // }
+    // ```
+    //
+    // We want to ensure that the `model` field in the path is not also
+    // serialized in the request body.
+    //
+    // [#6515]: https://github.com/googleapis/google-cloud-rust/issues/6515
+    #[tokio::test(flavor = "multi_thread")]
+    async fn path_variables_not_in_full_body() -> anyhow::Result<()> {
         let server = Server::run();
-
         server.expect(
             Expectation::matching(all_of![
                 request::method("POST"),
                 request::path(matches("^/ui/")),
-            ])
-            .times(0) // should not be called
-            .respond_with(json_encoded(json! {"missing content-length"})),
-        );
-
-        server.expect(
-            Expectation::matching(all_of![
-                request::method("POST"),
-                request::path(matches("^/ui/")),
-                request::headers(contains(key("content-length"))),
+                request::body(json_decoded(eq(json!({})))),
             ])
             .respond_with(json_encoded(json!({}))),
         );
+        let endpoint = server.url_str("/ui");
 
-        server
+        let client = PredictionService::builder()
+            .with_endpoint(&endpoint)
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+
+        client
+            .embed_content()
+            .set_model("projects/test-project/locations/global/publishers/google/models/gemini-embedding-2")
+            .send()
+            .await?;
+        Ok(())
     }
 }


### PR DESCRIPTION
Omit path variables from the body of requests.

On testing: I opted for a fake HTTP server. While I did verify the RPC works against prod, I think the fake server is better for the CI than a live test hitting prod.

Fixes #6515 

Corresponds to librarian changes in https://github.com/googleapis/librarian/pull/7378