### PR TITLE
chore(ci): add MSRV 1-year check to scheduled workflow

### DIFF
--- a/.github/workflows/rust-toolchain-check.yaml
+++ b/.github/workflows/rust-toolchain-check.yaml
@@ -84,3 +84,63 @@ jobs:
           else
             echo "Rust toolchain is up to date (${{ env.CURRENT_RUST_VERSION }})."
           fi
+
+      - name: Check for eligible MSRV bump
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          CURRENT_MSRV=$(grep -oP '(?<=rust-version = ")[0-9.]+' Cargo.toml)
+          CURRENT_MINOR=$(echo "${CURRENT_MSRV}" | cut -d. -f2)
+
+          ELIGIBLE_LINE=$(curl -sSL https://raw.githubusercontent.com/rust-lang/rust/master/RELEASES.md | \
+            grep -E 'Version 1\.[0-9]+\.[0-9]+ \([0-9]{4}-[0-9]{2}-[0-9]{2}\)' | \
+            awk -v cutoff="$(date -d '1 year ago' +%F)" '
+              match($0, /[0-9]{4}-[0-9]{2}-[0-9]{2}/) {
+                d = substr($0, RSTART, RLENGTH)
+                if (d >= cutoff) {
+                  last = $0
+                } else {
+                  print last
+                  found = 1
+                  exit
+                }
+              }
+              END {
+                if (!found && last) print last
+              }
+            ')
+          ELIGIBLE_MSRV=$(echo "${ELIGIBLE_LINE}" | grep -oP '(?<=Version )[0-9]+\.[0-9]+(\.[0-9]+)?')
+          ELIGIBLE_MINOR=$(echo "${ELIGIBLE_MSRV}" | cut -d. -f2)
+          ELIGIBLE_MAJOR_MINOR="1.${ELIGIBLE_MINOR}"
+
+          echo "Current configured MSRV: ${CURRENT_MSRV}"
+          echo "Eligible 1-year MSRV:    ${ELIGIBLE_MSRV}"
+
+          if [ "${ELIGIBLE_MINOR}" -gt "${CURRENT_MINOR}" ]; then
+            ISSUE_TITLE="Upgrade MSRV to ${ELIGIBLE_MSRV}"
+
+            cat << EOF > /tmp/msrv_issue_body.md
+          Rust ${ELIGIBLE_MSRV} is now eligible to become the new Minimum Supported Rust Version (MSRV) under the 1-year policy.
+
+          The current MSRV is configured in [Cargo.toml](https://github.com/googleapis/google-cloud-rust/blob/main/Cargo.toml) (${CURRENT_MSRV}).
+          There are other places in the repo that will also need to be updated. Searching for the number that is specified in \`rust-version\` should help you find them all (e.g. \`git grep "${CURRENT_MSRV}"\` or \`git grep "1.${CURRENT_MINOR}"\`).
+
+          Make any corresponding cleanups and submit a PR with the update.
+
+          cc @googleapis/cloud-sdk-rust-team
+          EOF
+            sed -i 's/^          //' /tmp/msrv_issue_body.md
+
+            # Check for an existing open issue with the same title to avoid duplicates
+            EXISTING_ISSUE=$(gh issue list --repo $GH_REPO --search "$ISSUE_TITLE in:title" --state open --json number --jq '.[0].number')
+
+            if [[ -n "$EXISTING_ISSUE" && "$EXISTING_ISSUE" != "null" ]]; then
+              echo "Found existing open issue #$EXISTING_ISSUE. Skipping to avoid noise."
+            else
+              echo "Creating new issue."
+              gh issue create --title "$ISSUE_TITLE" --body-file /tmp/msrv_issue_body.md --label "type: process" -R $GH_REPO
+            fi
+          else
+            echo "MSRV is up to date (${CURRENT_MSRV})."
+          fi


### PR DESCRIPTION
Add an automated step to .github/workflows/rust-toolchain-check.yaml to calculate MSRV eligibility under the 1-year policy and file a tracking issue when we can drop a version.