### PR TITLE
chore: update Rust toolchain to 1.98

### DIFF
--- a/.gcb/complex.yaml
+++ b/.gcb/complex.yaml
@@ -58,7 +58,7 @@ substitutions:
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'
   _POOL_REGION: us-central1
   _POOL_ID: rust-sdk-pool
-  _RUST_VERSION: '1.97'
+  _RUST_VERSION: '1.98'
 # The workspace-minimal-versions build can take over 1h (the default). This is
 # harmless (other than wasting CPU time) for other builds.
 timeout: 7200s

--- a/.gcb/coverage.yaml
+++ b/.gcb/coverage.yaml
@@ -85,7 +85,7 @@ substitutions:
   _CODECOV_SHA256: '80b5e6f898d6080be523f53ff169702a008a1c91b20c63c49df1175ed794d822'
   _POOL_REGION: us-central1
   _POOL_ID: rust-sdk-pool
-  _RUST_VERSION: '1.97'
+  _RUST_VERSION: '1.98'
 availableSecrets:
   secretManager:
     - versionName: projects/${PROJECT_ID}/secrets/CODECOV_TOKEN/versions/latest

--- a/.gcb/cryptoproviders.yaml
+++ b/.gcb/cryptoproviders.yaml
@@ -69,7 +69,7 @@ steps:
       done
 
 substitutions:
-  _RUST_VERSION: '1.97'
+  _RUST_VERSION: '1.98'
   _SCCACHE_VERSION: 'v0.12.0'
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'
   _POOL_REGION: us-central1

--- a/.gcb/format.yaml
+++ b/.gcb/format.yaml
@@ -182,7 +182,7 @@ substitutions:
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'
   _POOL_REGION: us-central1
   _POOL_ID: rust-sdk-pool
-  _RUST_VERSION: '1.97'
+  _RUST_VERSION: '1.98'
   _GO_VERSION: '1.25.6'
   _PYTHON_VERSION: '3.14'
   _TERRAFORM_VERSION: '1.14.0'

--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -78,7 +78,7 @@ steps:
       cargo test --features run-integration-tests --tests
 
 substitutions:
-  _RUST_VERSION: '1.97'
+  _RUST_VERSION: '1.98'
   _SCCACHE_VERSION: 'v0.12.0'
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'
   _POOL_REGION: us-central1

--- a/.gcb/scripts/semver-checks.sh
+++ b/.gcb/scripts/semver-checks.sh
@@ -15,7 +15,7 @@
 
 set -ev
 
-cargo install --locked cargo-semver-checks@0.46.0
+cargo install --locked cargo-semver-checks@0.50.0
 cargo version
 rustup show active-toolchain -v
 

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -22,7 +22,7 @@ on:
   release:
     types: [published]
 env:
-  GHA_RUST_VERSIONS: '{ "rust:current": "1.97" }'
+  GHA_RUST_VERSIONS: '{ "rust:current": "1.98" }'
   GHA_GO_VERSIONS: '{ "go:current": "1.25.6" }'
   # Define the unstable flags once
   UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_trust_boundaries --cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming --cfg google_cloud_unstable_tracing --cfg google_cloud_unstable_gapic_streaming'

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -38,7 +38,7 @@ tools:
     - name: cargo-minimal-versions
       version: 0.1.37
     - name: cargo-semver-checks
-      version: 0.46.0
+      version: 0.50.0
     - name: cargo-workspaces
       version: 0.4.0
     - name: taplo-cli

--- a/src/auth/.gcb/integration.yaml
+++ b/src/auth/.gcb/integration.yaml
@@ -66,6 +66,6 @@ steps:
         --features run-byoid-integration-tests \
         --package integration-tests-auth
 substitutions:
-  _RUST_VERSION: '1.97'
+  _RUST_VERSION: '1.98'
   _SCCACHE_VERSION: 'v0.12.0'
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'

--- a/src/pubsub/src/publisher/batch.rs
+++ b/src/pubsub/src/publisher/batch.rs
@@ -90,7 +90,7 @@ impl Batch {
     ) {
         let batch_to_send = Self {
             initial_size: self.initial_size,
-            messages: self.messages.drain(..).collect(),
+            messages: std::mem::take(&mut self.messages),
             messages_byte_size: self.messages_byte_size,
             batching_options: self.batching_options.clone(),
         };


### PR DESCRIPTION
Updates the stable Rust compiler version from `1.97` to `1.98` across GitHub Actions and Google Cloud Build configurations.
