### PR TITLE
refactor: adopt let_chains in handwritten crates

### DIFF
--- a/src/auth/src/credentials/external_account_sources/aws_sourced.rs
+++ b/src/auth/src/credentials/external_account_sources/aws_sourced.rs
@@ -420,10 +420,9 @@ impl AwsSourcedCredentials {
         client: &Client,
         imdsv2_token: Option<&str>,
     ) -> Result<AwsSecurityCredentials> {
-        if let (Ok(ak), Ok(sk)) = (
-            std::env::var(AWS_ACCESS_KEY_ID),
-            std::env::var(AWS_SECRET_ACCESS_KEY),
-        ) {
+        if let Ok(ak) = std::env::var(AWS_ACCESS_KEY_ID)
+            && let Ok(sk) = std::env::var(AWS_SECRET_ACCESS_KEY)
+        {
             return Ok(AwsSecurityCredentials {
                 access_key_id: ak,
                 secret_access_key: sk,

--- a/src/auth/src/credentials/external_account_sources/executable_sourced.rs
+++ b/src/auth/src/credentials/external_account_sources/executable_sourced.rs
@@ -100,11 +100,10 @@ impl SubjectTokenProvider for ExecutableSourcedCredentials {
     type Error = CredentialsError;
 
     async fn subject_token(&self) -> Result<SubjectToken> {
-        if let Some(output_file) = self.output_file.clone() {
-            let token = Self::from_output_file(output_file).await;
-            if let Ok(token) = token {
-                return Ok(SubjectTokenBuilder::new(token).build());
-            }
+        if let Some(output_file) = self.output_file.clone()
+            && let Ok(token) = Self::from_output_file(output_file).await
+        {
+            return Ok(SubjectTokenBuilder::new(token).build());
         }
         let token =
             Self::from_command(self.command.clone(), self.args.clone(), self.timeout).await?;

--- a/src/auth/src/credentials/impersonated.rs
+++ b/src/auth/src/credentials/impersonated.rs
@@ -648,12 +648,10 @@ impl Builder {
     pub fn build_signer(self) -> BuildResult<crate::signer::Signer> {
         let iam_endpoint = self.iam_endpoint_override.clone();
         let source = self.source.clone();
-        if let BuilderSource::FromJson(json) = source {
-            // try to build service account signer from json
-            let signer = build_signer_from_json(json.clone())?;
-            if let Some(signer) = signer {
-                return Ok(signer);
-            }
+        if let BuilderSource::FromJson(json) = source
+            && let Some(signer) = build_signer_from_json(json.clone())?
+        {
+            return Ok(signer);
         }
         let impersonation_url = self.resolve_impersonation_url()?;
         let client_email = impersonation_url.client_email()?;

--- a/src/auth/src/credentials/internal/sts_exchange.rs
+++ b/src/auth/src/credentials/internal/sts_exchange.rs
@@ -183,8 +183,8 @@ pub struct ClientAuthentication {
 impl ClientAuthentication {
     /// Add authentication to a Secure Token Service exchange request.
     fn inject_auth(&self, headers: &mut http::HeaderMap) -> Result<()> {
-        if let (Some(client_id), Some(client_secret)) =
-            (self.client_id.clone(), self.client_secret.clone())
+        if let Some(client_id) = &self.client_id
+            && let Some(client_secret) = &self.client_secret
         {
             let plain_header = format!("{client_id}:{client_secret}");
             let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(plain_header);

--- a/src/bigquery/src/query/execution.rs
+++ b/src/bigquery/src/query/execution.rs
@@ -95,8 +95,10 @@ impl InsertJobExecutor {
             .await?;
 
         let job_status = res.status.as_ref();
-        if job_status.and_then(|s| s.error_result.as_ref()).is_some() {
-            let errors = job_status.map(|s| s.errors.clone()).unwrap_or_default();
+        if let Some(status) = job_status
+            && status.error_result.is_some()
+        {
+            let errors = status.errors.clone();
             return Err(QueryError::JobFailed { errors });
         }
 

--- a/src/bigquery/src/query/query_handle.rs
+++ b/src/bigquery/src/query/query_handle.rs
@@ -192,7 +192,7 @@ impl Query {
                 retry_context,
             } = self;
 
-            if let (true, Some(cached_rows)) = (completed, cached_rows) {
+            if completed && let Some(cached_rows) = cached_rows {
                 return Ok(CompleteQuery::from_query_metadata(
                     job_service,
                     metadata,

--- a/src/gax-internal/src/observability/propagation.rs
+++ b/src/gax-internal/src/observability/propagation.rs
@@ -39,7 +39,9 @@ pub(crate) struct HeaderInjector<'a>(pub &'a mut HeaderMap);
 
 impl<'a> Injector for HeaderInjector<'a> {
     fn set(&mut self, key: &str, value: String) {
-        if let (Ok(key), Ok(value)) = (HeaderName::from_str(key), HeaderValue::from_str(&value)) {
+        if let Ok(key) = HeaderName::from_str(key)
+            && let Ok(value) = HeaderValue::from_str(&value)
+        {
             self.0.insert(key, value);
         }
     }

--- a/src/lro/src/internal/aip151.rs
+++ b/src/lro/src/internal/aip151.rs
@@ -288,11 +288,10 @@ where
     async fn poll(&mut self) -> Option<PollingResult<ResponseType, MetadataType>> {
         if let Some(start) = self.start.take() {
             let result = start().await;
-            if let Ok(ref op) = result {
-                let name = op.name();
-                if let Some(recorder) = LroRecorder::current() {
-                    recorder.record_destination_id(&name);
-                }
+            if let Ok(ref op) = result
+                && let Some(recorder) = LroRecorder::current()
+            {
+                recorder.record_destination_id(&op.name());
             }
             let (op, poll) = crate::details::handle_start(result);
             self.operation = op;
@@ -303,7 +302,9 @@ where
             let result = (self.query)(name.clone()).await;
             let (op, poll) =
                 crate::details::handle_poll(self.error_policy.clone(), &self.state, name, result);
-            if let (Some(next_name), Some(recorder)) = (&op, LroRecorder::current()) {
+            if let Some(next_name) = &op
+                && let Some(recorder) = LroRecorder::current()
+            {
                 recorder.record_destination_id(next_name);
             }
             self.operation = op;

--- a/src/lro/src/internal/discovery.rs
+++ b/src/lro/src/internal/discovery.rs
@@ -146,11 +146,11 @@ where
     async fn poll(&mut self) -> Option<PollingResult<O, O>> {
         if let Some(start) = self.start.take() {
             let result = start.await;
-            if let Ok(ref op) = result {
-                let name = op.name();
-                if let (Some(name), Some(recorder)) = (name, LroRecorder::current()) {
-                    recorder.record_destination_id(name);
-                }
+            if let Ok(ref op) = result
+                && let Some(name) = op.name()
+                && let Some(recorder) = LroRecorder::current()
+            {
+                recorder.record_destination_id(name);
             }
             let (op, poll) = self::handle_start(result);
             self::maybe_record_completed_error(&poll);
@@ -162,7 +162,9 @@ where
             let result = (self.query)(name.clone()).await;
             let (op, poll) =
                 self::handle_poll(self.error_policy.clone(), &self.state, name, result);
-            if let (Some(next_name), Some(recorder)) = (&op, LroRecorder::current()) {
+            if let Some(next_name) = &op
+                && let Some(recorder) = LroRecorder::current()
+            {
                 recorder.record_destination_id(next_name);
             }
             self::maybe_record_completed_error(&poll);

--- a/src/spanner/src/omni.rs
+++ b/src/spanner/src/omni.rs
@@ -193,8 +193,8 @@ impl TlsConfig {
         } else {
             tls = tls.with_enabled_roots();
         }
-        if let (Some(client_certificate), Some(client_private_key)) =
-            (&self.client_certificate, &self.client_private_key)
+        if let Some(client_certificate) = &self.client_certificate
+            && let Some(client_private_key) = &self.client_private_key
         {
             let identity = Identity::from_pem(client_certificate, client_private_key);
             tls = tls.identity(identity);

--- a/src/spanner/src/partitioned_dml_transaction.rs
+++ b/src/spanner/src/partitioned_dml_transaction.rs
@@ -239,9 +239,7 @@ async fn extract_lower_bound_update_count_from_stream(
             .take()
             .and_then(|cache_update| cache_update.cnv().ok());
         client.observe_cache_update(cache_update);
-        if let Some(stats) = partial_result_set.stats
-            && let Some(RowCountLowerBound(val)) = stats.row_count
-        {
+        if let Some(RowCountLowerBound(val)) = partial_result_set.stats.and_then(|s| s.row_count) {
             lower_bound = Some(val);
         }
     }

--- a/src/spanner/src/partitioned_dml_transaction.rs
+++ b/src/spanner/src/partitioned_dml_transaction.rs
@@ -239,7 +239,9 @@ async fn extract_lower_bound_update_count_from_stream(
             .take()
             .and_then(|cache_update| cache_update.cnv().ok());
         client.observe_cache_update(cache_update);
-        if let Some(RowCountLowerBound(val)) = partial_result_set.stats.and_then(|s| s.row_count) {
+        if let Some(stats) = partial_result_set.stats
+            && let Some(RowCountLowerBound(val)) = stats.row_count
+        {
             lower_bound = Some(val);
         }
     }

--- a/src/spanner/src/precommit.rs
+++ b/src/spanner/src/precommit.rs
@@ -33,7 +33,9 @@ impl PrecommitTokenTracker {
 
     /// Updates the tracker with an optional precommit token from a response.
     pub(crate) fn update(&self, token: Option<crate::model::MultiplexedSessionPrecommitToken>) {
-        if let (Some(token), Self::Track(tracker)) = (token, self) {
+        if let Some(token) = token
+            && let Self::Track(tracker) = self
+        {
             let mut guard = tracker.write().unwrap();
             if guard.as_ref().is_none_or(|c| c.seq_num < token.seq_num) {
                 *guard = Some(token);

--- a/src/spanner/src/routing/key_recipe/golden_tests.rs
+++ b/src/spanner/src/routing/key_recipe/golden_tests.rs
@@ -361,21 +361,28 @@ fn parse_test_block<'a, I: Iterator<Item = &'a str>>(
         } else if in_query_params && let Some(key_str) = extract_value(trimmed, "key:") {
             current_field_key = Some(key_str.to_string());
         } else if in_query_params && let Some(val_str) = extract_value(trimmed, "string_value:") {
-            if let (Some(params), Some(key)) = (query_params.as_mut(), current_field_key.take()) {
+            if let Some(params) = query_params.as_mut()
+                && let Some(key) = current_field_key.take()
+            {
                 params.insert(key, val_str.to_value());
             }
         } else if in_query_params && let Some(val_str) = extract_value(trimmed, "bool_value:") {
-            if let (Some(params), Some(key)) = (query_params.as_mut(), current_field_key.take()) {
+            if let Some(params) = query_params.as_mut()
+                && let Some(key) = current_field_key.take()
+            {
                 params.insert(key, (val_str == "true").to_value());
             }
         } else if in_query_params && let Some(val_str) = extract_value(trimmed, "number_value:") {
-            if let (Some(params), Some(key)) = (query_params.as_mut(), current_field_key.take())
+            if let Some(params) = query_params.as_mut()
+                && let Some(key) = current_field_key.take()
                 && let Ok(num) = val_str.parse::<f64>()
             {
                 params.insert(key, num.to_value());
             }
         } else if in_query_params && trimmed == "null_value: NULL_VALUE" {
-            if let (Some(params), Some(key)) = (query_params.as_mut(), current_field_key.take()) {
+            if let Some(params) = query_params.as_mut()
+                && let Some(key) = current_field_key.take()
+            {
                 params.insert(key, Value::null());
             }
         } else if let Some(start_string) = extract_value(trimmed, "start:") {
@@ -401,7 +408,7 @@ fn parse_test_block<'a, I: Iterator<Item = &'a str>>(
         }
     }
 
-    if let (true, Some(start_bytes)) = (is_point_key_or_query_or_mutation, start) {
+    if is_point_key_or_query_or_mutation && let Some(start_bytes) = start {
         Some(ParsedTest {
             values,
             query_params,

--- a/src/storage/src/storage/read_object/parse_http_response.rs
+++ b/src/storage/src/storage/read_object/parse_http_response.rs
@@ -58,7 +58,9 @@ pub fn object_highlights(generation: i64, headers: &HeaderMap) -> Result<ObjectH
 fn headers_to_metadata(headers: &HeaderMap) -> std::collections::HashMap<String, String> {
     let mut metadata = std::collections::HashMap::new();
     for (name, value) in headers.iter() {
-        if let (Some(key), Ok(val)) = (name.as_str().strip_prefix("x-goog-meta-"), value.to_str()) {
+        if let Some(key) = name.as_str().strip_prefix("x-goog-meta-")
+            && let Ok(val) = value.to_str()
+        {
             metadata
                 .entry(key.to_string())
                 .or_insert_with(|| val.to_string());

--- a/tests/o11y/src/auth.rs
+++ b/tests/o11y/src/auth.rs
@@ -103,10 +103,11 @@ async fn refresh_task(credentials: Credentials, tx: watch::Sender<Option<Metadat
             Ok(CacheableResource::New { entity_tag, data }) => {
                 let mut metadata = MetadataMap::new();
                 for (name, value) in data.iter() {
-                    if let (Ok(key), Ok(mut val)) = (
-                        tonic::metadata::MetadataKey::from_bytes(name.as_str().as_bytes()),
-                        tonic::metadata::MetadataValue::try_from(value.as_bytes()),
-                    ) {
+                    if let Ok(key) =
+                        tonic::metadata::MetadataKey::from_bytes(name.as_str().as_bytes())
+                        && let Ok(mut val) =
+                            tonic::metadata::MetadataValue::try_from(value.as_bytes())
+                    {
                         val.set_sensitive(value.is_sensitive());
                         metadata.insert(key, val);
                     } else {


### PR DESCRIPTION
Let chains were stabilized in Rust 1.88 and we now declare 1.90 as our MSRV.

Simplify nested pattern matches and tuple match constructs using let_chains across storage, auth, gax-internal, spanner, bigquery, and lro crates.

This flattens conditional logic when inspecting response headers, resolving external credentials, handling LRO polling states, and parsing telemetry metadata.