### PR TITLE
impl(bigquery): dry run queries should be routed to jobs.insert

### DIFF
--- a/src/bigquery/examples/src/query/dry_run.rs
+++ b/src/bigquery/examples/src/query/dry_run.rs
@@ -18,7 +18,7 @@ use google_cloud_bigquery::client::BigQuery;
 pub async fn sample(project_id: &str) -> anyhow::Result<()> {
     let client = BigQuery::builder().build().await?;
 
-    let complete_query = client
+    let query = client
         .query(
             "SELECT \
         name FROM `bigquery-public-data.usa_names.usa_1910_2013` \
@@ -28,11 +28,15 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .with_project_id(project_id)
         .set_dry_run(true)
         .set_location("US")
-        .until_done()
+        .send()
         .await?;
 
-    let bytes = complete_query.metadata().total_bytes_processed.unwrap_or(0);
+    let bytes = query.metadata().total_bytes_processed.unwrap_or(0);
     println!("This query will process {bytes} bytes.");
+
+    let stats = query.metadata().statistics.as_ref();
+    println!("Job Statistics: {stats:?}");
+    
     Ok(())
 }
 // [END bigquery_query_dry_run]

--- a/src/bigquery/examples/src/query/dry_run.rs
+++ b/src/bigquery/examples/src/query/dry_run.rs
@@ -36,7 +36,7 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
 
     let stats = query.metadata().statistics.as_ref();
     println!("Job Statistics: {stats:?}");
-    
+
     Ok(())
 }
 // [END bigquery_query_dry_run]

--- a/src/bigquery/src/query/builder.rs
+++ b/src/bigquery/src/query/builder.rs
@@ -340,6 +340,8 @@ mod tests {
                 .set_status(JobStatus::new().set_state("DONE"));
             Ok(google_cloud_gax::response::Response::from(job))
         });
+        mock.expect_query().never();
+
         let job_service = create_job_service(mock);
 
         let query_builder = Query::new(job_service, "SELECT 1".to_string())
@@ -362,6 +364,8 @@ mod tests {
                 QueryResponse::new().set_query_id("some_query_id"),
             ))
         });
+        mock.expect_insert_job().never();
+
         let job_service = create_job_service(mock);
         let query_builder =
             Query::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");

--- a/src/bigquery/src/query/execution.rs
+++ b/src/bigquery/src/query/execution.rs
@@ -150,8 +150,15 @@ impl RetryContext {
         }
     }
 
+    /// Returns true if the query should use the jobs.insert API.
+    fn force_job_path(&self) -> bool {
+        // jobs.query doesn't return full statistics information, so we route to jobs.insert
+        let dry_run = self.template.request.dry_run;
+        self.template.request.force_job_path() || dry_run
+    }
+
     async fn execute_once(&self, project_id: &str) -> Result<QueryHandle> {
-        if self.template.request.force_job_path() {
+        if self.force_job_path() {
             self.execute_jobs_insert(project_id).await
         } else {
             self.execute_jobs_query(project_id).await
@@ -404,6 +411,47 @@ mod tests {
 
         assert_eq!(query.completed, completed);
         assert_eq!(query.metadata.job_reference, Some(job_ref));
+        Ok(())
+    }
+
+    #[test_case(true, "insert-job"; "dry_run routes to jobs.insert")]
+    #[test_case(false, "query-job"; "non dry_run routes to jobs.query")]
+    #[tokio::test]
+    async fn test_dry_run_routing(dry_run: bool, expected_job_id: &'static str) -> TestResult {
+        let mut mock = MockJobService::new();
+        if dry_run {
+            mock.expect_insert_job().returning(move |req, _| {
+                let job_config = req.job.as_ref().unwrap().configuration.as_ref().unwrap();
+                assert_eq!(job_config.dry_run, Some(wkt::BoolValue::from(true)));
+                let job =
+                    Job::new().set_job_reference(JobReference::new().set_job_id(expected_job_id));
+                Ok(Response::from(job))
+            });
+            mock.expect_query().never();
+        } else {
+            mock.expect_query().returning(move |req, _| {
+                let query_req = req.query_request.as_ref().unwrap();
+                assert!(!query_req.dry_run);
+                let res = QueryResponse::new()
+                    .set_job_reference(JobReference::new().set_job_id(expected_job_id));
+                Ok(Response::from(res))
+            });
+            mock.expect_insert_job().never();
+        }
+
+        let job_service = create_job_service(mock);
+        let query = Query::new(job_service, "SELECT 1".to_string())
+            .with_project_id("my-project")
+            .set_dry_run(dry_run);
+
+        let retry_ctx = RetryContext::new(query);
+        assert_eq!(retry_ctx.force_job_path(), dry_run);
+
+        let handle = retry_ctx.execute_once("my-project").await?;
+        assert_eq!(
+            handle.metadata.job_reference.unwrap().job_id,
+            expected_job_id
+        );
         Ok(())
     }
 }

--- a/src/bigquery/src/query/execution.rs
+++ b/src/bigquery/src/query/execution.rs
@@ -414,44 +414,55 @@ mod tests {
         Ok(())
     }
 
-    #[test_case(true, "insert-job"; "dry_run routes to jobs.insert")]
-    #[test_case(false, "query-job"; "non dry_run routes to jobs.query")]
     #[tokio::test]
-    async fn test_dry_run_routing(dry_run: bool, expected_job_id: &'static str) -> TestResult {
+    async fn test_dry_run_routes_to_jobs_insert() -> TestResult {
         let mut mock = MockJobService::new();
-        if dry_run {
-            mock.expect_insert_job().returning(move |req, _| {
-                let job_config = req.job.as_ref().unwrap().configuration.as_ref().unwrap();
-                assert_eq!(job_config.dry_run, Some(wkt::BoolValue::from(true)));
-                let job =
-                    Job::new().set_job_reference(JobReference::new().set_job_id(expected_job_id));
-                Ok(Response::from(job))
-            });
-            mock.expect_query().never();
-        } else {
-            mock.expect_query().returning(move |req, _| {
-                let query_req = req.query_request.as_ref().unwrap();
-                assert!(!query_req.dry_run);
-                let res = QueryResponse::new()
-                    .set_job_reference(JobReference::new().set_job_id(expected_job_id));
-                Ok(Response::from(res))
-            });
-            mock.expect_insert_job().never();
-        }
+        mock.expect_insert_job().returning(|req, _| {
+            let job_config = req.job.as_ref().unwrap().configuration.as_ref().unwrap();
+            assert_eq!(job_config.dry_run, Some(wkt::BoolValue::from(true)));
+            let job = Job::new().set_job_reference(JobReference::new().set_job_id("insert-job"));
+            Ok(Response::from(job))
+        });
+        mock.expect_query().never();
 
         let job_service = create_job_service(mock);
         let query = Query::new(job_service, "SELECT 1".to_string())
             .with_project_id("my-project")
-            .set_dry_run(dry_run);
+            .set_dry_run(true);
 
         let retry_ctx = RetryContext::new(query);
-        assert_eq!(retry_ctx.force_job_path(), dry_run);
+        assert!(retry_ctx.force_job_path(), "Dry run should force job path");
 
         let handle = retry_ctx.execute_once("my-project").await?;
-        assert_eq!(
-            handle.metadata.job_reference.unwrap().job_id,
-            expected_job_id
+        assert_eq!(handle.metadata.job_reference.unwrap().job_id, "insert-job");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_non_dry_run_routes_to_jobs_query() -> TestResult {
+        let mut mock = MockJobService::new();
+        mock.expect_query().returning(|req, _| {
+            let query_req = req.query_request.as_ref().unwrap();
+            assert!(!query_req.dry_run);
+            let res =
+                QueryResponse::new().set_job_reference(JobReference::new().set_job_id("query-job"));
+            Ok(Response::from(res))
+        });
+        mock.expect_insert_job().never();
+
+        let job_service = create_job_service(mock);
+        let query = Query::new(job_service, "SELECT 1".to_string())
+            .with_project_id("my-project")
+            .set_dry_run(false);
+
+        let retry_ctx = RetryContext::new(query);
+        assert!(
+            !retry_ctx.force_job_path(),
+            "Non-dry run should not force job path"
         );
+
+        let handle = retry_ctx.execute_once("my-project").await?;
+        assert_eq!(handle.metadata.job_reference.unwrap().job_id, "query-job");
         Ok(())
     }
 }


### PR DESCRIPTION
`jobs.query` don't provide full job statistics, so routing to `jobs.insert` is more useful. Also, since dry run queries don't have queries results or are marked as complete, we change examples to show just using a `Query` handle, not `until_done` or a `CompleteQuery`. Right now calling `until_done` it's going to throw a RPC Binding Error (empty job_id), but will eval if worth it introducing a new `QueryError::DryRunQuery`

Supersedes https://github.com/googleapis/google-cloud-rust/pull/6508