### PR TITLE
fix(bigquery): preserve write ordering

### DIFF
--- a/src/bigquery/src/write/append_builder.rs
+++ b/src/bigquery/src/write/append_builder.rs
@@ -84,12 +84,27 @@ impl AppendWithOffset {
     /// ```
     pub fn send(self) -> AppendFuture {
         let (tx, rx) = oneshot::channel();
-
+        let (resp_tx, resp_rx) = oneshot::channel();
+        let req = match self.req.to_proto().map_err(Error::deser) {
+            Ok(req) => req,
+            Err(e) => {
+                let _ = tx.send(Err(e.into()));
+                return AppendFuture::new(rx);
+            }
+        };
+        let write = WriteRequest { req, resp_tx };
+        let _ = self.req_tx.send(write);
         tokio::spawn(async move {
-            let res = send_append_request(self.req_tx, self.req).await;
+            let res = async {
+                let resp = resp_rx
+                    .await
+                    .map_err(|_| AppendError::UnexpectedEndOfStream)??;
+                let resp = resp.cnv().map_err(Error::ser)?;
+                to_result(resp)
+            }
+            .await;
             let _ = tx.send(res);
         });
-
         AppendFuture::new(rx)
     }
 }
@@ -99,22 +114,6 @@ impl AppendWithOffset {
 pub struct Append {
     req_tx: mpsc::UnboundedSender<WriteRequest>,
     pub(crate) req: AppendRowsRequest,
-}
-
-/// Executes the network transmission and underlying proto translation for an `AppendRowsRequest`.
-pub(crate) async fn send_append_request(
-    req_tx: mpsc::UnboundedSender<WriteRequest>,
-    req: AppendRowsRequest,
-) -> AppendResult<AppendResponse> {
-    let (resp_tx, resp_rx) = oneshot::channel();
-    let req = req.to_proto().map_err(Error::deser)?;
-    let write = WriteRequest { req, resp_tx };
-    let _ = req_tx.send(write);
-    let resp = resp_rx
-        .await
-        .map_err(|_| AppendError::UnexpectedEndOfStream)??;
-    let resp = resp.cnv().map_err(Error::ser)?;
-    to_result(resp)
 }
 
 impl Append {
@@ -145,7 +144,15 @@ impl Append {
     /// }
     /// ```
     pub async fn send(self) -> AppendResult<AppendResponse> {
-        send_append_request(self.req_tx, self.req).await
+        let (resp_tx, resp_rx) = oneshot::channel();
+        let req = self.req.to_proto().map_err(Error::deser)?;
+        let write = WriteRequest { req, resp_tx };
+        let _ = self.req_tx.send(write);
+        let resp = resp_rx
+            .await
+            .map_err(|_| AppendError::UnexpectedEndOfStream)??;
+        let resp = resp.cnv().map_err(Error::ser)?;
+        to_result(resp)
     }
 }
 
@@ -346,6 +353,30 @@ mod tests {
 
         let err = future.await.expect_err("should return an error");
         assert!(matches!(err, AppendError::RowErrors(_)));
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn synchronous_queueing() -> anyhow::Result<()> {
+        const NUM_WRITES: i64 = 1000;
+        let (req_tx, mut req_rx) = mpsc::unbounded_channel();
+        let write_handle = tokio::spawn(async move {
+            let mut writes = tokio::task::JoinSet::new();
+            for i in 0..NUM_WRITES {
+                writes.spawn(
+                    AppendWithOffset::new(req_tx.clone(), AppendRowsRequest::new())
+                        .set_offset(i)
+                        .send(),
+                );
+            }
+            let _ = writes.join_all().await;
+        });
+
+        for i in 0..NUM_WRITES {
+            let write = req_rx.recv().await.expect("should receive request");
+            assert_eq!(write.req.offset, Some(i), "received out of order write");
+        }
+        write_handle.await?;
         Ok(())
     }
 


### PR DESCRIPTION
For ordered writes (streams that support offsets), we need to forward the write request in the current execution context before spawning a task to await the response asynchronously. Otherwise, spawning the tasks will race and we will send the requests to the server out of order, leading to unnecessary errors.

Fixes #6524 