### PR TITLE
chore: update librarian to v0.39.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.38.1-0.20260824162858-1baf7d92dfda
+version: v0.39.0
 repo: googleapis/google-cloud-rust
 sources:
   conformance:


### PR DESCRIPTION
Updates Librarian to v0.39.0 and regenerates crates.