### PR TITLE
fix(secretmanager): apply retry policy to all protobuf integration tests

### DIFF
--- a/tests/protobuf/src/lib.rs
+++ b/tests/protobuf/src/lib.rs
@@ -165,8 +165,8 @@ pub async fn run(builder: ClientBuilder) -> Result<()> {
 
 pub fn retry_policy() -> impl RetryPolicy {
     AlwaysRetry
-        .with_time_limit(Duration::from_secs(15))
-        .with_attempt_limit(5)
+        .with_time_limit(Duration::from_secs(60))
+        .with_attempt_limit(10)
 }
 
 async fn run_locations(client: &SecretManagerService, project_id: &str) -> Result<()> {

--- a/tests/protobuf/tests/driver.rs
+++ b/tests/protobuf/tests/driver.rs
@@ -21,10 +21,9 @@ mod protobuf {
     use integration_tests_protobuf::retry_policy;
     use test_case::test_case;
 
-    #[test_case(SecretManagerService::builder(); "default")]
-    #[test_case(SecretManagerService::builder().with_tracing(); "with tracing enabled")]
-    #[test_case(SecretManagerService::builder().with_retry_policy(retry_policy()); "with retry enabled")]
-    #[test_case(SecretManagerService::builder().with_endpoint("https://www.googleapis.com"); "with alternative endpoint")]
+    #[test_case(SecretManagerService::builder().with_retry_policy(retry_policy()); "default")]
+    #[test_case(SecretManagerService::builder().with_retry_policy(retry_policy()).with_tracing(); "with tracing enabled")]
+    #[test_case(SecretManagerService::builder().with_retry_policy(retry_policy()).with_endpoint("https://www.googleapis.com"); "with alternative endpoint")]
     #[tokio::test]
     async fn run(builder: ClientBuilder) -> anyhow::Result<()> {
         let _guard = enable_tracing();


### PR DESCRIPTION
Fixes #6550