### PR TITLE
impl(bigquery-read): support server-side streaming for ReadRows

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -586,6 +586,7 @@ libraries:
         - extend_grpc_transport: true
           generate_setter_samples: "false"
           generate_rpc_samples: "false"
+          include_server_streaming_methods: true
           included_ids:
             - .google.cloud.bigquery.storage.v1.BigQueryRead
           name_overrides: .google.cloud.bigquery.storage.v1.BigQueryRead=Read

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.39.1-0.20260826135306-a5a970776839
+version: v0.39.1-0.20260826211627-9acd367c5252
 repo: googleapis/google-cloud-rust
 sources:
   conformance:
@@ -586,9 +586,9 @@ libraries:
         - extend_grpc_transport: true
           generate_setter_samples: "false"
           generate_rpc_samples: "false"
-          include_server_streaming_methods: true
           included_ids:
             - .google.cloud.bigquery.storage.v1.BigQueryRead
+          include_server_streaming_methods: true
           name_overrides: .google.cloud.bigquery.storage.v1.BigQueryRead=Read
           output: src/bigquery-read/src/generated/gapic_storage
           service_config: google/cloud/bigquery/storage/v1/bigquerystorage_v1.yaml

--- a/src/bigquery-read/src/generated/gapic_storage/builder.rs
+++ b/src/bigquery-read/src/generated/gapic_storage/builder.rs
@@ -166,6 +166,105 @@ pub mod read {
         }
     }
 
+    /// The request builder for [Read::read_rows][crate::client::Read::read_rows] calls.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_read::builder::read::ReadRows;
+    /// # async fn sample() -> google_cloud_bigquery_read::Result<()> {
+    /// let builder = prepare_request_builder();
+    /// let mut receiver = builder.send().await?;
+    /// # Ok(()) }
+    ///
+    /// fn prepare_request_builder() -> ReadRows {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[derive(Clone, Debug)]
+    pub struct ReadRows(RequestBuilder<crate::model::ReadRowsRequest>);
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    impl ReadRows {
+        pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::Read>) -> Self {
+            Self(RequestBuilder::new(stub))
+        }
+
+        /// Sets the full request, replacing any prior values.
+        pub fn with_request<V: Into<crate::model::ReadRowsRequest>>(mut self, v: V) -> Self {
+            self.0.request = v.into();
+            self
+        }
+
+        /// Sets all the options, replacing any prior values.
+        pub fn with_options<V: Into<crate::RequestOptions>>(mut self, v: V) -> Self {
+            self.0.options = v.into();
+            self
+        }
+
+        /// Initiates the server stream.
+        pub async fn send(
+            self,
+        ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::ReadRowsResponse>>
+        {
+            (*self.0.stub)
+                .read_rows(self.0.request, self.0.options)
+                .await
+        }
+
+        /// Sets the value of [read_stream][crate::model::ReadRowsRequest::read_stream].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_read_stream<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.read_stream = v.into();
+            self
+        }
+
+        /// Sets the value of [offset][crate::model::ReadRowsRequest::offset].
+        pub fn set_offset<T: Into<i64>>(mut self, v: T) -> Self {
+            self.0.request.offset = v.into();
+            self
+        }
+
+        /// Sets the value of [output_format_serialization_options][crate::model::ReadRowsRequest::output_format_serialization_options].
+        ///
+        /// Note that all the setters affecting `output_format_serialization_options` are
+        /// mutually exclusive.
+        pub fn set_output_format_serialization_options<
+            T: Into<Option<crate::model::read_rows_request::OutputFormatSerializationOptions>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.output_format_serialization_options = v.into();
+            self
+        }
+
+        /// Sets the value of [output_format_serialization_options][crate::model::ReadRowsRequest::output_format_serialization_options]
+        /// to hold a `ArrowSerializationOptions`.
+        ///
+        /// Note that all the setters affecting `output_format_serialization_options` are
+        /// mutually exclusive.
+        pub fn set_arrow_serialization_options<
+            T: std::convert::Into<std::boxed::Box<crate::model::ArrowSerializationOptions>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request = self.0.request.set_arrow_serialization_options(v);
+            self
+        }
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[doc(hidden)]
+    impl crate::RequestBuilder for ReadRows {
+        fn request_options(&mut self) -> &mut crate::RequestOptions {
+            &mut self.0.options
+        }
+    }
+
     /// The request builder for [Read::split_read_stream][crate::client::Read::split_read_stream] calls.
     ///
     /// # Example

--- a/src/bigquery-read/src/generated/gapic_storage/client.rs
+++ b/src/bigquery-read/src/generated/gapic_storage/client.rs
@@ -145,6 +145,18 @@ impl Read {
         super::builder::read::CreateReadSession::new(self.inner.clone())
     }
 
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    /// Reads rows from the stream in the format prescribed by the ReadSession.
+    /// Each response contains one or more table rows, up to a maximum of 128 MB
+    /// per response; read requests which attempt to read individual rows larger
+    /// than 128 MB will fail.
+    ///
+    /// Each request also returns a set of stream statistics reflecting the current
+    /// state of the stream.
+    pub fn read_rows(&self) -> super::builder::read::ReadRows {
+        super::builder::read::ReadRows::new(self.inner.clone())
+    }
+
     /// Splits a given `ReadStream` into two `ReadStream` objects. These
     /// `ReadStream` objects are referred to as the primary and the residual
     /// streams of the split. The original `ReadStream` can still be read from in

--- a/src/bigquery-read/src/generated/gapic_storage/stub.rs
+++ b/src/bigquery-read/src/generated/gapic_storage/stub.rs
@@ -48,6 +48,20 @@ pub trait Read: std::fmt::Debug + Send + Sync {
         gaxi::unimplemented::unimplemented_stub()
     }
 
+    /// Implements [super::client::Read::read_rows].
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    fn read_rows(
+        &self,
+        _req: crate::model::ReadRowsRequest,
+        _options: crate::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<
+            google_cloud_gax::streaming::ResponseReceiver<crate::model::ReadRowsResponse>,
+        >,
+    > + Send {
+        gaxi::unimplemented::unimplemented_server_streaming_stub()
+    }
+
     /// Implements [super::client::Read::split_read_stream].
     fn split_read_stream(
         &self,

--- a/src/bigquery-read/src/generated/gapic_storage/stub/dynamic.rs
+++ b/src/bigquery-read/src/generated/gapic_storage/stub/dynamic.rs
@@ -23,6 +23,13 @@ pub trait Read: std::fmt::Debug + Send + Sync {
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<crate::model::ReadSession>>;
 
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn read_rows(
+        &self,
+        req: crate::model::ReadRowsRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::ReadRowsResponse>>;
+
     async fn split_read_stream(
         &self,
         req: crate::model::SplitReadStreamRequest,
@@ -40,6 +47,17 @@ impl<T: super::Read> Read for T {
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<crate::model::ReadSession>> {
         T::create_read_session(self, req, options).await
+    }
+
+    /// Forwards the call to the implementation provided by `T`.
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn read_rows(
+        &self,
+        req: crate::model::ReadRowsRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::ReadRowsResponse>>
+    {
+        T::read_rows(self, req, options).await
     }
 
     /// Forwards the call to the implementation provided by `T`.

--- a/src/bigquery-read/src/generated/gapic_storage/tracing.rs
+++ b/src/bigquery-read/src/generated/gapic_storage/tracing.rs
@@ -55,6 +55,15 @@ where
         pending.await
     }
 
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn read_rows(
+        &self,
+        req: crate::model::ReadRowsRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::ReadRowsResponse>> {
+        self.inner.read_rows(req, options).await
+    }
+
     #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn split_read_stream(
         &self,

--- a/src/bigquery-read/src/generated/gapic_storage/transport.rs
+++ b/src/bigquery-read/src/generated/gapic_storage/transport.rs
@@ -126,6 +126,48 @@ impl super::stub::Read for Read {
             .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::ReadSession>)
     }
 
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn read_rows(
+        &self,
+        req: crate::model::ReadRowsRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::ReadRowsResponse>> {
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "google.cloud.bigquery.storage.v1.BigQueryRead",
+                "ReadRows",
+            ));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static(
+            "/google.cloud.bigquery.storage.v1.BigQueryRead/ReadRows",
+        );
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.read_stream)
+            .map(|s| s.as_str())
+            .map(|v| format!("read_stream={v}"))]
+        .into_iter()
+        .flatten()
+        .fold(String::new(), |b, p| b + "&" + &p);
+
+        self.inner
+            .execute_server_streaming::<
+                crate::model::ReadRowsRequest,
+                crate::model::ReadRowsResponse,
+                crate::google::cloud::bigquery::storage::v1::ReadRowsRequest,
+                crate::google::cloud::bigquery::storage::v1::ReadRowsResponse,
+            >(
+                extensions,
+                path,
+                req,
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+    }
+
     async fn split_read_stream(
         &self,
         req: crate::model::SplitReadStreamRequest,

--- a/tests/bigquery/Cargo.toml
+++ b/tests/bigquery/Cargo.toml
@@ -20,6 +20,9 @@ version           = "0.0.0"
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 # These are normally disabled because they run against production.
 run-integration-tests = []

--- a/tests/bigquery/src/lib.rs
+++ b/tests/bigquery/src/lib.rs
@@ -24,6 +24,8 @@ pub use query::{
     query_client, query_client_datatypes, query_client_job, query_client_multi_page,
     query_client_nested_types, query_client_numeric_limits,
 };
+#[cfg(google_cloud_unstable_gapic_streaming)]
+pub use reads::read_rows;
 pub use reads::run_reads;
 pub use writes::run_writes;
 

--- a/tests/bigquery/src/reads.rs
+++ b/tests/bigquery/src/reads.rs
@@ -16,6 +16,7 @@ use anyhow::Result;
 use bigquery_samples::{
     cleanup_stale_datasets, create_dataset, create_table, delete_dataset, random_dataset_id,
 };
+use google_cloud_bigquery::client::BigQuery;
 use google_cloud_bigquery_read::client::Read;
 use google_cloud_bigquery_read::model::{DataFormat, ReadSession};
 use google_cloud_bigquery_v2::client::{DatasetService, TableService};
@@ -39,7 +40,23 @@ pub async fn run_reads() -> Result<()> {
             TableFieldSchema::new().set_name("age").set_type("INTEGER"),
         ]);
         create_table(&table_service, &project_id, &dataset_id, table_id, schema).await?;
-        basic(&project_id, &dataset_id, table_id).await
+
+        // Insert sample data into the table.
+        let bq_client = BigQuery::builder().build().await?;
+        let insert_query = format!(
+            "INSERT INTO `{project_id}.{dataset_id}.{table_id}` (name, age) VALUES ('Alice', 25), ('Bob', 28), ('Charlie', 31)"
+        );
+        bq_client
+            .query(insert_query)
+            .with_project_id(&project_id)
+            .set_labels(vec![(bigquery_samples::INSTANCE_LABEL, "true")])
+            .until_done()
+            .await?;
+
+        basic(&project_id, &dataset_id, table_id).await?;
+        #[cfg(google_cloud_unstable_gapic_streaming)]
+        read_rows(&project_id, &dataset_id, table_id).await?;
+        Ok(())
     }
     .await;
 
@@ -47,7 +64,7 @@ pub async fn run_reads() -> Result<()> {
     result
 }
 
-// Calls the one unary RPC the service has to offer.
+// Calls the unary CreateReadSession RPC.
 pub async fn basic(project_id: &str, dataset_id: &str, table_id: &str) -> Result<()> {
     let client = Read::builder().build().await?;
 
@@ -64,5 +81,45 @@ pub async fn basic(project_id: &str, dataset_id: &str, table_id: &str) -> Result
         .send()
         .await?;
     println!("Successfully created ReadSession: {session:?}");
+    Ok(())
+}
+
+// Calls the server-streaming ReadRows RPC and consumes responses.
+#[cfg(google_cloud_unstable_gapic_streaming)]
+pub async fn read_rows(project_id: &str, dataset_id: &str, table_id: &str) -> Result<()> {
+    let client = Read::builder().build().await?;
+
+    let table = format!("projects/{project_id}/datasets/{dataset_id}/tables/{table_id}");
+    let session = client
+        .create_read_session()
+        .set_parent(format!("projects/{project_id}"))
+        .set_read_session(
+            ReadSession::new()
+                .set_data_format(DataFormat::Arrow)
+                .set_table(table),
+        )
+        .set_max_stream_count(1)
+        .send()
+        .await?;
+
+    assert!(
+        !session.streams.is_empty(),
+        "expected at least one stream in read session"
+    );
+
+    let stream_name = &session.streams[0].name;
+    let mut stream = client
+        .read_rows()
+        .set_read_stream(stream_name)
+        .send()
+        .await?;
+
+    let mut total_rows = 0;
+    while let Some(response) = stream.recv().await {
+        let response = response?;
+        total_rows += response.row_count;
+    }
+    assert_eq!(total_rows, 3, "expected 3 rows to be read from stream");
+
     Ok(())
 }

--- a/tests/bigquery/src/reads.rs
+++ b/tests/bigquery/src/reads.rs
@@ -53,8 +53,6 @@ pub async fn run_reads() -> Result<()> {
             .until_done()
             .await?;
 
-        basic(&project_id, &dataset_id, table_id).await?;
-        #[cfg(google_cloud_unstable_gapic_streaming)]
         read_rows(&project_id, &dataset_id, table_id).await?;
         Ok(())
     }
@@ -64,28 +62,7 @@ pub async fn run_reads() -> Result<()> {
     result
 }
 
-// Calls the unary CreateReadSession RPC.
-pub async fn basic(project_id: &str, dataset_id: &str, table_id: &str) -> Result<()> {
-    let client = Read::builder().build().await?;
-
-    let table = format!("projects/{project_id}/datasets/{dataset_id}/tables/{table_id}");
-    let session = client
-        .create_read_session()
-        .set_parent(format!("projects/{project_id}"))
-        .set_read_session(
-            ReadSession::new()
-                .set_data_format(DataFormat::Arrow)
-                .set_table(table),
-        )
-        .set_max_stream_count(1)
-        .send()
-        .await?;
-    println!("Successfully created ReadSession: {session:?}");
-    Ok(())
-}
-
 // Calls the server-streaming ReadRows RPC and consumes responses.
-#[cfg(google_cloud_unstable_gapic_streaming)]
 pub async fn read_rows(project_id: &str, dataset_id: &str, table_id: &str) -> Result<()> {
     let client = Read::builder().build().await?;
 
@@ -107,19 +84,22 @@ pub async fn read_rows(project_id: &str, dataset_id: &str, table_id: &str) -> Re
         "expected at least one stream in read session"
     );
 
-    let stream_name = &session.streams[0].name;
-    let mut stream = client
-        .read_rows()
-        .set_read_stream(stream_name)
-        .send()
-        .await?;
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    {
+        let stream_name = &session.streams[0].name;
+        let mut stream = client
+            .read_rows()
+            .set_read_stream(stream_name)
+            .send()
+            .await?;
 
-    let mut total_rows = 0;
-    while let Some(response) = stream.recv().await {
-        let response = response?;
-        total_rows += response.row_count;
+        let mut total_rows = 0;
+        while let Some(response) = stream.recv().await {
+            let response = response?;
+            total_rows += response.row_count;
+        }
+        assert_eq!(total_rows, 3, "expected 3 rows to be read from stream");
     }
-    assert_eq!(total_rows, 3, "expected 3 rows to be read from stream");
 
     Ok(())
 }


### PR DESCRIPTION
Enable include_server_streaming_methods for google-cloud-bigquery-read in librarian.yaml and regenerate the client with server-side streaming support for the ReadRows RPC.

Also add an integration test.