### PR TITLE
feat(bigquery): abstract attachable writers

### DIFF
--- a/src/bigquery/src/write/arrow.rs
+++ b/src/bigquery/src/write/arrow.rs
@@ -17,10 +17,12 @@ mod buffered;
 mod committed;
 mod default;
 mod pending;
+mod try_from_stream;
 mod writer_builder;
 
 pub use buffered::BufferedWriter;
 pub use committed::CommittedWriter;
 pub use default::DefaultWriter;
 pub use pending::PendingWriter;
+pub use try_from_stream::TryFromStream;
 pub use writer_builder::WriterBuilder;

--- a/src/bigquery/src/write/arrow/buffered.rs
+++ b/src/bigquery/src/write/arrow/buffered.rs
@@ -40,6 +40,7 @@ impl BufferedWriter {
         &self.inner.write_stream
     }
 
+    /// Append rows to the stream.
     pub fn append(&self, rows: ArrowRecordBatch) -> AppendWithOffset {
         AppendWithOffset::new(
             self.inner.runner.req_tx.clone(),

--- a/src/bigquery/src/write/arrow/buffered.rs
+++ b/src/bigquery/src/write/arrow/buffered.rs
@@ -35,6 +35,11 @@ impl BufferedWriter {
     }
 
     /// Append rows to the buffered stream.
+    /// Return the full resource name of the underlying write stream.
+    pub fn write_stream(&self) -> &str {
+        &self.inner.write_stream
+    }
+
     pub fn append(&self, rows: ArrowRecordBatch) -> AppendWithOffset {
         AppendWithOffset::new(
             self.inner.runner.req_tx.clone(),

--- a/src/bigquery/src/write/arrow/committed.rs
+++ b/src/bigquery/src/write/arrow/committed.rs
@@ -35,6 +35,11 @@ impl CommittedWriter {
     }
 
     /// Append rows to the stream.
+    /// Return the full resource name of the underlying write stream.
+    pub fn write_stream(&self) -> &str {
+        &self.inner.write_stream
+    }
+
     pub fn append(&self, rows: ArrowRecordBatch) -> AppendWithOffset {
         AppendWithOffset::new(
             self.inner.runner.req_tx.clone(),

--- a/src/bigquery/src/write/arrow/committed.rs
+++ b/src/bigquery/src/write/arrow/committed.rs
@@ -40,6 +40,7 @@ impl CommittedWriter {
         &self.inner.write_stream
     }
 
+    /// Append rows to the stream.
     pub fn append(&self, rows: ArrowRecordBatch) -> AppendWithOffset {
         AppendWithOffset::new(
             self.inner.runner.req_tx.clone(),

--- a/src/bigquery/src/write/arrow/pending.rs
+++ b/src/bigquery/src/write/arrow/pending.rs
@@ -37,6 +37,11 @@ impl PendingWriter {
     }
 
     /// Appends rows to the pending stream.
+    /// Returns the full resource name of the underlying write stream.
+    pub fn write_stream(&self) -> &str {
+        &self.inner.write_stream
+    }
+
     pub fn append(&self, rows: ArrowRecordBatch) -> AppendWithOffset {
         AppendWithOffset::new(
             self.inner.runner.req_tx.clone(),

--- a/src/bigquery/src/write/arrow/pending.rs
+++ b/src/bigquery/src/write/arrow/pending.rs
@@ -42,6 +42,7 @@ impl PendingWriter {
         &self.inner.write_stream
     }
 
+    /// Append rows to the stream.
     pub fn append(&self, rows: ArrowRecordBatch) -> AppendWithOffset {
         AppendWithOffset::new(
             self.inner.runner.req_tx.clone(),

--- a/src/bigquery/src/write/arrow/try_from_stream.rs
+++ b/src/bigquery/src/write/arrow/try_from_stream.rs
@@ -1,0 +1,60 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{BufferedWriter, CommittedWriter, PendingWriter};
+use crate::model::ArrowSchema;
+use crate::model::write_stream::Type;
+use crate::write::transport::Transport;
+use std::sync::Arc;
+
+mod private {
+    use super::*;
+    pub trait Sealed {}
+    impl Sealed for PendingWriter {}
+    impl Sealed for CommittedWriter {}
+    impl Sealed for BufferedWriter {}
+}
+
+/// A trait for strongly-typed stream writers that can be attached to an existing stream.
+pub trait TryFromStream: private::Sealed + Sized {
+    #[doc(hidden)]
+    const EXPECTED_TYPE: Type;
+
+    #[doc(hidden)]
+    fn build(inner: Arc<Transport>, write_stream: String, schema: ArrowSchema) -> Self;
+}
+
+impl TryFromStream for PendingWriter {
+    const EXPECTED_TYPE: Type = Type::Pending;
+
+    fn build(inner: Arc<Transport>, write_stream: String, schema: ArrowSchema) -> Self {
+        Self::new(inner, write_stream, schema)
+    }
+}
+
+impl TryFromStream for CommittedWriter {
+    const EXPECTED_TYPE: Type = Type::Committed;
+
+    fn build(inner: Arc<Transport>, write_stream: String, schema: ArrowSchema) -> Self {
+        Self::new(inner, write_stream, schema)
+    }
+}
+
+impl TryFromStream for BufferedWriter {
+    const EXPECTED_TYPE: Type = Type::Buffered;
+
+    fn build(inner: Arc<Transport>, write_stream: String, schema: ArrowSchema) -> Self {
+        Self::new(inner, write_stream, schema)
+    }
+}

--- a/src/bigquery/src/write/arrow/writer_builder.rs
+++ b/src/bigquery/src/write/arrow/writer_builder.rs
@@ -14,7 +14,7 @@
 
 use super::super::generated::gapic_storage::client::BigQueryWrite;
 use super::super::transport::Transport;
-use super::{BufferedWriter, CommittedWriter, DefaultWriter, PendingWriter};
+use super::{BufferedWriter, CommittedWriter, DefaultWriter, PendingWriter, TryFromStream};
 use crate::model::write_stream::Type;
 use crate::model::{ArrowSchema, WriteStream};
 use crate::{Error, Result};
@@ -172,6 +172,33 @@ impl WriterBuilder {
             self.schema,
         ))
     }
+
+    /// Attaches to an existing stream.
+    pub async fn attach<U: TryFromStream>(self, write_stream: impl Into<String>) -> Result<U> {
+        let write_stream = write_stream.into();
+        validate_stream(write_stream.as_str())?;
+
+        let client = BigQueryWrite::from_stub::<Transport>(self.inner.clone());
+        let stream = client
+            .get_write_stream()
+            .set_name(&write_stream)
+            .send()
+            .await?;
+
+        if stream.r#type != U::EXPECTED_TYPE {
+            let msg = format!(
+                "stream type mismatch. expected {:?}, got {:?}",
+                U::EXPECTED_TYPE,
+                stream.r#type
+            );
+            return Err(Error::io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                msg,
+            )));
+        }
+
+        Ok(U::build(self.inner, write_stream, self.schema))
+    }
 }
 
 fn validate_table(table: &str) -> Result<()> {
@@ -190,6 +217,32 @@ fn validate_table(table: &str) -> Result<()> {
                 segments,
                 "table",
                 "projects/*/datasets/*/tables/*",
+            );
+            Error::binding(BindingError {
+                paths: vec![builder.build()],
+            })
+        })
+        .map(|_| ())
+}
+
+fn validate_stream(stream: &str) -> Result<()> {
+    let segments = &[
+        Segment::Literal("projects/"),
+        Segment::SingleWildcard,
+        Segment::Literal("/datasets/"),
+        Segment::SingleWildcard,
+        Segment::Literal("/tables/"),
+        Segment::SingleWildcard,
+        Segment::Literal("/streams/"),
+        Segment::SingleWildcard,
+    ];
+    try_match(Some(stream), segments)
+        .ok_or_else(|| {
+            let builder = PathMismatchBuilder::default().maybe_add(
+                Some(stream),
+                segments,
+                "name",
+                "projects/*/datasets/*/tables/*/streams/*",
             );
             Error::binding(BindingError {
                 paths: vec![builder.build()],
@@ -364,6 +417,80 @@ mod tests {
             .await
             .expect_err("should fail locally on bad format");
         assert!(err.is_binding(), "{err:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn attach_success() -> anyhow::Result<()> {
+        use bigquery_grpc_mock::google::cloud::bigquery::storage::v1::WriteStream as MockWriteStream;
+        use bigquery_grpc_mock::{MockBigQueryWrite, start};
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_get_write_stream().return_once(|req| {
+            let req = req.into_inner();
+            assert_eq!(req.name, "projects/p/datasets/d/tables/t/streams/s");
+            Ok(gaxi::grpc::tonic::Response::new(MockWriteStream {
+                name: "projects/p/datasets/d/tables/t/streams/s".to_string(),
+                r#type: 1, // Type::Committed mapped purely for proto enum bounds
+                ..Default::default()
+            }))
+        });
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let transport = Arc::new(test_transport(endpoint).await?);
+        let schema = ArrowSchema::new().set_serialized_schema("test");
+        let builder = WriterBuilder::new(transport, schema.clone());
+        let writer: CommittedWriter = builder
+            .attach("projects/p/datasets/d/tables/t/streams/s")
+            .await?;
+        assert_eq!(
+            writer.inner.write_stream,
+            "projects/p/datasets/d/tables/t/streams/s"
+        );
+        assert_eq!(writer.inner.schema, schema);
+        Ok(())
+    }
+
+    #[test_case("projects/p")]
+    #[test_case("projects/p/tables/t")]
+    #[test_case("projects/p/datasets/d/tables/t")]
+    #[test_case("projects/p/datasets/d/tables/t/streams/")]
+    #[tokio::test]
+    async fn attach_bad_stream_format(stream: &str) -> anyhow::Result<()> {
+        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
+        let schema = ArrowSchema::new().set_serialized_schema("test");
+        let builder = WriterBuilder::new(transport, schema.clone());
+        let err = builder
+            .attach::<CommittedWriter>(stream)
+            .await
+            .expect_err("should fail locally on bad format");
+        assert!(err.is_binding(), "{err:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn attach_stream_type_mismatch() -> anyhow::Result<()> {
+        use bigquery_grpc_mock::google::cloud::bigquery::storage::v1::WriteStream as MockWriteStream;
+        use bigquery_grpc_mock::{MockBigQueryWrite, start};
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_get_write_stream().return_once(|req| {
+            let req = req.into_inner();
+            assert_eq!(req.name, "projects/p/datasets/d/tables/t/streams/s");
+            // Return buffered type (3) when they requested a CommittedWriter (1)
+            Ok(gaxi::grpc::tonic::Response::new(MockWriteStream {
+                name: "projects/p/datasets/d/tables/t/streams/s".to_string(),
+                r#type: 3,
+                ..Default::default()
+            }))
+        });
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let transport = Arc::new(test_transport(endpoint).await?);
+        let schema = ArrowSchema::new().set_serialized_schema("test");
+        let builder = WriterBuilder::new(transport, schema.clone());
+        let err = builder
+            .attach::<CommittedWriter>("projects/p/datasets/d/tables/t/streams/s")
+            .await
+            .expect_err("should return type mismatch error");
+        assert!(err.is_io(), "{err:?}");
+        assert!(err.to_string().contains("stream type mismatch"));
         Ok(())
     }
 }


### PR DESCRIPTION
Isolate the foundation to support stream attachment.

For https://github.com/googleapis/google-cloud-rust/issues/6405