### PR TITLE
chore(spanner): wire location-aware routing into unary RPCs

### DIFF
--- a/src/spanner/src/database_client.rs
+++ b/src/spanner/src/database_client.rs
@@ -15,12 +15,14 @@
 use crate::batch_read_only_transaction::BatchReadOnlyTransactionBuilder;
 use crate::batch_write_transaction::BatchWriteTransactionBuilder;
 use crate::client::Spanner;
+use crate::model::transaction_options::Mode;
+use crate::model::transaction_options::read_only::TimestampBound;
 use crate::model::transaction_selector::Selector;
 use crate::model::{
     BatchWriteRequest, BeginTransactionRequest, CacheUpdate, CommitRequest, CommitResponse,
     ExecuteBatchDmlRequest, ExecuteBatchDmlResponse, ExecuteSqlRequest, PartitionQueryRequest,
     PartitionReadRequest, PartitionResponse, ReadRequest, ResultSet, RollbackRequest, Transaction,
-    TransactionSelector,
+    TransactionOptions, TransactionSelector,
 };
 use crate::observability::Observability;
 use crate::omni::{InstanceType, format_database_name};
@@ -31,7 +33,10 @@ use crate::read_only_transaction::{
 use crate::routing::cache_updater::CacheUpdater;
 use crate::routing::connection_cache::ConnectionCache;
 use crate::routing::endpoint_cooldown::EndpointCooldownTracker;
-use crate::routing::key_extractor::extract_proto_read_request_routing_key;
+use crate::routing::key_extractor::{
+    extract_mutation_routing_key, extract_mutations_routing_key,
+    extract_proto_partition_read_request_routing_key, extract_proto_read_request_routing_key,
+};
 use crate::routing::key_range_cache::KeyRangeCache;
 use crate::routing::key_recipe_cache::KeyRecipeCache;
 use crate::routing::location_router::{LocationRouter, RoutingContext};
@@ -41,6 +46,7 @@ use crate::session_maintainer::ManagedSessionMaintainer;
 use crate::transaction_runner::TransactionRunnerBuilder;
 use crate::write_only_transaction::WriteOnlyTransactionBuilder;
 use crate::{RequestOptions, Result};
+use bytes::Bytes;
 use std::env;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
@@ -79,18 +85,31 @@ pub struct DatabaseClient {
 }
 
 macro_rules! define_db_rpc {
-    ($method:ident, $expect_method:ident, $request_type:ty, $response_type:ty) => {
+    (
+        $method:ident,
+        $expect_method:ident,
+        $request_type:ty,
+        $response_type:ty,
+        $pre_route:path,
+        $post_hook:path
+    ) => {
         pub(crate) async fn $method(
             &self,
             request: $request_type,
             options: RequestOptions,
             channel_hint: usize,
         ) -> Result<$response_type> {
-            let channel = self.spanner.get_channel(channel_hint);
-            let response = self
+            let (connection, routing_context) = $pre_route(self, &request);
+            let channel = match &connection {
+                Some(connection) => connection.channel(),
+                None => self.spanner.get_channel(channel_hint),
+            };
+            let result = self
                 .spanner
                 .$method(request, options, channel, &self.o11y)
-                .await?;
+                .await;
+            $post_hook(self, routing_context, connection.as_ref(), &result);
+            let response = result?;
             response.observe(self);
             Ok(response)
         }
@@ -128,8 +147,9 @@ macro_rules! define_db_streaming_rpc {
             // - If disabled (standard Cloud Spanner), returns `None` immediately on the fast path.
             // - If enabled but both `transaction_id` and `routing_key` are `None`, returns `None` early.
             // - If a target tablet replica or affinity connection is found, returns `Some(connection)`.
-            let connection = self
-                .resolve_routing_connection(request.transaction.as_ref(), routing_key.as_deref());
+            let context =
+                routing_context_from_selector(request.transaction.as_ref(), routing_key.as_deref());
+            let connection = self.resolve_routing_connection(&context);
 
             // Step 3: Select the gRPC channel:
             // - If location-aware routing resolved a direct node connection (`Some(connection)`), use `connection.channel()`.
@@ -151,33 +171,57 @@ macro_rules! for_all_unary_db_rpcs {
             begin_transaction,
             expect_begin_transaction,
             BeginTransactionRequest,
-            Transaction
+            Transaction,
+            DatabaseClient::pre_route_begin_transaction,
+            DatabaseClient::post_route_begin_transaction
         );
-        $macro!(commit, expect_commit, CommitRequest, CommitResponse);
+        $macro!(
+            commit,
+            expect_commit,
+            CommitRequest,
+            CommitResponse,
+            DatabaseClient::pre_route_commit,
+            DatabaseClient::post_route_commit
+        );
         $macro!(
             execute_batch_dml,
             expect_execute_batch_dml,
             ExecuteBatchDmlRequest,
-            ExecuteBatchDmlResponse
+            ExecuteBatchDmlResponse,
+            DatabaseClient::pre_route_execute_batch_dml,
+            DatabaseClient::post_route_execute_batch_dml
         );
         $macro!(
             execute_sql,
             expect_execute_sql,
             ExecuteSqlRequest,
-            ResultSet
+            ResultSet,
+            DatabaseClient::pre_route_execute_sql,
+            DatabaseClient::post_route_execute_sql
         );
-        $macro!(rollback, expect_rollback, RollbackRequest, ());
+        $macro!(
+            rollback,
+            expect_rollback,
+            RollbackRequest,
+            (),
+            DatabaseClient::pre_route_rollback,
+            DatabaseClient::post_route_rollback
+        );
         $macro!(
             partition_query,
             expect_partition_query,
             PartitionQueryRequest,
-            PartitionResponse
+            PartitionResponse,
+            DatabaseClient::pre_route_partition_query,
+            DatabaseClient::post_route_noop
         );
         $macro!(
             partition_read,
             expect_partition_read,
             PartitionReadRequest,
-            PartitionResponse
+            PartitionResponse,
+            DatabaseClient::pre_route_partition_read,
+            DatabaseClient::post_route_noop
         );
     };
 }
@@ -242,25 +286,13 @@ impl DatabaseClient {
     ///     pointing directly to the target node.
     pub(crate) fn resolve_routing_connection(
         &self,
-        transaction: Option<&TransactionSelector>,
-        routing_key: Option<&[u8]>,
+        context: &RoutingContext,
     ) -> Option<ServerConnection> {
-        // Fast path: When location routing is disabled (standard Cloud Spanner), exit immediately.
         let routing = self.location_routing.as_ref()?;
-
-        // Fast path: No routing metadata available to route the request (preserves channel pooling).
-        let transaction_id = extract_transaction_id(transaction);
-        if transaction_id.is_none() && routing_key.is_none() {
+        if context.transaction_id.is_none() && context.routing_key.is_none() {
             return None;
         }
-
-        let routing_context = RoutingContext {
-            transaction_id,
-            routing_key,
-            prefer_leader: false,
-            use_transaction_affinity: transaction_id.is_some(),
-        };
-        Some(routing.location_router.resolve_connection(&routing_context))
+        Some(routing.location_router.resolve_connection(context))
     }
 
     for_all_streaming_db_rpcs!(define_db_streaming_rpc);
@@ -548,12 +580,299 @@ impl DatabaseClient {
                 .store(routing.cache_updater.database_id(), Ordering::Release);
         }
     }
+
+    fn pre_route_begin_transaction(
+        &self,
+        request: &BeginTransactionRequest,
+    ) -> (Option<ServerConnection>, bool) {
+        let Some(routing) = &self.location_routing else {
+            return (None, false);
+        };
+        let routing_key = request.mutation_key.as_ref().and_then(|mutation_key| {
+            extract_mutation_routing_key(&routing.key_recipe_cache, mutation_key)
+        });
+        let prefer_leader = prefer_leader_from_options(request.options.as_ref());
+        let context = RoutingContext {
+            routing_key: routing_key.as_deref(),
+            prefer_leader,
+            ..Default::default()
+        };
+        let connection = self.resolve_routing_connection(&context);
+        let is_read_write = is_read_write_options(request.options.as_ref());
+        (connection, is_read_write)
+    }
+
+    fn post_route_begin_transaction(
+        &self,
+        is_read_write: bool,
+        connection: Option<&ServerConnection>,
+        result: &Result<Transaction>,
+    ) {
+        self.record_transaction_affinity_routing(
+            is_read_write,
+            result
+                .as_ref()
+                .ok()
+                .map(|transaction| transaction.id.as_ref()),
+            connection,
+        );
+    }
+
+    fn pre_route_commit(
+        &self,
+        request: &CommitRequest,
+    ) -> (Option<ServerConnection>, Option<Bytes>) {
+        let Some(routing) = &self.location_routing else {
+            return (None, None);
+        };
+        let transaction_id = request
+            .transaction_id()
+            .filter(|id| !id.is_empty())
+            .cloned();
+        let routing_key = if transaction_id.is_none() && !request.mutations.is_empty() {
+            extract_mutations_routing_key(&routing.key_recipe_cache, &request.mutations)
+        } else {
+            None
+        };
+        let context = RoutingContext {
+            transaction_id: transaction_id.as_deref(),
+            routing_key: routing_key.as_deref(),
+            prefer_leader: true,
+            use_transaction_affinity: transaction_id.is_some(),
+        };
+        let connection = self.resolve_routing_connection(&context);
+        (connection, transaction_id)
+    }
+
+    fn post_route_commit(
+        &self,
+        transaction_id: Option<Bytes>,
+        _connection: Option<&ServerConnection>,
+        _result: &Result<CommitResponse>,
+    ) {
+        self.clear_transaction_affinity_routing(transaction_id.as_deref());
+    }
+
+    fn pre_route_execute_batch_dml(
+        &self,
+        request: &ExecuteBatchDmlRequest,
+    ) -> (Option<ServerConnection>, bool) {
+        self.pre_route_transaction_selector(request.transaction.as_ref())
+    }
+
+    fn post_route_execute_batch_dml(
+        &self,
+        is_read_write_begin: bool,
+        connection: Option<&ServerConnection>,
+        result: &Result<ExecuteBatchDmlResponse>,
+    ) {
+        let transaction_id = result
+            .as_ref()
+            .ok()
+            .and_then(|response| response.result_sets.first())
+            .and_then(|result_set| result_set.metadata.as_ref())
+            .and_then(|metadata| metadata.transaction.as_ref())
+            .map(|transaction| transaction.id.as_ref());
+        self.record_transaction_affinity_routing(is_read_write_begin, transaction_id, connection);
+    }
+
+    fn pre_route_execute_sql(
+        &self,
+        request: &ExecuteSqlRequest,
+    ) -> (Option<ServerConnection>, bool) {
+        self.pre_route_transaction_selector(request.transaction.as_ref())
+    }
+
+    fn post_route_execute_sql(
+        &self,
+        is_read_write_begin: bool,
+        connection: Option<&ServerConnection>,
+        result: &Result<ResultSet>,
+    ) {
+        let transaction_id = result
+            .as_ref()
+            .ok()
+            .and_then(|result_set| result_set.metadata.as_ref())
+            .and_then(|metadata| metadata.transaction.as_ref())
+            .map(|transaction| transaction.id.as_ref());
+        self.record_transaction_affinity_routing(is_read_write_begin, transaction_id, connection);
+    }
+
+    fn pre_route_rollback(
+        &self,
+        request: &RollbackRequest,
+    ) -> (Option<ServerConnection>, Option<Bytes>) {
+        let Some(_routing) = &self.location_routing else {
+            return (None, None);
+        };
+        let transaction_id =
+            (!request.transaction_id.is_empty()).then(|| request.transaction_id.clone());
+        let context = RoutingContext {
+            transaction_id: transaction_id.as_deref(),
+            routing_key: None,
+            prefer_leader: true,
+            use_transaction_affinity: transaction_id.is_some(),
+        };
+        let connection = self.resolve_routing_connection(&context);
+        (connection, transaction_id)
+    }
+
+    fn post_route_rollback(
+        &self,
+        transaction_id: Option<Bytes>,
+        _connection: Option<&ServerConnection>,
+        _result: &Result<()>,
+    ) {
+        self.clear_transaction_affinity_routing(transaction_id.as_deref());
+    }
+
+    fn pre_route_partition_query(
+        &self,
+        request: &PartitionQueryRequest,
+    ) -> (Option<ServerConnection>, ()) {
+        (
+            self.pre_route_transaction_selector(request.transaction.as_ref())
+                .0,
+            (),
+        )
+    }
+
+    fn pre_route_partition_read(
+        &self,
+        request: &PartitionReadRequest,
+    ) -> (Option<ServerConnection>, ()) {
+        let Some(routing) = &self.location_routing else {
+            return (None, ());
+        };
+        let routing_key =
+            extract_proto_partition_read_request_routing_key(&routing.key_recipe_cache, request);
+        let context =
+            routing_context_from_selector(request.transaction.as_ref(), routing_key.as_deref());
+        (self.resolve_routing_connection(&context), ())
+    }
+
+    fn post_route_noop<T>(
+        &self,
+        _context: (),
+        _connection: Option<&ServerConnection>,
+        _result: &Result<T>,
+    ) {
+    }
+
+    fn pre_route_transaction_selector(
+        &self,
+        transaction: Option<&TransactionSelector>,
+    ) -> (Option<ServerConnection>, bool) {
+        let Some(_routing) = &self.location_routing else {
+            return (None, false);
+        };
+        let context = routing_context_from_selector(transaction, None);
+        let connection = self.resolve_routing_connection(&context);
+        let is_read_write_begin = is_read_write_begin(transaction);
+        (connection, is_read_write_begin)
+    }
+
+    fn record_transaction_affinity_routing(
+        &self,
+        should_record: bool,
+        transaction_id: Option<&[u8]>,
+        connection: Option<&ServerConnection>,
+    ) {
+        if !should_record {
+            return;
+        }
+        let Some(transaction_id) = transaction_id.filter(|id| !id.is_empty()) else {
+            return;
+        };
+        let Some(routing) = &self.location_routing else {
+            return;
+        };
+        let address = match connection {
+            Some(connection) => connection.address(),
+            None => routing
+                .location_router
+                .connection_cache()
+                .default_connection()
+                .address(),
+        };
+        routing
+            .location_router
+            .record_transaction_affinity(transaction_id, address);
+    }
+
+    fn clear_transaction_affinity_routing(&self, transaction_id: Option<&[u8]>) {
+        let Some(transaction_id) = transaction_id.filter(|id| !id.is_empty()) else {
+            return;
+        };
+        let Some(routing) = &self.location_routing else {
+            return;
+        };
+        routing
+            .location_router
+            .clear_transaction_affinity(transaction_id);
+    }
+}
+
+fn routing_context_from_selector<'a>(
+    transaction: Option<&'a TransactionSelector>,
+    routing_key: Option<&'a [u8]>,
+) -> RoutingContext<'a> {
+    let transaction_id = extract_transaction_id(transaction);
+    let prefer_leader = prefer_leader_from_selector(transaction);
+    RoutingContext {
+        transaction_id,
+        routing_key,
+        prefer_leader,
+        use_transaction_affinity: transaction_id.is_some(),
+    }
 }
 
 fn extract_transaction_id(transaction: Option<&TransactionSelector>) -> Option<&[u8]> {
-    match transaction?.selector.as_ref()? {
-        Selector::Id(bytes) => Some(bytes.as_ref()),
+    match transaction.and_then(|t| t.selector.as_ref()) {
+        Some(Selector::Id(id)) => Some(id.as_ref()),
         _ => None,
+    }
+}
+
+fn prefer_leader_from_selector(selector: Option<&TransactionSelector>) -> bool {
+    let Some(selector) = selector else {
+        return true;
+    };
+    match &selector.selector {
+        Some(Selector::Begin(options)) => prefer_leader_from_options(Some(options)),
+        Some(Selector::SingleUse(options)) => prefer_leader_from_options(Some(options)),
+        _ => true,
+    }
+}
+
+fn prefer_leader_from_options(options: Option<&TransactionOptions>) -> bool {
+    let Some(options) = options else {
+        return true;
+    };
+    match &options.mode {
+        Some(Mode::ReadOnly(read_only)) => match &read_only.timestamp_bound {
+            Some(TimestampBound::Strong(strong)) => *strong,
+            Some(_) => false,
+            None => true,
+        },
+        _ => true,
+    }
+}
+
+fn is_read_write_options(options: Option<&TransactionOptions>) -> bool {
+    let Some(options) = options else {
+        return false;
+    };
+    matches!(&options.mode, Some(Mode::ReadWrite(_)))
+}
+
+fn is_read_write_begin(selector: Option<&TransactionSelector>) -> bool {
+    let Some(selector) = selector else {
+        return false;
+    };
+    match &selector.selector {
+        Some(Selector::Begin(options)) => is_read_write_options(Some(options)),
+        _ => false,
     }
 }
 
@@ -812,6 +1131,7 @@ mod tests {
     use crate::client::SpannerBuilderExt;
     use crate::model::key_recipe::Part;
     use crate::model::key_recipe::part::{NullOrder, Order};
+    use crate::model::transaction_options::{PartitionedDml, ReadOnly, ReadWrite};
     use crate::model::{
         CacheUpdate, CommitResponse, Group, KeyRecipe, KeySet, Range, RecipeList, Tablet,
         TransactionOptions, Type, TypeCode,
@@ -1744,7 +2064,11 @@ mod tests {
             .expect("build should succeed");
 
         assert!(!db_client.is_location_aware_routing_enabled());
-        let connection = db_client.resolve_routing_connection(None, Some(b"Users.id=1".as_slice()));
+        let context = RoutingContext {
+            routing_key: Some(b"Users.id=1".as_slice()),
+            ..Default::default()
+        };
+        let connection = db_client.resolve_routing_connection(&context);
         assert!(connection.is_none());
     }
 
@@ -1794,8 +2118,8 @@ mod tests {
             extract_proto_read_request_routing_key(&routing.key_recipe_cache, &read_request)
         });
         assert!(routing_key.is_none());
-        let cold_start_connection =
-            db_client.resolve_routing_connection(None, routing_key.as_deref());
+        let cold_start_context = routing_context_from_selector(None, routing_key.as_deref());
+        let cold_start_connection = db_client.resolve_routing_connection(&cold_start_context);
         assert!(
             cold_start_connection.is_none(),
             "Cold start with unpopulated cache must resolve to None"
@@ -1840,15 +2164,16 @@ mod tests {
         let routing_key = db_client.location_routing.as_ref().and_then(|routing| {
             extract_proto_read_request_routing_key(&routing.key_recipe_cache, &read_request)
         });
+        let hit_context = routing_context_from_selector(None, routing_key.as_deref());
         let hit_connection = db_client
-            .resolve_routing_connection(None, routing_key.as_deref())
+            .resolve_routing_connection(&hit_context)
             .expect("hit connection present");
         assert_eq!(hit_connection.address(), node_address);
 
         // 4. Mark node on cooldown: falls back to default connection
         router.cooldown_tracker().record_failure(node_address);
         let fallback_connection = db_client
-            .resolve_routing_connection(None, routing_key.as_deref())
+            .resolve_routing_connection(&hit_context)
             .expect("fallback connection present");
         assert_ne!(fallback_connection.address(), node_address);
     }
@@ -1868,6 +2193,144 @@ mod tests {
             extract_transaction_id(Some(&selector_id)),
             Some(b"txn-123".as_slice())
         );
+    }
+
+    #[test]
+    fn is_read_write_begin_cases() {
+        assert!(!is_read_write_begin(None));
+
+        let selector_id = TransactionSelector::new().set_id(bytes::Bytes::from_static(b"tx-1"));
+        assert!(!is_read_write_begin(Some(&selector_id)));
+
+        let selector_single = TransactionSelector::new()
+            .set_single_use(TransactionOptions::new().set_read_write(ReadWrite::default()));
+        assert!(!is_read_write_begin(Some(&selector_single)));
+
+        let selector_begin_ro = TransactionSelector::new()
+            .set_begin(TransactionOptions::new().set_read_only(ReadOnly::default()));
+        assert!(!is_read_write_begin(Some(&selector_begin_ro)));
+
+        let selector_begin_pdml = TransactionSelector::new()
+            .set_begin(TransactionOptions::new().set_partitioned_dml(PartitionedDml::default()));
+        assert!(!is_read_write_begin(Some(&selector_begin_pdml)));
+
+        let selector_begin_rw = TransactionSelector::new()
+            .set_begin(TransactionOptions::new().set_read_write(ReadWrite::default()));
+        assert!(is_read_write_begin(Some(&selector_begin_rw)));
+    }
+
+    #[test]
+    fn prefer_leader_from_selector_cases() {
+        assert!(prefer_leader_from_selector(None));
+
+        let selector_empty = TransactionSelector::new();
+        assert!(prefer_leader_from_selector(Some(&selector_empty)));
+
+        let selector_id = TransactionSelector::new().set_id(bytes::Bytes::from_static(b"tx-1"));
+        assert!(prefer_leader_from_selector(Some(&selector_id)));
+
+        // ReadOnly with default options (no timestamp bound) defaults to strong -> prefers leader
+        let ro_default = ReadOnly::new();
+        let selector_ro_default = TransactionSelector::new()
+            .set_single_use(TransactionOptions::new().set_read_only(ro_default));
+        assert!(prefer_leader_from_selector(Some(&selector_ro_default)));
+
+        // Strong read prefers leader
+        let ro_strong = ReadOnly::new().set_strong(true);
+        let selector_ro_strong = TransactionSelector::new()
+            .set_single_use(TransactionOptions::new().set_read_only(ro_strong));
+        assert!(prefer_leader_from_selector(Some(&selector_ro_strong)));
+
+        let ro_strong_false = ReadOnly::new().set_strong(false);
+        let selector_ro_strong_false = TransactionSelector::new()
+            .set_single_use(TransactionOptions::new().set_read_only(ro_strong_false));
+        assert!(!prefer_leader_from_selector(Some(
+            &selector_ro_strong_false
+        )));
+
+        // Exact staleness read does not prefer leader
+        let ro_exact_staleness = ReadOnly::new().set_exact_staleness(wkt::Duration::clamp(10, 0));
+        let selector_ro_exact_staleness = TransactionSelector::new()
+            .set_single_use(TransactionOptions::new().set_read_only(ro_exact_staleness));
+        assert!(!prefer_leader_from_selector(Some(
+            &selector_ro_exact_staleness
+        )));
+
+        // Max staleness read does not prefer leader
+        let ro_max_staleness = ReadOnly::new().set_max_staleness(wkt::Duration::clamp(10, 0));
+        let selector_ro_max_staleness = TransactionSelector::new()
+            .set_single_use(TransactionOptions::new().set_read_only(ro_max_staleness));
+        assert!(!prefer_leader_from_selector(Some(
+            &selector_ro_max_staleness
+        )));
+
+        // Min read timestamp does not prefer leader
+        let ro_min_timestamp =
+            ReadOnly::new().set_min_read_timestamp(wkt::Timestamp::clamp(100, 0));
+        let selector_ro_min_timestamp = TransactionSelector::new()
+            .set_single_use(TransactionOptions::new().set_read_only(ro_min_timestamp));
+        assert!(!prefer_leader_from_selector(Some(
+            &selector_ro_min_timestamp
+        )));
+
+        // Read timestamp does not prefer leader
+        let ro_read_timestamp = ReadOnly::new().set_read_timestamp(wkt::Timestamp::clamp(100, 0));
+        let selector_ro_read_timestamp = TransactionSelector::new()
+            .set_single_use(TransactionOptions::new().set_read_only(ro_read_timestamp));
+        assert!(!prefer_leader_from_selector(Some(
+            &selector_ro_read_timestamp
+        )));
+
+        // ReadWrite and PartitionedDml prefer leader
+        let selector_rw = TransactionSelector::new()
+            .set_begin(TransactionOptions::new().set_read_write(ReadWrite::default()));
+        assert!(prefer_leader_from_selector(Some(&selector_rw)));
+
+        let selector_pdml = TransactionSelector::new()
+            .set_begin(TransactionOptions::new().set_partitioned_dml(PartitionedDml::default()));
+        assert!(prefer_leader_from_selector(Some(&selector_pdml)));
+
+        // Empty options (mode: None) prefers leader
+        let selector_empty_options =
+            TransactionSelector::new().set_begin(TransactionOptions::new());
+        assert!(prefer_leader_from_selector(Some(&selector_empty_options)));
+    }
+
+    #[test]
+    fn routing_context_from_selector_cases() {
+        // None selector
+        let context_none = routing_context_from_selector(None, Some(b"key1"));
+        assert_eq!(context_none.transaction_id, None);
+        assert_eq!(context_none.routing_key, Some(b"key1".as_slice()));
+        assert!(context_none.prefer_leader);
+        assert!(!context_none.use_transaction_affinity);
+
+        // SingleUse selector
+        let selector_single = TransactionSelector::new()
+            .set_single_use(TransactionOptions::new().set_read_write(ReadWrite::default()));
+        let context_single = routing_context_from_selector(Some(&selector_single), Some(b"key2"));
+        assert_eq!(context_single.transaction_id, None);
+        assert!(!context_single.use_transaction_affinity);
+
+        // Id selector
+        let selector_id = TransactionSelector::new().set_id(bytes::Bytes::from_static(b"tx-123"));
+        let context_id = routing_context_from_selector(Some(&selector_id), Some(b"key3"));
+        assert_eq!(context_id.transaction_id, Some(b"tx-123".as_slice()));
+        assert!(context_id.use_transaction_affinity);
+
+        // Begin ReadWrite selector: no transaction_id yet, so use_transaction_affinity is false
+        let selector_begin_rw = TransactionSelector::new()
+            .set_begin(TransactionOptions::new().set_read_write(ReadWrite::default()));
+        let context_begin_rw = routing_context_from_selector(Some(&selector_begin_rw), None);
+        assert_eq!(context_begin_rw.transaction_id, None);
+        assert!(!context_begin_rw.use_transaction_affinity);
+
+        // Begin ReadOnly selector: no transaction_id yet, so use_transaction_affinity is false
+        let selector_begin_ro = TransactionSelector::new()
+            .set_begin(TransactionOptions::new().set_read_only(ReadOnly::default()));
+        let context_begin_ro = routing_context_from_selector(Some(&selector_begin_ro), None);
+        assert_eq!(context_begin_ro.transaction_id, None);
+        assert!(!context_begin_ro.use_transaction_affinity);
     }
 
     #[tokio_test_no_panics]
@@ -1907,23 +2370,27 @@ mod tests {
 
         // 1. Neither transaction_id nor routing_key: must return None to preserve channel pool round-robin
         assert!(
-            db_client.resolve_routing_connection(None, None).is_none(),
+            db_client
+                .resolve_routing_connection(&RoutingContext::default())
+                .is_none(),
             "Requests with neither transaction_id nor routing_key must resolve to None"
         );
 
         // 2. Transaction selector without an explicit ID and no routing key: must return None
         let selector_none = TransactionSelector::new();
+        let context_none = routing_context_from_selector(Some(&selector_none), None);
         assert!(
             db_client
-                .resolve_routing_connection(Some(&selector_none), None)
+                .resolve_routing_connection(&context_none)
                 .is_none(),
             "Requests with empty transaction selector must resolve to None"
         );
 
         let selector_single = TransactionSelector::new().set_single_use(TransactionOptions::new());
+        let context_single = routing_context_from_selector(Some(&selector_single), None);
         assert!(
             db_client
-                .resolve_routing_connection(Some(&selector_single), None)
+                .resolve_routing_connection(&context_single)
                 .is_none(),
             "Requests with single_use transaction selector must resolve to None"
         );
@@ -1993,8 +2460,10 @@ mod tests {
 
         // 2. Initial request with transaction_id and routing_key:
         //    Resolves to node-1 AND records transaction affinity in LocationRouter.
+        let initial_context =
+            routing_context_from_selector(Some(&selector), Some(routing_key.as_slice()));
         let initial_connection = db_client
-            .resolve_routing_connection(Some(&selector), Some(routing_key.as_slice()))
+            .resolve_routing_connection(&initial_context)
             .expect("initial connection resolved");
         assert_eq!(initial_connection.address(), node_address);
         assert_eq!(
@@ -2008,8 +2477,9 @@ mod tests {
 
         // 4. Subsequent request with transaction_id but NO routing_key (e.g. unkeyed query):
         //    Must resolve to node-1 via transaction affinity.
+        let unkeyed_context = routing_context_from_selector(Some(&selector), None);
         let unkeyed_connection = db_client
-            .resolve_routing_connection(Some(&selector), None)
+            .resolve_routing_connection(&unkeyed_context)
             .expect("unkeyed request with transaction affinity must resolve to connection");
         assert_eq!(
             unkeyed_connection.address(),
@@ -2019,8 +2489,10 @@ mod tests {
 
         // 5. Subsequent request with transaction_id and a different routing key:
         //    Must STILL resolve to node-1 via transaction affinity.
+        let different_key_context =
+            routing_context_from_selector(Some(&selector), Some(b"Orders.id=99".as_slice()));
         let different_key_connection = db_client
-            .resolve_routing_connection(Some(&selector), Some(b"Orders.id=99".as_slice()))
+            .resolve_routing_connection(&different_key_context)
             .expect("different key request with transaction affinity must resolve");
         assert_eq!(
             different_key_connection.address(),
@@ -2039,7 +2511,7 @@ mod tests {
         // 7. Request with transaction_id after affinity is cleared and with no routing_key:
         //    Must resolve to fallback connection.
         let post_cleanup_connection = db_client
-            .resolve_routing_connection(Some(&selector), None)
+            .resolve_routing_connection(&unkeyed_context)
             .expect("post-cleanup resolution fallback");
         assert_ne!(
             post_cleanup_connection.address(),
@@ -2108,8 +2580,9 @@ mod tests {
         let routing_key = b"Users.id=10";
 
         // 1. None transaction selector with routing key: routes to node-1 without recording affinity
+        let context_none = routing_context_from_selector(None, Some(routing_key.as_slice()));
         let connection_none = db_client
-            .resolve_routing_connection(None, Some(routing_key.as_slice()))
+            .resolve_routing_connection(&context_none)
             .expect("keyed request resolves to connection");
         assert_eq!(connection_none.address(), node_address);
         assert_eq!(
@@ -2120,8 +2593,10 @@ mod tests {
 
         // 2. Single-use transaction selector with routing key: routes to node-1 without recording affinity
         let selector_single = TransactionSelector::new().set_single_use(TransactionOptions::new());
+        let context_single =
+            routing_context_from_selector(Some(&selector_single), Some(routing_key.as_slice()));
         let connection_single = db_client
-            .resolve_routing_connection(Some(&selector_single), Some(routing_key.as_slice()))
+            .resolve_routing_connection(&context_single)
             .expect("single-use keyed request resolves to connection");
         assert_eq!(connection_single.address(), node_address);
         assert_eq!(
@@ -2176,7 +2651,7 @@ mod tests {
 
         // Set up mock expectations for all unary RPCs via macro
         macro_rules! setup_unary_mock {
-            ($method:ident, $expect_method:ident, $request_type:ident, $response_type:ty) => {
+            ($method:ident, $expect_method:ident, $request_type:ident, $response_type:ty $(, $extra:expr)*) => {
                 let captured_clone = Arc::clone(&captured_requests);
                 mock.$expect_method().returning(move |req| {
                     if let Some(id) = req.metadata().get("x-goog-spanner-request-id") {
@@ -2234,7 +2709,7 @@ mod tests {
             let expected_channel_id = format!(".{}.", channel_hint + 1);
 
             macro_rules! call_unary_rpc {
-                ($method:ident, $expect_method:ident, $request_type:ident, $response_type:ty) => {
+                ($method:ident, $expect_method:ident, $request_type:ident, $response_type:ty $(, $extra:expr)*) => {
                     let _ = db_client
                         .$method(
                             $request_type::default(),

--- a/src/spanner/src/routing/key_extractor.rs
+++ b/src/spanner/src/routing/key_extractor.rs
@@ -24,7 +24,8 @@ use crate::Result;
 use crate::key::{Endpoint, KeySet};
 use crate::model::mutation::Operation as ProtoOperation;
 use crate::model::{
-    KeyRecipe, KeySet as ProtoKeySet, Mutation as ProtoMutation, ReadRequest as ProtoReadRequest,
+    KeyRecipe, KeySet as ProtoKeySet, Mutation as ProtoMutation, PartitionReadRequest,
+    ReadRequest as ProtoReadRequest,
 };
 use crate::mutation::{InternalMutation, Mutation};
 use crate::read::ReadRequest;
@@ -362,6 +363,7 @@ pub(crate) fn extract_read_routing_key(
     index: Option<&str>,
     key_set: &KeySet,
 ) -> Option<Vec<u8>> {
+    // Fast path: bypass KeyRecipeCache lock and recipe lookup for full table scans or empty key sets.
     if key_set.all || (key_set.keys.is_empty() && key_set.ranges.is_empty()) {
         return None;
     }
@@ -411,32 +413,61 @@ pub(crate) fn extract_key_from_proto_key_set(
     Ok(Some(buffer))
 }
 
-/// Resolves the table or index [`KeyRecipe`] from [`KeyRecipeCache`] and encodes the routing key for a protobuf [`ProtoReadRequest`].
-pub(crate) fn extract_proto_read_request_routing_key(
+/// Resolves the table or index [`KeyRecipe`] from [`KeyRecipeCache`] and encodes the routing key for read request parameters.
+pub(crate) fn extract_proto_read_key_set_routing_key(
     key_recipe_cache: &KeyRecipeCache,
-    request: &ProtoReadRequest,
+    table: &str,
+    index: &str,
+    key_set: Option<&ProtoKeySet>,
 ) -> Option<Vec<u8>> {
-    let key_set = request.key_set.as_ref()?;
+    let key_set = key_set?;
+    // Fast path: bypass KeyRecipeCache lock and recipe lookup for full table scans or empty key sets.
     if key_set.all || (key_set.keys.is_empty() && key_set.ranges.is_empty()) {
         return None;
     }
-    let recipe = if !request.index.is_empty() {
-        key_recipe_cache.get_index_recipe(&request.index)?
+    let recipe = if !index.is_empty() {
+        key_recipe_cache.get_index_recipe(index)?
     } else {
-        key_recipe_cache.get_table_recipe(&request.table)?
+        key_recipe_cache.get_table_recipe(table)?
     };
     match extract_key_from_proto_key_set(&recipe, key_set) {
         Ok(key) => key,
         Err(err) => {
             warn!(
                 error = %err,
-                table = request.table.as_str(),
-                index = request.index.as_str(),
+                table = table,
+                index = index,
                 "Failed to extract routing key from proto read request"
             );
             None
         }
     }
+}
+
+/// Resolves the table or index [`KeyRecipe`] from [`KeyRecipeCache`] and encodes the routing key for a protobuf [`ProtoReadRequest`].
+pub(crate) fn extract_proto_read_request_routing_key(
+    key_recipe_cache: &KeyRecipeCache,
+    request: &ProtoReadRequest,
+) -> Option<Vec<u8>> {
+    extract_proto_read_key_set_routing_key(
+        key_recipe_cache,
+        &request.table,
+        &request.index,
+        request.key_set.as_ref(),
+    )
+}
+
+/// Resolves the table or index [`KeyRecipe`] from [`KeyRecipeCache`] and encodes the routing key for a protobuf [`PartitionReadRequest`].
+pub(crate) fn extract_proto_partition_read_request_routing_key(
+    key_recipe_cache: &KeyRecipeCache,
+    request: &PartitionReadRequest,
+) -> Option<Vec<u8>> {
+    extract_proto_read_key_set_routing_key(
+        key_recipe_cache,
+        &request.table,
+        &request.index,
+        request.key_set.as_ref(),
+    )
 }
 
 #[cfg(test)]
@@ -1477,6 +1508,111 @@ mod tests {
             extract_proto_read_request_routing_key(&cache, &request),
             None,
             "Invalid date key value must fail encoding, log warning, and return None"
+        );
+    }
+
+    #[test]
+    fn extract_proto_partition_read_request_routing_key_all_cases() {
+        let cache = KeyRecipeCache::new();
+        let recipe = sample_table_recipe_with_identifiers(
+            "Users",
+            vec![(
+                Part::new()
+                    .set_order(Order::Ascending)
+                    .set_null_order(NullOrder::NotNull)
+                    .set_type(Type::default().set_code(TypeCode::Int64)),
+                "id",
+            )],
+        );
+        cache.insert(recipe);
+
+        let index_recipe = sample_index_recipe_with_identifiers(
+            "UsersByEmail",
+            vec![(
+                Part::new()
+                    .set_order(Order::Ascending)
+                    .set_null_order(NullOrder::NotNull)
+                    .set_type(Type::default().set_code(TypeCode::String)),
+                "email",
+            )],
+        );
+        cache.insert(index_recipe);
+
+        // Missing key_set returns None
+        let request_no_key_set = PartitionReadRequest::new().set_table("Users");
+        assert_eq!(
+            extract_proto_partition_read_request_routing_key(&cache, &request_no_key_set),
+            None
+        );
+
+        // KeySet::all returns None
+        let mut key_set_all = ProtoKeySet::new();
+        key_set_all.all = true;
+        let request_all = PartitionReadRequest::new()
+            .set_table("Users")
+            .set_key_set(key_set_all);
+        assert_eq!(
+            extract_proto_partition_read_request_routing_key(&cache, &request_all),
+            None
+        );
+
+        // Table partition read with valid point key
+        let mut key_set_point = ProtoKeySet::new();
+        key_set_point
+            .keys
+            .push(vec![serde_json::Value::String("42".to_string())]);
+        let request_point = PartitionReadRequest::new()
+            .set_table("Users")
+            .set_key_set(key_set_point);
+        let routing_key = extract_proto_partition_read_request_routing_key(&cache, &request_point);
+        assert!(
+            routing_key.is_some(),
+            "Point key in PartitionReadRequest must encode routing key"
+        );
+
+        // Index partition read with valid point key
+        let mut key_set_index = ProtoKeySet::new();
+        key_set_index.keys.push(vec![serde_json::Value::String(
+            "alice@example.com".to_string(),
+        )]);
+        let request_index = PartitionReadRequest::new()
+            .set_table("Users")
+            .set_index("UsersByEmail")
+            .set_key_set(key_set_index);
+        let index_routing_key =
+            extract_proto_partition_read_request_routing_key(&cache, &request_index);
+        assert!(
+            index_routing_key.is_some(),
+            "Index point key in PartitionReadRequest must encode routing key"
+        );
+
+        // Table partition read with closed range
+        let mut key_set_closed_range = ProtoKeySet::new();
+        let range_closed = ProtoKeyRange::new()
+            .set_start_closed(vec![serde_json::Value::String("100".to_string())])
+            .set_end_open(vec![serde_json::Value::String("200".to_string())]);
+        key_set_closed_range.ranges.push(range_closed);
+        let request_closed_range = PartitionReadRequest::new()
+            .set_table("Users")
+            .set_key_set(key_set_closed_range);
+        let closed_range_key =
+            extract_proto_partition_read_request_routing_key(&cache, &request_closed_range);
+        assert!(
+            closed_range_key.is_some(),
+            "Range start in PartitionReadRequest must encode routing key"
+        );
+
+        // Uncached table returns None
+        let mut key_set_uncached = ProtoKeySet::new();
+        key_set_uncached
+            .keys
+            .push(vec![serde_json::Value::String("1".to_string())]);
+        let request_uncached = PartitionReadRequest::new()
+            .set_table("NonExistent")
+            .set_key_set(key_set_uncached);
+        assert_eq!(
+            extract_proto_partition_read_request_routing_key(&cache, &request_uncached),
+            None
         );
     }
 }

--- a/src/spanner/src/routing/mock_tests.rs
+++ b/src/spanner/src/routing/mock_tests.rs
@@ -25,17 +25,25 @@
 //! - Transaction affinity isolation across concurrent transactions and independence for read-only transactions.
 //! - Proactive background cache synchronization via `CacheSubscriber`.
 
+use crate::RequestOptions;
 use crate::client::{Spanner, SpannerBuilderExt};
 use crate::database_client::DatabaseClient;
+use crate::key;
 use crate::key::KeySet;
 use crate::model::directed_read_options::replica_selection::Type as ReplicaType;
 use crate::model::directed_read_options::{
     ExcludeReplicas, IncludeReplicas, ReplicaSelection, Replicas,
 };
+use crate::model::execute_batch_dml_request::Statement as BatchStatement;
+use crate::model::key_recipe::part::{NullOrder, Order, ValueType};
+use crate::model::key_recipe::{Part, Target};
 use crate::model::tablet::Role;
+use crate::model::transaction_options::{ReadOnly, ReadWrite};
 use crate::model::{
-    CacheUpdate as ModelCacheUpdate, DirectedReadOptions, Group as ModelGroup, Range as ModelRange,
-    Tablet as ModelTablet,
+    BeginTransactionRequest, CacheUpdate as ModelCacheUpdate, CommitRequest, DirectedReadOptions,
+    ExecuteBatchDmlRequest, ExecuteSqlRequest, Group as ModelGroup, KeyRecipe,
+    PartitionQueryRequest, PartitionReadRequest, Range as ModelRange, RecipeList, RollbackRequest,
+    Tablet as ModelTablet, TransactionOptions, TransactionSelector, Type, TypeCode,
 };
 use crate::mutation::Mutation;
 use crate::omni::InstanceType;
@@ -57,6 +65,7 @@ use spanner_grpc_mock::google::rpc::Status;
 use spanner_grpc_mock::google::spanner::v1 as mock_v1;
 use spanner_grpc_mock::start;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
@@ -2411,6 +2420,858 @@ async fn proactive_cache_subscriber_streams_update_to_router() -> anyhow::Result
     Ok(())
 }
 
+#[tokio_test_no_panics]
+async fn unary_commit_routes_to_affinity_address_and_clears_affinity() -> anyhow::Result<()> {
+    let mock_gateway = create_base_mock();
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let mut mock_tablet = create_base_mock();
+    let tablet_commit_received = Arc::new(AtomicBool::new(false));
+    let tablet_commit_received_clone = Arc::clone(&tablet_commit_received);
+    mock_tablet.expect_commit().returning(move |_| {
+        tablet_commit_received_clone.store(true, Ordering::SeqCst);
+        Ok(Response::new(mock_v1::CommitResponse {
+            commit_timestamp: Some(Timestamp {
+                seconds: 1700000001,
+                nanos: 0,
+            }),
+            ..Default::default()
+        }))
+    });
+    let (tablet_address, _tablet_server) = start("127.0.0.1:0", mock_tablet).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+
+    let client_config = database_client
+        .cache_updater()
+        .expect("cache updater present")
+        .client_config();
+    let _ = router
+        .connection_cache()
+        .get(&tablet_address, client_config)
+        .await?;
+
+    let transaction_id = b"tx-commit-affinity-test";
+    router.record_transaction_affinity(transaction_id, &tablet_address);
+    assert_eq!(
+        router.get_transaction_affinity(transaction_id),
+        Some(Arc::from(tablet_address.as_str())),
+        "affinity must be recorded before commit"
+    );
+
+    let commit_request = CommitRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_transaction_id(Bytes::copy_from_slice(transaction_id));
+
+    let response = database_client
+        .commit(commit_request, RequestOptions::default(), 0)
+        .await?;
+
+    assert!(
+        tablet_commit_received.load(Ordering::SeqCst),
+        "commit request must be routed directly to the tablet affinity connection"
+    );
+    assert_eq!(
+        response
+            .commit_timestamp
+            .as_ref()
+            .map(|timestamp| timestamp.seconds()),
+        Some(1700000001),
+        "commit response timestamp must match mock"
+    );
+    assert_eq!(
+        router.get_transaction_affinity(transaction_id),
+        None,
+        "commit completion must clear transaction affinity"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn unary_rollback_routes_to_affinity_address_and_clears_affinity() -> anyhow::Result<()> {
+    let mock_gateway = create_base_mock();
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let mut mock_tablet = create_base_mock();
+    let tablet_rollback_received = Arc::new(AtomicBool::new(false));
+    let tablet_rollback_received_clone = Arc::clone(&tablet_rollback_received);
+    mock_tablet.expect_rollback().returning(move |_| {
+        tablet_rollback_received_clone.store(true, Ordering::SeqCst);
+        Ok(Response::new(()))
+    });
+    let (tablet_address, _tablet_server) = start("127.0.0.1:0", mock_tablet).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+
+    let client_config = database_client
+        .cache_updater()
+        .expect("cache updater present")
+        .client_config();
+    let _ = router
+        .connection_cache()
+        .get(&tablet_address, client_config)
+        .await?;
+
+    let transaction_id = b"tx-rollback-affinity-test";
+    router.record_transaction_affinity(transaction_id, &tablet_address);
+    assert_eq!(
+        router.get_transaction_affinity(transaction_id),
+        Some(Arc::from(tablet_address.as_str())),
+        "affinity must be recorded before rollback"
+    );
+
+    let rollback_request = RollbackRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_transaction_id(Bytes::copy_from_slice(transaction_id));
+
+    database_client
+        .rollback(rollback_request, RequestOptions::default(), 0)
+        .await?;
+
+    assert!(
+        tablet_rollback_received.load(Ordering::SeqCst),
+        "rollback request must be routed directly to the tablet affinity connection"
+    );
+    assert_eq!(
+        router.get_transaction_affinity(transaction_id),
+        None,
+        "rollback completion must clear transaction affinity"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn unary_single_use_commit_routes_to_leader_tablet_replica() -> anyhow::Result<()> {
+    let mock_gateway = create_base_mock();
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let mut mock_tablet_leader = create_base_mock();
+    let leader_commit_received = Arc::new(AtomicBool::new(false));
+    let leader_commit_received_clone = Arc::clone(&leader_commit_received);
+    mock_tablet_leader.expect_commit().returning(move |_| {
+        leader_commit_received_clone.store(true, Ordering::SeqCst);
+        Ok(Response::new(mock_v1::CommitResponse {
+            commit_timestamp: Some(Timestamp {
+                seconds: 1700000002,
+                nanos: 0,
+            }),
+            ..Default::default()
+        }))
+    });
+    let (tablet_leader_address, _tablet_leader_server) =
+        start("127.0.0.1:0", mock_tablet_leader).await?;
+
+    let mock_tablet_follower = create_base_mock();
+    let (tablet_follower_address, _tablet_follower_server) =
+        start("127.0.0.1:0", mock_tablet_follower).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let mut update = sample_model_cache_update(
+        10101,
+        8001,
+        &tablet_leader_address,
+        &tablet_follower_address,
+    );
+    update.range = vec![ModelRange {
+        start_key: Bytes::from_static(b""),
+        limit_key: Bytes::from_static(b""),
+        group_uid: 8001,
+        split_id: 8001,
+        generation: Bytes::from_static(b"gen_1"),
+        _unknown_fields: Default::default(),
+    }];
+    database_client.observe_cache_update(Some(update));
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+    let client_config = database_client
+        .cache_updater()
+        .expect("cache updater present")
+        .client_config();
+    let _ = router
+        .connection_cache()
+        .get(&tablet_leader_address, client_config)
+        .await?;
+
+    let mutation = Mutation::new_insert_builder("Singers")
+        .set("SingerId")
+        .to(101i64)
+        .set("Name")
+        .to("Alice")
+        .build();
+
+    let commit_request = CommitRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_mutations(vec![mutation.build_proto()]);
+
+    let response = database_client
+        .commit(commit_request, RequestOptions::default(), 0)
+        .await?;
+
+    assert!(
+        leader_commit_received.load(Ordering::SeqCst),
+        "single-use commit must route directly to the leader tablet replica"
+    );
+    assert_eq!(
+        response
+            .commit_timestamp
+            .as_ref()
+            .map(|timestamp| timestamp.seconds()),
+        Some(1700000002),
+        "commit response timestamp must match mock"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn unary_begin_transaction_with_mutation_key_routes_to_leader_and_records_affinity()
+-> anyhow::Result<()> {
+    let mock_gateway = create_base_mock();
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let mut mock_tablet_leader = create_base_mock();
+    let leader_begin_received = Arc::new(AtomicBool::new(false));
+    let leader_begin_received_clone = Arc::clone(&leader_begin_received);
+    mock_tablet_leader
+        .expect_begin_transaction()
+        .returning(move |_| {
+            leader_begin_received_clone.store(true, Ordering::SeqCst);
+            Ok(Response::new(mock_v1::Transaction {
+                id: b"tx-begin-routed-123".to_vec(),
+                ..Default::default()
+            }))
+        });
+    let (tablet_leader_address, _tablet_leader_server) =
+        start("127.0.0.1:0", mock_tablet_leader).await?;
+
+    let mock_tablet_follower = create_base_mock();
+    let (tablet_follower_address, _tablet_follower_server) =
+        start("127.0.0.1:0", mock_tablet_follower).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let mut update = sample_model_cache_update(
+        10102,
+        8002,
+        &tablet_leader_address,
+        &tablet_follower_address,
+    );
+    update.range = vec![ModelRange {
+        start_key: Bytes::from_static(b""),
+        limit_key: Bytes::from_static(b""),
+        group_uid: 8002,
+        split_id: 8002,
+        generation: Bytes::from_static(b"gen_1"),
+        _unknown_fields: Default::default(),
+    }];
+    database_client.observe_cache_update(Some(update));
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+    let client_config = database_client
+        .cache_updater()
+        .expect("cache updater present")
+        .client_config();
+    let _ = router
+        .connection_cache()
+        .get(&tablet_leader_address, client_config)
+        .await?;
+
+    let mutation = Mutation::new_insert_builder("Singers")
+        .set("SingerId")
+        .to(101i64)
+        .build();
+
+    let begin_request = BeginTransactionRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_options(TransactionOptions::default().set_read_write(ReadWrite::default()))
+        .set_mutation_key(mutation.build_proto());
+
+    let response = database_client
+        .begin_transaction(begin_request, RequestOptions::default(), 0)
+        .await?;
+
+    assert!(
+        leader_begin_received.load(Ordering::SeqCst),
+        "explicit begin transaction with mutation key must route to the leader tablet"
+    );
+    assert_eq!(
+        response.id.as_ref(),
+        b"tx-begin-routed-123",
+        "transaction ID must match mock"
+    );
+    assert_eq!(
+        router.get_transaction_affinity(b"tx-begin-routed-123"),
+        Some(Arc::from(tablet_leader_address.as_str())),
+        "read-write transaction ID returned from begin_transaction must bind server affinity"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn unary_begin_transaction_with_read_only_options_does_not_record_affinity()
+-> anyhow::Result<()> {
+    let mock_gateway = create_base_mock();
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let mut mock_tablet_leader = create_base_mock();
+    let leader_begin_received = Arc::new(AtomicBool::new(false));
+    let leader_begin_received_clone = Arc::clone(&leader_begin_received);
+    mock_tablet_leader
+        .expect_begin_transaction()
+        .returning(move |_| {
+            leader_begin_received_clone.store(true, Ordering::SeqCst);
+            Ok(Response::new(mock_v1::Transaction {
+                id: b"tx-ro-begin-123".to_vec(),
+                ..Default::default()
+            }))
+        });
+    let (tablet_leader_address, _tablet_leader_server) =
+        start("127.0.0.1:0", mock_tablet_leader).await?;
+
+    let mock_tablet_follower = create_base_mock();
+    let (tablet_follower_address, _tablet_follower_server) =
+        start("127.0.0.1:0", mock_tablet_follower).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let mut update = sample_model_cache_update(
+        10103,
+        8003,
+        &tablet_leader_address,
+        &tablet_follower_address,
+    );
+    update.range = vec![ModelRange {
+        start_key: Bytes::from_static(b""),
+        limit_key: Bytes::from_static(b""),
+        group_uid: 8003,
+        split_id: 8003,
+        generation: Bytes::from_static(b"gen_1"),
+        _unknown_fields: Default::default(),
+    }];
+    database_client.observe_cache_update(Some(update));
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+    let client_config = database_client
+        .cache_updater()
+        .expect("cache updater present")
+        .client_config();
+    let _ = router
+        .connection_cache()
+        .get(&tablet_leader_address, client_config)
+        .await?;
+
+    let mutation = Mutation::new_insert_builder("Singers")
+        .set("SingerId")
+        .to(101i64)
+        .build();
+
+    let begin_request = BeginTransactionRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_options(TransactionOptions::default().set_read_only(ReadOnly::new().set_strong(true)))
+        .set_mutation_key(mutation.build_proto());
+
+    let response = database_client
+        .begin_transaction(begin_request, RequestOptions::default(), 0)
+        .await?;
+
+    assert!(
+        leader_begin_received.load(Ordering::SeqCst),
+        "read-only begin transaction with mutation key routes to tablet leader"
+    );
+    assert_eq!(
+        response.id.as_ref(),
+        b"tx-ro-begin-123",
+        "transaction ID must match mock"
+    );
+    assert_eq!(
+        router.get_transaction_affinity(b"tx-ro-begin-123"),
+        None,
+        "read-only transaction must NOT bind transaction affinity in location router"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn unary_execute_sql_routes_to_affinity_address() -> anyhow::Result<()> {
+    let mock_gateway = create_base_mock();
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let mut mock_tablet = create_base_mock();
+    let tablet_sql_received = Arc::new(AtomicBool::new(false));
+    let tablet_sql_received_clone = Arc::clone(&tablet_sql_received);
+    mock_tablet.expect_execute_sql().returning(move |_| {
+        tablet_sql_received_clone.store(true, Ordering::SeqCst);
+        Ok(Response::new(mock_v1::ResultSet::default()))
+    });
+    let (tablet_address, _tablet_server) = start("127.0.0.1:0", mock_tablet).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+    let client_config = database_client
+        .cache_updater()
+        .expect("cache updater present")
+        .client_config();
+    let _ = router
+        .connection_cache()
+        .get(&tablet_address, client_config)
+        .await?;
+
+    let transaction_id = b"tx-sql-affinity-test";
+    router.record_transaction_affinity(transaction_id, &tablet_address);
+
+    let execute_sql_request = ExecuteSqlRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_sql("SELECT 1")
+        .set_transaction(
+            TransactionSelector::default().set_id(Bytes::copy_from_slice(transaction_id)),
+        );
+
+    let _ = database_client
+        .execute_sql(execute_sql_request, RequestOptions::default(), 0)
+        .await?;
+
+    assert!(
+        tablet_sql_received.load(Ordering::SeqCst),
+        "execute_sql request with transaction affinity must route to affinity tablet"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn unary_execute_sql_with_inline_begin_rw_records_affinity() -> anyhow::Result<()> {
+    let mut mock_gateway = create_base_mock();
+    let gateway_sql_received = Arc::new(AtomicBool::new(false));
+    let gateway_sql_received_clone = Arc::clone(&gateway_sql_received);
+    mock_gateway.expect_execute_sql().returning(move |_| {
+        gateway_sql_received_clone.store(true, Ordering::SeqCst);
+        Ok(Response::new(mock_v1::ResultSet {
+            metadata: Some(mock_v1::ResultSetMetadata {
+                transaction: Some(mock_v1::Transaction {
+                    id: b"tx-inline-sql-rw".to_vec(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+    });
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+
+    let execute_sql_request = ExecuteSqlRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_sql("SELECT 1")
+        .set_transaction(
+            TransactionSelector::default()
+                .set_begin(TransactionOptions::default().set_read_write(ReadWrite::default())),
+        );
+
+    let _ = database_client
+        .execute_sql(execute_sql_request, RequestOptions::default(), 0)
+        .await?;
+
+    assert!(
+        gateway_sql_received.load(Ordering::SeqCst),
+        "execute_sql with inline begin must be executed"
+    );
+    assert_eq!(
+        router.get_transaction_affinity(b"tx-inline-sql-rw"),
+        Some(Arc::from(gateway_address.as_str())),
+        "inline begin in execute_sql must record transaction affinity"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn unary_execute_batch_dml_routes_to_affinity_address() -> anyhow::Result<()> {
+    let mock_gateway = create_base_mock();
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let mut mock_tablet = create_base_mock();
+    let tablet_batch_received = Arc::new(AtomicBool::new(false));
+    let tablet_batch_received_clone = Arc::clone(&tablet_batch_received);
+    mock_tablet.expect_execute_batch_dml().returning(move |_| {
+        tablet_batch_received_clone.store(true, Ordering::SeqCst);
+        Ok(Response::new(mock_v1::ExecuteBatchDmlResponse::default()))
+    });
+    let (tablet_address, _tablet_server) = start("127.0.0.1:0", mock_tablet).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+    let client_config = database_client
+        .cache_updater()
+        .expect("cache updater present")
+        .client_config();
+    let _ = router
+        .connection_cache()
+        .get(&tablet_address, client_config)
+        .await?;
+
+    let transaction_id = b"tx-batch-affinity-test";
+    router.record_transaction_affinity(transaction_id, &tablet_address);
+
+    let batch_dml_request = ExecuteBatchDmlRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_transaction(
+            TransactionSelector::default().set_id(Bytes::copy_from_slice(transaction_id)),
+        )
+        .set_statements(vec![
+            BatchStatement::default().set_sql("UPDATE Singers SET Name = 'Bob' WHERE SingerId = 1"),
+        ])
+        .set_seqno(1);
+
+    let _ = database_client
+        .execute_batch_dml(batch_dml_request, RequestOptions::default(), 0)
+        .await?;
+
+    assert!(
+        tablet_batch_received.load(Ordering::SeqCst),
+        "execute_batch_dml request with transaction affinity must route to affinity tablet"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn unary_execute_batch_dml_with_inline_begin_rw_records_affinity() -> anyhow::Result<()> {
+    let mut mock_gateway = create_base_mock();
+    let gateway_batch_received = Arc::new(AtomicBool::new(false));
+    let gateway_batch_received_clone = Arc::clone(&gateway_batch_received);
+    mock_gateway.expect_execute_batch_dml().returning(move |_| {
+        gateway_batch_received_clone.store(true, Ordering::SeqCst);
+        Ok(Response::new(mock_v1::ExecuteBatchDmlResponse {
+            result_sets: vec![mock_v1::ResultSet {
+                metadata: Some(mock_v1::ResultSetMetadata {
+                    transaction: Some(mock_v1::Transaction {
+                        id: b"tx-inline-batch-rw".to_vec(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }))
+    });
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+
+    let batch_dml_request = ExecuteBatchDmlRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_transaction(
+            TransactionSelector::default()
+                .set_begin(TransactionOptions::default().set_read_write(ReadWrite::default())),
+        )
+        .set_statements(vec![
+            BatchStatement::default().set_sql("UPDATE Singers SET Name = 'Bob' WHERE SingerId = 1"),
+        ])
+        .set_seqno(1);
+
+    let _ = database_client
+        .execute_batch_dml(batch_dml_request, RequestOptions::default(), 0)
+        .await?;
+
+    assert!(
+        gateway_batch_received.load(Ordering::SeqCst),
+        "execute_batch_dml with inline begin must be executed"
+    );
+    assert_eq!(
+        router.get_transaction_affinity(b"tx-inline-batch-rw"),
+        Some(Arc::from(gateway_address.as_str())),
+        "inline begin in execute_batch_dml must record transaction affinity"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn unary_partition_read_routes_to_tablet_node() -> anyhow::Result<()> {
+    let mock_gateway = create_base_mock();
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let mut mock_tablet = create_base_mock();
+    let tablet_partition_read_received = Arc::new(AtomicBool::new(false));
+    let tablet_partition_read_received_clone = Arc::clone(&tablet_partition_read_received);
+    mock_tablet.expect_partition_read().returning(move |_| {
+        tablet_partition_read_received_clone.store(true, Ordering::SeqCst);
+        Ok(Response::new(mock_v1::PartitionResponse::default()))
+    });
+    let (tablet_address, _tablet_server) = start("127.0.0.1:0", mock_tablet).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let mut update = sample_model_cache_update(10106, 8006, &tablet_address, &tablet_address);
+    update.range = vec![ModelRange {
+        start_key: Bytes::from_static(b""),
+        limit_key: Bytes::from_static(b""),
+        group_uid: 8006,
+        split_id: 8006,
+        generation: Bytes::from_static(b"gen_1"),
+        _unknown_fields: Default::default(),
+    }];
+    database_client.observe_cache_update(Some(update));
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+    let client_config = database_client
+        .cache_updater()
+        .expect("cache updater present")
+        .client_config();
+    let _ = router
+        .connection_cache()
+        .get(&tablet_address, client_config)
+        .await?;
+
+    let key_set = KeySet::from(key![101i64]);
+    let partition_read_request = PartitionReadRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_table("Singers")
+        .set_key_set(key_set.into_proto());
+
+    let _ = database_client
+        .partition_read(partition_read_request, RequestOptions::default(), 0)
+        .await?;
+
+    assert!(
+        tablet_partition_read_received.load(Ordering::SeqCst),
+        "partition_read request with point key must route to tablet connection"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn unary_partition_query_with_transaction_id_routes_to_affinity_address() -> anyhow::Result<()>
+{
+    let mock_gateway = create_base_mock();
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let mut mock_tablet = create_base_mock();
+    let tablet_partition_query_received = Arc::new(AtomicBool::new(false));
+    let tablet_partition_query_received_clone = Arc::clone(&tablet_partition_query_received);
+    mock_tablet.expect_partition_query().returning(move |_| {
+        tablet_partition_query_received_clone.store(true, Ordering::SeqCst);
+        Ok(Response::new(mock_v1::PartitionResponse::default()))
+    });
+    let (tablet_address, _tablet_server) = start("127.0.0.1:0", mock_tablet).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+    let client_config = database_client
+        .cache_updater()
+        .expect("cache updater present")
+        .client_config();
+    let _ = router
+        .connection_cache()
+        .get(&tablet_address, client_config)
+        .await?;
+
+    let transaction_id = b"tx-part-query-affinity";
+    router.record_transaction_affinity(transaction_id, &tablet_address);
+
+    let partition_query_request = PartitionQueryRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_sql("SELECT * FROM Singers")
+        .set_transaction(
+            TransactionSelector::default().set_id(Bytes::copy_from_slice(transaction_id)),
+        );
+
+    let _ = database_client
+        .partition_query(partition_query_request, RequestOptions::default(), 0)
+        .await?;
+
+    assert!(
+        tablet_partition_query_received.load(Ordering::SeqCst),
+        "partition_query request with transaction affinity must route to affinity tablet"
+    );
+
+    Ok(())
+}
+
 fn create_base_mock() -> MockSpanner {
     let mut mock = MockSpanner::new();
     mock.expect_create_session().returning(|_| {
@@ -2590,7 +3451,37 @@ fn sample_model_cache_update(
             generation: Bytes::from_static(b"gen_1"),
             _unknown_fields: Default::default(),
         }],
-        key_recipes: None,
+        key_recipes: Some(RecipeList {
+            schema_generation: Bytes::from_static(b"schema_v1"),
+            recipe: vec![KeyRecipe {
+                target: Some(Target::TableName("Singers".to_string())),
+                part: vec![
+                    Part {
+                        tag: 100,
+                        order: Order::Unspecified,
+                        null_order: NullOrder::Unspecified,
+                        r#type: None,
+                        struct_identifiers: vec![],
+                        value_type: None,
+                        _unknown_fields: Default::default(),
+                    },
+                    Part {
+                        tag: 0,
+                        order: Order::Ascending,
+                        null_order: NullOrder::NullsFirst,
+                        r#type: Some(Type {
+                            code: TypeCode::Int64,
+                            ..Default::default()
+                        }),
+                        struct_identifiers: vec![],
+                        value_type: Some(ValueType::Identifier("SingerId".to_string())),
+                        _unknown_fields: Default::default(),
+                    },
+                ],
+                _unknown_fields: Default::default(),
+            }],
+            _unknown_fields: Default::default(),
+        }),
         _unknown_fields: Default::default(),
     }
 }


### PR DESCRIPTION
- Wire `LocationRouter` into unary database RPCs (`begin_transaction`, `commit`, `rollback`, `execute_sql`, `execute_batch_dml`, `partition_read`, `partition_query`).
- Add routing key extraction for `PartitionReadRequest` and `PartitionQueryRequest`.
- Track and enforce transaction server affinity for read-write transactions (including inline begin and commit/rollback lifecycle clearing).
- Ingest inline `CacheUpdate` from unary responses (`CommitResponse`, `Transaction`, `ResultSet`, `ExecuteBatchDmlResponse`).