### PR TITLE
fix(secretmanager): apply retry policy to openapi integration tests

### DIFF
--- a/tests/openapi/src/global.rs
+++ b/tests/openapi/src/global.rs
@@ -14,6 +14,7 @@
 
 use anyhow::Result;
 use google_cloud_gax::paginator::Paginator;
+use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
 use google_cloud_test_utils::resource_names::random_secret_id;
 use google_cloud_test_utils::runtime_config::{project_id, test_service_account};
 use google_cloud_wkt::FieldMask;
@@ -22,6 +23,7 @@ use secretmanager_openapi_v1::model::{
     AddSecretVersionRequest, Automatic, Binding, Replication, Secret, SecretPayload,
     SetIamPolicyRequest, TestIamPermissionsRequest,
 };
+use std::time::Duration;
 
 pub async fn run() -> Result<()> {
     let project_id = project_id()?;
@@ -29,6 +31,11 @@ pub async fn run() -> Result<()> {
 
     let client = SecretManagerService::builder()
         .with_tracing()
+        .with_retry_policy(
+            AlwaysRetry
+                .with_time_limit(Duration::from_secs(60))
+                .with_attempt_limit(10),
+        )
         .build()
         .await?;
 

--- a/tests/openapi/src/global.rs
+++ b/tests/openapi/src/global.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use anyhow::Result;
+use google_cloud_gax::options::RequestOptionsBuilder;
 use google_cloud_gax::paginator::Paginator;
-use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
 use google_cloud_test_utils::resource_names::random_secret_id;
 use google_cloud_test_utils::runtime_config::{project_id, test_service_account};
 use google_cloud_wkt::FieldMask;
@@ -23,7 +23,6 @@ use secretmanager_openapi_v1::model::{
     AddSecretVersionRequest, Automatic, Binding, Replication, Secret, SecretPayload,
     SetIamPolicyRequest, TestIamPermissionsRequest,
 };
-use std::time::Duration;
 
 pub async fn run() -> Result<()> {
     let project_id = project_id()?;
@@ -31,11 +30,6 @@ pub async fn run() -> Result<()> {
 
     let client = SecretManagerService::builder()
         .with_tracing()
-        .with_retry_policy(
-            AlwaysRetry
-                .with_time_limit(Duration::from_secs(60))
-                .with_attempt_limit(10),
-        )
         .build()
         .await?;
 
@@ -49,6 +43,7 @@ pub async fn run() -> Result<()> {
                 .set_replication(Replication::new().set_automatic(Automatic::new()))
                 .set_labels([("integration-test", "true")]),
         )
+        .with_idempotency(true)
         .send()
         .await?;
     println!("CREATE = {create:?}");
@@ -64,6 +59,7 @@ pub async fn run() -> Result<()> {
         .get_secret()
         .set_project(&project_id)
         .set_secret(&secret_id)
+        .with_idempotency(true)
         .send()
         .await?;
     println!("GET = {get:?}");
@@ -81,6 +77,7 @@ pub async fn run() -> Result<()> {
         .set_secret(&secret_id)
         .set_update_mask(FieldMask::default().set_paths(["labels"]))
         .set_body(Secret::new().set_labels(new_labels))
+        .with_idempotency(true)
         .send()
         .await?;
     println!("UPDATE = {update:?}");
@@ -101,6 +98,7 @@ pub async fn run() -> Result<()> {
         .delete_secret()
         .set_project(&project_id)
         .set_secret(&secret_id)
+        .with_idempotency(true)
         .send()
         .await?;
     println!("DELETE = {response:?}");
@@ -112,6 +110,7 @@ async fn run_locations(client: &SecretManagerService, project_id: &str) -> Resul
     let locations = client
         .list_locations()
         .set_project(project_id)
+        .with_idempotency(true)
         .send()
         .await?;
     println!("LOCATIONS = {locations:?}");
@@ -131,6 +130,7 @@ async fn run_locations(client: &SecretManagerService, project_id: &str) -> Resul
         .get_location()
         .set_project(project_id)
         .set_location(first.location_id.clone().unwrap())
+        .with_idempotency(true)
         .send()
         .await?;
     println!("GET = {get:?}");
@@ -148,6 +148,7 @@ async fn run_iam(client: &SecretManagerService, project_id: &str, secret_id: &st
         .get_iam_policy()
         .set_project(project_id)
         .set_secret(secret_id)
+        .with_idempotency(true)
         .send()
         .await?;
     println!("POLICY = {policy:?}");
@@ -160,6 +161,7 @@ async fn run_iam(client: &SecretManagerService, project_id: &str, secret_id: &st
         .set_body(
             TestIamPermissionsRequest::new().set_permissions(["secretmanager.versions.access"]),
         )
+        .with_idempotency(true)
         .send()
         .await?;
     println!("RESPONSE = {response:?}");
@@ -194,6 +196,7 @@ async fn run_iam(client: &SecretManagerService, project_id: &str, secret_id: &st
                 .set_update_mask(FieldMask::default().set_paths(["bindings"]))
                 .set_policy(new_policy),
         )
+        .with_idempotency(true)
         .send()
         .await?;
     println!("RESPONSE = {response:?}");
@@ -220,6 +223,7 @@ async fn run_secret_versions(
                     .set_data_crc_32_c(checksum as i64),
             ),
         )
+        .with_idempotency(true)
         .send()
         .await?;
     println!("CREATE_SECRET_VERSION = {create:?}");
@@ -244,6 +248,7 @@ async fn run_secret_versions(
         .set_project(project_id)
         .set_secret(secret_id)
         .set_version(version_id)
+        .with_idempotency(true)
         .send()
         .await?;
     println!("GET_SECRET_VERSION = {get:?}");
@@ -265,6 +270,7 @@ async fn run_secret_versions(
         .set_project(project_id)
         .set_secret(secret_id)
         .set_version(version_id)
+        .with_idempotency(true)
         .send()
         .await?;
     println!("ACCESS_SECRET_VERSION = {access_secret_version:?}");
@@ -279,6 +285,7 @@ async fn run_secret_versions(
         .set_project(project_id)
         .set_secret(secret_id)
         .set_version(version_id)
+        .with_idempotency(true)
         .send()
         .await?;
     println!("DISABLE_SECRET_VERSION = {disable:?}");
@@ -289,6 +296,7 @@ async fn run_secret_versions(
         .set_project(project_id)
         .set_secret(secret_id)
         .set_version(version_id)
+        .with_idempotency(true)
         .send()
         .await?;
     println!("ENABLE_SECRET_VERSION = {enable:?}");
@@ -299,6 +307,7 @@ async fn run_secret_versions(
         .set_project(project_id)
         .set_secret(secret_id)
         .set_version(version_id)
+        .with_idempotency(true)
         .send()
         .await?;
     println!("RESPONSE = {delete:?}");
@@ -319,6 +328,7 @@ async fn get_all_secret_version_names(
             .set_project(project_id)
             .set_secret(secret_id)
             .set_or_clear_page_token(page_token)
+            .with_idempotency(true)
             .send()
             .await?;
         response

--- a/tests/openapi/src/locational.rs
+++ b/tests/openapi/src/locational.rs
@@ -15,7 +15,6 @@
 use anyhow::Result;
 use anyhow::anyhow;
 use google_cloud_gax::options::RequestOptionsBuilder;
-use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
 use google_cloud_test_utils::resource_names::random_secret_id;
 use google_cloud_test_utils::runtime_config::{project_id, test_service_account};
 use google_cloud_wkt::{FieldMask, Timestamp};
@@ -24,7 +23,6 @@ use secretmanager_openapi_v1::model::{
     AddSecretVersionRequest, Binding, Secret, SecretPayload, SetIamPolicyRequest,
     TestIamPermissionsRequest,
 };
-use std::time::Duration;
 
 pub async fn run() -> Result<()> {
     let project_id = project_id()?;
@@ -36,11 +34,6 @@ pub async fn run() -> Result<()> {
     let client = SecretManagerService::builder()
         .with_tracing()
         .with_endpoint(endpoint)
-        .with_retry_policy(
-            AlwaysRetry
-                .with_time_limit(Duration::from_secs(60))
-                .with_attempt_limit(10),
-        )
         .build()
         .await?;
 

--- a/tests/openapi/src/locational.rs
+++ b/tests/openapi/src/locational.rs
@@ -15,6 +15,7 @@
 use anyhow::Result;
 use anyhow::anyhow;
 use google_cloud_gax::options::RequestOptionsBuilder;
+use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
 use google_cloud_test_utils::resource_names::random_secret_id;
 use google_cloud_test_utils::runtime_config::{project_id, test_service_account};
 use google_cloud_wkt::{FieldMask, Timestamp};
@@ -23,6 +24,7 @@ use secretmanager_openapi_v1::model::{
     AddSecretVersionRequest, Binding, Secret, SecretPayload, SetIamPolicyRequest,
     TestIamPermissionsRequest,
 };
+use std::time::Duration;
 
 pub async fn run() -> Result<()> {
     let project_id = project_id()?;
@@ -34,6 +36,11 @@ pub async fn run() -> Result<()> {
     let client = SecretManagerService::builder()
         .with_tracing()
         .with_endpoint(endpoint)
+        .with_retry_policy(
+            AlwaysRetry
+                .with_time_limit(Duration::from_secs(60))
+                .with_attempt_limit(10),
+        )
         .build()
         .await?;
 


### PR DESCRIPTION
This proactively prevents `503 Unavailable` flakes in the REST clients similar to the protobuf integration tests.

Related to #6550