### PR TITLE
cleanup(gax): remove google_cloud_unstable_gapic_streaming

### DIFF
--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -40,7 +40,6 @@ locals {
     "--cfg google_cloud_unstable_grpc_server_streaming",
     "--cfg google_cloud_unstable_tracing",
     "--cfg google_cloud_unstable_grpc_rust",
-    "--cfg google_cloud_unstable_gapic_streaming",
   ])
 
   tokio_unstable_flags = "--cfg tokio_unstable"

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -25,7 +25,7 @@ env:
   GHA_RUST_VERSIONS: '{ "rust:current": "1.98" }'
   GHA_GO_VERSIONS: '{ "go:current": "1.25.6" }'
   # Define the unstable flags once
-  UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_trust_boundaries --cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming --cfg google_cloud_unstable_tracing --cfg google_cloud_unstable_gapic_streaming'
+  UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_trust_boundaries --cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming --cfg google_cloud_unstable_tracing'
 
 jobs:
   build:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3529,7 +3529,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax-internal"
-version = "0.7.18"
+version = "0.7.19"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -607,7 +607,6 @@ storage-grpc-mock         = { path = "src/storage/grpc-mock" }
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = [
-  'cfg(google_cloud_unstable_gapic_streaming)',
   'cfg(google_cloud_unstable_grpc_rust)',
   'cfg(google_cloud_unstable_grpc_server_streaming)',
   'cfg(google_cloud_unstable_storage_bidi)',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -530,8 +530,8 @@ tokio-stream      = { default-features = false, version = "0.1.16" }
 
 # Local packages used as dependencies.
 google-cloud-auth        = { default-features = false, version = "1.16.0", path = "src/auth" }
-google-cloud-gax         = { default-features = false, version = "1.14.0", path = "src/gax" }
-gaxi                     = { default-features = false, version = "0.7.18", path = "src/gax-internal", package = "google-cloud-gax-internal" }
+google-cloud-gax         = { default-features = false, version = "1.15.0", path = "src/gax" }
+gaxi                     = { default-features = false, version = "0.7.19", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 wkt                      = { default-features = false, version = "1.7.0", path = "src/wkt", package = "google-cloud-wkt" }
 google-cloud-wkt         = { default-features = false, version = "1.7.0", path = "src/wkt", package = "google-cloud-wkt" }
 google-cloud-api         = { default-features = false, version = "1.7.0", path = "src/generated/api/types" }

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -948,11 +948,11 @@ libraries:
     version: 1.14.0
     copyright_year: "2025"
   - name: google-cloud-gax
-    version: 1.14.0
+    version: 1.15.0
     copyright_year: "2025"
     output: src/gax
   - name: google-cloud-gax-internal
-    version: 0.7.18
+    version: 0.7.19
     copyright_year: "2025"
     output: src/gax-internal
     rust:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.39.1-0.20260826211627-9acd367c5252
+version: v0.39.1-0.20260827174510-d04c05be6896
 repo: googleapis/google-cloud-rust
 sources:
   conformance:

--- a/src/bigquery-read/src/generated/gapic_storage/builder.rs
+++ b/src/bigquery-read/src/generated/gapic_storage/builder.rs
@@ -181,11 +181,9 @@ pub mod read {
     ///   // ... details omitted ...
     /// }
     /// ```
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug)]
     pub struct ReadRows(RequestBuilder<crate::model::ReadRowsRequest>);
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl ReadRows {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::Read>) -> Self {
             Self(RequestBuilder::new(stub))
@@ -257,7 +255,6 @@ pub mod read {
         }
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[doc(hidden)]
     impl crate::RequestBuilder for ReadRows {
         fn request_options(&mut self) -> &mut crate::RequestOptions {

--- a/src/bigquery-read/src/generated/gapic_storage/client.rs
+++ b/src/bigquery-read/src/generated/gapic_storage/client.rs
@@ -145,7 +145,6 @@ impl Read {
         super::builder::read::CreateReadSession::new(self.inner.clone())
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     /// Reads rows from the stream in the format prescribed by the ReadSession.
     /// Each response contains one or more table rows, up to a maximum of 128 MB
     /// per response; read requests which attempt to read individual rows larger

--- a/src/bigquery-read/src/generated/gapic_storage/stub.rs
+++ b/src/bigquery-read/src/generated/gapic_storage/stub.rs
@@ -49,7 +49,6 @@ pub trait Read: std::fmt::Debug + Send + Sync {
     }
 
     /// Implements [super::client::Read::read_rows].
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn read_rows(
         &self,
         _req: crate::model::ReadRowsRequest,

--- a/src/bigquery-read/src/generated/gapic_storage/stub/dynamic.rs
+++ b/src/bigquery-read/src/generated/gapic_storage/stub/dynamic.rs
@@ -23,7 +23,6 @@ pub trait Read: std::fmt::Debug + Send + Sync {
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<crate::model::ReadSession>>;
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn read_rows(
         &self,
         req: crate::model::ReadRowsRequest,
@@ -50,7 +49,6 @@ impl<T: super::Read> Read for T {
     }
 
     /// Forwards the call to the implementation provided by `T`.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn read_rows(
         &self,
         req: crate::model::ReadRowsRequest,

--- a/src/bigquery-read/src/generated/gapic_storage/tracing.rs
+++ b/src/bigquery-read/src/generated/gapic_storage/tracing.rs
@@ -55,7 +55,6 @@ where
         pending.await
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn read_rows(
         &self,
         req: crate::model::ReadRowsRequest,

--- a/src/bigquery-read/src/generated/gapic_storage/transport.rs
+++ b/src/bigquery-read/src/generated/gapic_storage/transport.rs
@@ -126,7 +126,6 @@ impl super::stub::Read for Read {
             .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::ReadSession>)
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn read_rows(
         &self,
         req: crate::model::ReadRowsRequest,

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-gax-internal"
-version     = "0.7.18"
+version     = "0.7.19"
 description = "Google Cloud Client Libraries for Rust - Implementation Details"
 build       = "build.rs"
 # Inherit other attributes from the workspace.

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -19,7 +19,6 @@ mod grpc_helpers;
 #[cfg(google_cloud_unstable_grpc_rust)]
 mod grpc_rust;
 pub mod status;
-#[cfg(google_cloud_unstable_gapic_streaming)]
 pub(crate) mod streaming;
 pub mod tonic;
 mod transport_policies;
@@ -230,7 +229,6 @@ impl Client {
     }
 
     /// Opens a bidirectional stream with automatic model <-> proto conversion and channel management.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     pub fn execute_bidi_streaming<DomainReq, DomainResp, ProstReq, ProstResp>(
         &self,
         extensions: tonic::Extensions,
@@ -264,7 +262,6 @@ impl Client {
         )
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn spawn_bidi_stream<ProstReq, ProstResp>(
         &self,
         extensions: tonic::Extensions,
@@ -381,7 +378,6 @@ impl Client {
     }
 
     /// Opens a server stream with automatic model <-> proto conversion and stream mapping.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     pub async fn execute_server_streaming<DomainReq, DomainResp, ProstReq, ProstResp>(
         &self,
         extensions: tonic::Extensions,

--- a/src/gax-internal/src/unimplemented.rs
+++ b/src/gax-internal/src/unimplemented.rs
@@ -14,7 +14,6 @@
 
 use google_cloud_gax::Result;
 use google_cloud_gax::response::Response;
-#[cfg(google_cloud_unstable_gapic_streaming)]
 use google_cloud_gax::streaming::{RequestSender, ResponseReceiver};
 
 pub const UNIMPLEMENTED: &str = concat!(
@@ -33,12 +32,10 @@ pub async fn unimplemented_stub<T: Send>() -> Result<Response<T>> {
     unimplemented!("{UNIMPLEMENTED}");
 }
 
-#[cfg(google_cloud_unstable_gapic_streaming)]
 pub fn unimplemented_bidi_stub<I, O>() -> (RequestSender<I>, ResponseReceiver<O>) {
     unimplemented!("{UNIMPLEMENTED}");
 }
 
-#[cfg(google_cloud_unstable_gapic_streaming)]
 pub async fn unimplemented_server_streaming_stub<O: Send>() -> Result<ResponseReceiver<O>> {
     unimplemented!("{UNIMPLEMENTED}");
 }
@@ -53,14 +50,12 @@ mod tests {
         let _ = unimplemented_stub::<()>().await;
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[test]
     #[should_panic(expected = "to prevent breaking changes as services gain new RPCs")]
     fn test_unimplemented_bidi_stub() {
         let _ = unimplemented_bidi_stub::<(), ()>();
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[tokio::test]
     #[should_panic(expected = "to prevent breaking changes as services gain new RPCs")]
     async fn test_unimplemented_server_streaming_stub() {

--- a/src/gax-internal/tests/grpc_server_streaming_request.rs
+++ b/src/gax-internal/tests/grpc_server_streaming_request.rs
@@ -255,13 +255,11 @@ mod tests {
             .await
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug, PartialEq)]
     struct DomainEchoRequest {
         message: String,
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl google_cloud_gax_internal::prost::ToProto<EchoRequest> for DomainEchoRequest {
         type Output = EchoRequest;
         fn to_proto(
@@ -275,13 +273,11 @@ mod tests {
         }
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug, PartialEq)]
     struct DomainEchoResponse {
         message: String,
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl google_cloud_gax_internal::prost::FromProto<DomainEchoResponse> for EchoResponse {
         fn cnv(
             self,
@@ -293,7 +289,6 @@ mod tests {
         }
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[tokio::test]
     async fn execute_server_streaming_basic() -> anyhow::Result<()> {
         let (endpoint, _server) = start_echo_server().await?;

--- a/src/gax-internal/tests/grpc_streaming_request.rs
+++ b/src/gax-internal/tests/grpc_streaming_request.rs
@@ -259,13 +259,11 @@ mod tests {
             .await
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug, PartialEq)]
     struct DomainEchoRequest {
         message: String,
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl google_cloud_gax_internal::prost::ToProto<EchoRequest> for DomainEchoRequest {
         type Output = EchoRequest;
         fn to_proto(
@@ -279,13 +277,11 @@ mod tests {
         }
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug, PartialEq)]
     struct DomainEchoResponse {
         message: String,
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl google_cloud_gax_internal::prost::FromProto<DomainEchoResponse> for EchoResponse {
         fn cnv(
             self,
@@ -297,7 +293,6 @@ mod tests {
         }
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[tokio::test]
     async fn execute_bidi_streaming_basic() -> anyhow::Result<()> {
         let (endpoint, _server) = start_echo_server().await?;

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -18,7 +18,7 @@ name = "google-cloud-gax"
 #     version of all downstream dependencies. For details see:
 #         https://github.com/googleapis/google-cloud-rust/issues/3237
 #         https://github.com/googleapis/google-cloud-rust/issues/3265
-version     = "1.14.0"
+version     = "1.15.0"
 description = "Google Cloud Client Libraries for Rust"
 # Inherit other attributes from the workspace.
 authors.workspace      = true

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -39,7 +39,6 @@ pub mod paginator;
 
 pub mod response;
 
-#[cfg(google_cloud_unstable_gapic_streaming)]
 pub mod streaming;
 
 pub mod backoff_policy;

--- a/src/gax/src/options.rs
+++ b/src/gax/src/options.rs
@@ -50,7 +50,6 @@ pub struct RequestOptions {
     retry_throttler: Option<SharedRetryThrottler>,
     polling_error_policy: Option<Arc<dyn PollingErrorPolicy>>,
     polling_backoff_policy: Option<Arc<dyn PollingBackoffPolicy>>,
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     request_stream_channel_capacity: Option<usize>,
     extensions: http::Extensions,
 }
@@ -174,7 +173,6 @@ impl RequestOptions {
     }
 
     /// Gets the current request stream channel capacity, if set.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     pub fn request_stream_channel_capacity(&self) -> Option<usize> {
         self.request_stream_channel_capacity
     }
@@ -182,7 +180,6 @@ impl RequestOptions {
     /// Sets the buffer capacity of the internal request channel for streaming RPCs.
     ///
     /// Valid values are between `1` and `usize::MAX >> 3`. Values outside this range will be clamped.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     pub fn set_request_stream_channel_capacity(&mut self, capacity: usize) {
         self.request_stream_channel_capacity =
             Some(capacity.clamp(1, MAX_REQUEST_CHANNEL_CAPACITY));
@@ -193,7 +190,6 @@ impl RequestOptions {
 ///
 /// This upper limit matches Tokio's internal `mpsc::channel` capacity limit
 /// (`usize::MAX >> 3`).
-#[cfg(google_cloud_unstable_gapic_streaming)]
 const MAX_REQUEST_CHANNEL_CAPACITY: usize = usize::MAX >> 3;
 
 /// Implementations of this trait provide setters to configure request options.
@@ -304,7 +300,6 @@ pub trait RequestOptionsBuilder: internal::RequestBuilder {
     ///
     /// Valid values are between `1` and `usize::MAX >> 3`. The default
     /// capacity is `16`. Values outside this range will be clamped.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn with_request_stream_channel_capacity(self, _capacity: usize) -> Self
     where
         Self: Sized,
@@ -482,7 +477,6 @@ where
         self
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn with_request_stream_channel_capacity(mut self, capacity: usize) -> Self {
         self.request_options()
             .set_request_stream_channel_capacity(capacity);
@@ -718,7 +712,6 @@ mod tests {
         );
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[test]
     fn request_options_builder_request_stream_channel_capacity() {
         let builder = TestBuilder::default();

--- a/src/generated/cloud/speech/v2/src/builder.rs
+++ b/src/generated/cloud/speech/v2/src/builder.rs
@@ -70,14 +70,12 @@ pub mod speech {
     }
 
     /// Common implementation for [crate::client::Speech] bidi stream builders.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug)]
     pub(crate) struct BidiStreamBuilder {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Speech>,
         options: crate::RequestOptions,
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl BidiStreamBuilder {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::Speech>) -> Self {
             Self {
@@ -987,11 +985,9 @@ pub mod speech {
     ///   // ... details omitted ...
     /// }
     /// ```
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug)]
     pub struct StreamingRecognize(BidiStreamBuilder);
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl StreamingRecognize {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::Speech>) -> Self {
             Self(BidiStreamBuilder::new(stub))
@@ -1014,7 +1010,6 @@ pub mod speech {
         }
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[doc(hidden)]
     impl crate::RequestBuilder for StreamingRecognize {
         fn request_options(&mut self) -> &mut crate::RequestOptions {

--- a/src/generated/cloud/speech/v2/src/client.rs
+++ b/src/generated/cloud/speech/v2/src/client.rs
@@ -339,7 +339,6 @@ impl Speech {
         super::builder::speech::Recognize::new(self.inner.clone())
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     /// Performs bidirectional streaming speech recognition: receive results while
     /// sending audio. This method is only available via the gRPC API (not REST).
     ///

--- a/src/generated/cloud/speech/v2/src/lib.rs
+++ b/src/generated/cloud/speech/v2/src/lib.rs
@@ -83,7 +83,6 @@ pub(crate) mod tracing;
 #[doc(hidden)]
 pub(crate) mod transport;
 
-#[cfg(google_cloud_unstable_gapic_streaming)]
 #[doc(hidden)]
 #[allow(clippy::all)]
 #[allow(unused_imports)]

--- a/src/generated/cloud/speech/v2/src/stub.rs
+++ b/src/generated/cloud/speech/v2/src/stub.rs
@@ -115,7 +115,6 @@ pub trait Speech: std::fmt::Debug + Send + Sync {
     }
 
     /// Implements [super::client::Speech::streaming_recognize].
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn streaming_recognize(
         &self,
         _options: crate::RequestOptions,

--- a/src/generated/cloud/speech/v2/src/stub/dynamic.rs
+++ b/src/generated/cloud/speech/v2/src/stub/dynamic.rs
@@ -59,7 +59,6 @@ pub trait Speech: std::fmt::Debug + Send + Sync {
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<crate::model::RecognizeResponse>>;
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn streaming_recognize(
         &self,
         options: crate::RequestOptions,
@@ -277,7 +276,6 @@ impl<T: super::Speech> Speech for T {
     }
 
     /// Forwards the call to the implementation provided by `T`.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn streaming_recognize(
         &self,
         options: crate::RequestOptions,

--- a/src/generated/cloud/speech/v2/src/tracing.rs
+++ b/src/generated/cloud/speech/v2/src/tracing.rs
@@ -139,7 +139,6 @@ where
         pending.await
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn streaming_recognize(
         &self,
         options: crate::RequestOptions,

--- a/src/generated/cloud/speech/v2/src/transport.rs
+++ b/src/generated/cloud/speech/v2/src/transport.rs
@@ -22,7 +22,6 @@ use crate::Result;
 #[derive(Clone)]
 pub struct Speech {
     inner: gaxi::http::ReqwestClient,
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     grpc_inner: gaxi::grpc::Client,
 }
 
@@ -30,7 +29,6 @@ impl std::fmt::Debug for Speech {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         let mut builder = f.debug_struct("Speech");
         builder.field("inner", &self.inner);
-        #[cfg(google_cloud_unstable_gapic_streaming)]
         builder.field("grpc_inner", &self.grpc_inner);
         builder.finish()
     }
@@ -45,7 +43,6 @@ impl Speech {
         } else {
             inner
         };
-        #[cfg(google_cloud_unstable_gapic_streaming)]
         let grpc_inner = if tracing_is_enabled {
             gaxi::grpc::Client::new_with_instrumentation(
                 config,
@@ -56,11 +53,7 @@ impl Speech {
         } else {
             gaxi::grpc::Client::new(config, crate::DEFAULT_HOST).await?
         };
-        Ok(Self {
-            inner,
-            #[cfg(google_cloud_unstable_gapic_streaming)]
-            grpc_inner,
-        })
+        Ok(Self { inner, grpc_inner })
     }
 }
 
@@ -590,7 +583,6 @@ impl super::stub::Speech for Speech {
         self.inner.execute(builder, body, options).await
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn streaming_recognize(
         &self,
         options: crate::RequestOptions,

--- a/src/generated/showcase/src/builder.rs
+++ b/src/generated/showcase/src/builder.rs
@@ -2416,14 +2416,12 @@ pub mod echo {
     }
 
     /// Common implementation for [crate::client::Echo] bidi stream builders.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug)]
     pub(crate) struct BidiStreamBuilder {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Echo>,
         options: crate::RequestOptions,
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl BidiStreamBuilder {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::Echo>) -> Self {
             Self {
@@ -2726,11 +2724,9 @@ pub mod echo {
     ///   // ... details omitted ...
     /// }
     /// ```
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug)]
     pub struct Expand(RequestBuilder<crate::model::ExpandRequest>);
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl Expand {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::Echo>) -> Self {
             Self(RequestBuilder::new(stub))
@@ -2799,7 +2795,6 @@ pub mod echo {
         }
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[doc(hidden)]
     impl crate::RequestBuilder for Expand {
         fn request_options(&mut self) -> &mut crate::RequestOptions {
@@ -2831,11 +2826,9 @@ pub mod echo {
     ///   // ... details omitted ...
     /// }
     /// ```
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug)]
     pub struct Chat(BidiStreamBuilder);
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl Chat {
         pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::Echo>) -> Self {
             Self(BidiStreamBuilder::new(stub))
@@ -2858,7 +2851,6 @@ pub mod echo {
         }
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[doc(hidden)]
     impl crate::RequestBuilder for Chat {
         fn request_options(&mut self) -> &mut crate::RequestOptions {
@@ -5435,14 +5427,12 @@ pub mod messaging {
     }
 
     /// Common implementation for [crate::client::Messaging] bidi stream builders.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug)]
     pub(crate) struct BidiStreamBuilder {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Messaging>,
         options: crate::RequestOptions,
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl BidiStreamBuilder {
         pub(crate) fn new(
             stub: std::sync::Arc<dyn super::super::stub::dynamic::Messaging>,
@@ -6385,11 +6375,9 @@ pub mod messaging {
     ///   // ... details omitted ...
     /// }
     /// ```
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug)]
     pub struct StreamBlurbs(RequestBuilder<crate::model::StreamBlurbsRequest>);
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl StreamBlurbs {
         pub(crate) fn new(
             stub: std::sync::Arc<dyn super::super::stub::dynamic::Messaging>,
@@ -6450,7 +6438,6 @@ pub mod messaging {
         }
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[doc(hidden)]
     impl crate::RequestBuilder for StreamBlurbs {
         fn request_options(&mut self) -> &mut crate::RequestOptions {
@@ -6482,11 +6469,9 @@ pub mod messaging {
     ///   // ... details omitted ...
     /// }
     /// ```
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug)]
     pub struct Connect(BidiStreamBuilder);
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl Connect {
         pub(crate) fn new(
             stub: std::sync::Arc<dyn super::super::stub::dynamic::Messaging>,
@@ -6511,7 +6496,6 @@ pub mod messaging {
         }
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[doc(hidden)]
     impl crate::RequestBuilder for Connect {
         fn request_options(&mut self) -> &mut crate::RequestOptions {
@@ -7693,13 +7677,11 @@ pub mod sequence_service {
     ///   // ... details omitted ...
     /// }
     /// ```
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[derive(Clone, Debug)]
     pub struct AttemptStreamingSequence(
         RequestBuilder<crate::model::AttemptStreamingSequenceRequest>,
     );
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     impl AttemptStreamingSequence {
         pub(crate) fn new(
             stub: std::sync::Arc<dyn super::super::stub::dynamic::SequenceService>,
@@ -7750,7 +7732,6 @@ pub mod sequence_service {
         }
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[doc(hidden)]
     impl crate::RequestBuilder for AttemptStreamingSequence {
         fn request_options(&mut self) -> &mut crate::RequestOptions {

--- a/src/generated/showcase/src/client.rs
+++ b/src/generated/showcase/src/client.rs
@@ -730,14 +730,12 @@ impl Echo {
         super::builder::echo::FailEchoWithDetails::new(self.inner.clone())
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     /// This method splits the given content into words and will pass each word back
     /// through the stream. This method showcases server-side streaming RPCs.
     pub fn expand(&self) -> super::builder::echo::Expand {
         super::builder::echo::Expand::new(self.inner.clone())
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     /// This method, upon receiving a request on the stream, will pass the same
     /// content back on the stream. This method showcases bidirectional
     /// streaming RPCs.
@@ -1884,14 +1882,12 @@ impl Messaging {
         super::builder::messaging::SearchBlurbs::new(self.inner.clone())
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     /// This returns a stream that emits the blurbs that are created for a
     /// particular chat room or user profile.
     pub fn stream_blurbs(&self) -> super::builder::messaging::StreamBlurbs {
         super::builder::messaging::StreamBlurbs::new(self.inner.clone())
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     /// This method starts a bidirectional stream that receives all blurbs that
     /// are being created after the stream has started and sends requests to create
     /// blurbs. If an invalid blurb is requested to be created, the stream will
@@ -2336,7 +2332,6 @@ impl SequenceService {
         super::builder::sequence_service::AttemptSequence::new(self.inner.clone())
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     /// Attempts a server streaming call with a sequence of responses
     /// Can be used to test retries and stream resumption logic
     /// May not function as expected in HTTP mode due to when http statuses are sent

--- a/src/generated/showcase/src/lib.rs
+++ b/src/generated/showcase/src/lib.rs
@@ -92,7 +92,6 @@ pub(crate) mod tracing;
 #[doc(hidden)]
 pub(crate) mod transport;
 
-#[cfg(google_cloud_unstable_gapic_streaming)]
 #[doc(hidden)]
 #[allow(clippy::all)]
 #[allow(unused_imports)]

--- a/src/generated/showcase/src/stub.rs
+++ b/src/generated/showcase/src/stub.rs
@@ -296,7 +296,6 @@ pub trait Echo: std::fmt::Debug + Send + Sync {
     }
 
     /// Implements [super::client::Echo::expand].
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn expand(
         &self,
         _req: crate::model::ExpandRequest,
@@ -310,7 +309,6 @@ pub trait Echo: std::fmt::Debug + Send + Sync {
     }
 
     /// Implements [super::client::Echo::chat].
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn chat(
         &self,
         _options: crate::RequestOptions,
@@ -800,7 +798,6 @@ pub trait Messaging: std::fmt::Debug + Send + Sync {
     }
 
     /// Implements [super::client::Messaging::stream_blurbs].
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn stream_blurbs(
         &self,
         _req: crate::model::StreamBlurbsRequest,
@@ -814,7 +811,6 @@ pub trait Messaging: std::fmt::Debug + Send + Sync {
     }
 
     /// Implements [super::client::Messaging::connect].
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn connect(
         &self,
         _options: crate::RequestOptions,
@@ -1026,7 +1022,6 @@ pub trait SequenceService: std::fmt::Debug + Send + Sync {
     }
 
     /// Implements [super::client::SequenceService::attempt_streaming_sequence].
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn attempt_streaming_sequence(
         &self,
         _req: crate::model::AttemptStreamingSequenceRequest,

--- a/src/generated/showcase/src/stub/dynamic.rs
+++ b/src/generated/showcase/src/stub/dynamic.rs
@@ -330,14 +330,12 @@ pub trait Echo: std::fmt::Debug + Send + Sync {
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<crate::model::FailEchoWithDetailsResponse>>;
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn expand(
         &self,
         req: crate::model::ExpandRequest,
         options: crate::RequestOptions,
     ) -> crate::Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>>;
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn chat(
         &self,
         options: crate::RequestOptions,
@@ -477,7 +475,6 @@ impl<T: super::Echo> Echo for T {
     }
 
     /// Forwards the call to the implementation provided by `T`.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn expand(
         &self,
         req: crate::model::ExpandRequest,
@@ -488,7 +485,6 @@ impl<T: super::Echo> Echo for T {
     }
 
     /// Forwards the call to the implementation provided by `T`.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn chat(
         &self,
         options: crate::RequestOptions,
@@ -938,7 +934,6 @@ pub trait Messaging: std::fmt::Debug + Send + Sync {
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<google_cloud_longrunning::model::Operation>>;
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn stream_blurbs(
         &self,
         req: crate::model::StreamBlurbsRequest,
@@ -947,7 +942,6 @@ pub trait Messaging: std::fmt::Debug + Send + Sync {
         google_cloud_gax::streaming::ResponseReceiver<crate::model::StreamBlurbsResponse>,
     >;
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn connect(
         &self,
         options: crate::RequestOptions,
@@ -1129,7 +1123,6 @@ impl<T: super::Messaging> Messaging for T {
     }
 
     /// Forwards the call to the implementation provided by `T`.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn stream_blurbs(
         &self,
         req: crate::model::StreamBlurbsRequest,
@@ -1141,7 +1134,6 @@ impl<T: super::Messaging> Messaging for T {
     }
 
     /// Forwards the call to the implementation provided by `T`.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn connect(
         &self,
         options: crate::RequestOptions,
@@ -1290,7 +1282,6 @@ pub trait SequenceService: std::fmt::Debug + Send + Sync {
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<()>>;
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn attempt_streaming_sequence(
         &self,
         req: crate::model::AttemptStreamingSequenceRequest,
@@ -1405,7 +1396,6 @@ impl<T: super::SequenceService> SequenceService for T {
     }
 
     /// Forwards the call to the implementation provided by `T`.
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn attempt_streaming_sequence(
         &self,
         req: crate::model::AttemptStreamingSequenceRequest,

--- a/src/generated/showcase/src/tracing.rs
+++ b/src/generated/showcase/src/tracing.rs
@@ -416,7 +416,6 @@ where
         pending.await
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn expand(
         &self,
         req: crate::model::ExpandRequest,
@@ -425,7 +424,6 @@ where
         self.inner.expand(req, options).await
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn chat(
         &self,
         options: crate::RequestOptions,
@@ -1141,7 +1139,6 @@ where
         pending.await
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn stream_blurbs(
         &self,
         req: crate::model::StreamBlurbsRequest,
@@ -1151,7 +1148,6 @@ where
         self.inner.stream_blurbs(req, options).await
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn connect(
         &self,
         options: crate::RequestOptions,
@@ -1450,7 +1446,6 @@ where
         pending.await
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn attempt_streaming_sequence(
         &self,
         req: crate::model::AttemptStreamingSequenceRequest,

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -1608,7 +1608,6 @@ impl super::stub::Compliance for Compliance {
 #[derive(Clone)]
 pub struct Echo {
     inner: gaxi::http::ReqwestClient,
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     grpc_inner: gaxi::grpc::Client,
 }
 
@@ -1616,7 +1615,6 @@ impl std::fmt::Debug for Echo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         let mut builder = f.debug_struct("Echo");
         builder.field("inner", &self.inner);
-        #[cfg(google_cloud_unstable_gapic_streaming)]
         builder.field("grpc_inner", &self.grpc_inner);
         builder.finish()
     }
@@ -1631,7 +1629,6 @@ impl Echo {
         } else {
             inner
         };
-        #[cfg(google_cloud_unstable_gapic_streaming)]
         let grpc_inner = if tracing_is_enabled {
             gaxi::grpc::Client::new_with_instrumentation(
                 config,
@@ -1642,11 +1639,7 @@ impl Echo {
         } else {
             gaxi::grpc::Client::new(config, crate::DEFAULT_HOST).await?
         };
-        Ok(Self {
-            inner,
-            #[cfg(google_cloud_unstable_gapic_streaming)]
-            grpc_inner,
-        })
+        Ok(Self { inner, grpc_inner })
     }
 }
 
@@ -1793,7 +1786,6 @@ impl super::stub::Echo for Echo {
         self.inner.execute(builder, body, options).await
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn expand(
         &self,
         req: crate::model::ExpandRequest,
@@ -1831,7 +1823,6 @@ impl super::stub::Echo for Echo {
             .await
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn chat(
         &self,
         options: crate::RequestOptions,
@@ -4119,7 +4110,6 @@ impl super::stub::Identity for Identity {
 #[derive(Clone)]
 pub struct Messaging {
     inner: gaxi::http::ReqwestClient,
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     grpc_inner: gaxi::grpc::Client,
 }
 
@@ -4127,7 +4117,6 @@ impl std::fmt::Debug for Messaging {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         let mut builder = f.debug_struct("Messaging");
         builder.field("inner", &self.inner);
-        #[cfg(google_cloud_unstable_gapic_streaming)]
         builder.field("grpc_inner", &self.grpc_inner);
         builder.finish()
     }
@@ -4142,7 +4131,6 @@ impl Messaging {
         } else {
             inner
         };
-        #[cfg(google_cloud_unstable_gapic_streaming)]
         let grpc_inner = if tracing_is_enabled {
             gaxi::grpc::Client::new_with_instrumentation(
                 config,
@@ -4153,11 +4141,7 @@ impl Messaging {
         } else {
             gaxi::grpc::Client::new(config, crate::DEFAULT_HOST).await?
         };
-        Ok(Self {
-            inner,
-            #[cfg(google_cloud_unstable_gapic_streaming)]
-            grpc_inner,
-        })
+        Ok(Self { inner, grpc_inner })
     }
 }
 
@@ -5070,7 +5054,6 @@ impl super::stub::Messaging for Messaging {
         self.inner.execute(builder, body, options).await
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn stream_blurbs(
         &self,
         req: crate::model::StreamBlurbsRequest,
@@ -5113,7 +5096,6 @@ impl super::stub::Messaging for Messaging {
             .await
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn connect(
         &self,
         options: crate::RequestOptions,
@@ -6010,7 +5992,6 @@ impl super::stub::Messaging for Messaging {
 #[derive(Clone)]
 pub struct SequenceService {
     inner: gaxi::http::ReqwestClient,
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     grpc_inner: gaxi::grpc::Client,
 }
 
@@ -6018,7 +5999,6 @@ impl std::fmt::Debug for SequenceService {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         let mut builder = f.debug_struct("SequenceService");
         builder.field("inner", &self.inner);
-        #[cfg(google_cloud_unstable_gapic_streaming)]
         builder.field("grpc_inner", &self.grpc_inner);
         builder.finish()
     }
@@ -6033,7 +6013,6 @@ impl SequenceService {
         } else {
             inner
         };
-        #[cfg(google_cloud_unstable_gapic_streaming)]
         let grpc_inner = if tracing_is_enabled {
             gaxi::grpc::Client::new_with_instrumentation(
                 config,
@@ -6044,11 +6023,7 @@ impl SequenceService {
         } else {
             gaxi::grpc::Client::new(config, crate::DEFAULT_HOST).await?
         };
-        Ok(Self {
-            inner,
-            #[cfg(google_cloud_unstable_gapic_streaming)]
-            grpc_inner,
-        })
+        Ok(Self { inner, grpc_inner })
     }
 }
 
@@ -6343,7 +6318,6 @@ impl super::stub::SequenceService for SequenceService {
             })
     }
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn attempt_streaming_sequence(
         &self,
         req: crate::model::AttemptStreamingSequenceRequest,

--- a/tests/bigquery/src/lib.rs
+++ b/tests/bigquery/src/lib.rs
@@ -26,7 +26,6 @@ pub use query::{
     query_client, query_client_datatypes, query_client_job, query_client_multi_page,
     query_client_nested_types, query_client_numeric_limits,
 };
-#[cfg(google_cloud_unstable_gapic_streaming)]
 pub use reads::read_rows;
 pub use reads::run_reads;
 pub use writes::run_writes;

--- a/tests/bigquery/src/reads.rs
+++ b/tests/bigquery/src/reads.rs
@@ -84,22 +84,19 @@ pub async fn read_rows(project_id: &str, dataset_id: &str, table_id: &str) -> Re
         "expected at least one stream in read session"
     );
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
-    {
-        let stream_name = &session.streams[0].name;
-        let mut stream = client
-            .read_rows()
-            .set_read_stream(stream_name)
-            .send()
-            .await?;
+    let stream_name = &session.streams[0].name;
+    let mut stream = client
+        .read_rows()
+        .set_read_stream(stream_name)
+        .send()
+        .await?;
 
-        let mut total_rows = 0;
-        while let Some(response) = stream.recv().await {
-            let response = response?;
-            total_rows += response.row_count;
-        }
-        assert_eq!(total_rows, 3, "expected 3 rows to be read from stream");
+    let mut total_rows = 0;
+    while let Some(response) = stream.recv().await {
+        let response = response?;
+        total_rows += response.row_count;
     }
+    assert_eq!(total_rows, 3, "expected 3 rows to be read from stream");
 
     Ok(())
 }

--- a/tests/showcase/src/lib.rs
+++ b/tests/showcase/src/lib.rs
@@ -26,7 +26,6 @@ mod compliance;
 mod echo;
 mod identity;
 pub mod pqc;
-#[cfg(google_cloud_unstable_gapic_streaming)]
 mod streaming;
 
 /// The version of gapic-showcase used in these tests.
@@ -65,11 +64,8 @@ pub async fn run() -> Result<()> {
     tracing::info!("running tests for Compliance service");
     compliance::run().await?;
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
-    {
-        tracing::info!("running tests for Streaming");
-        streaming::run().await?;
-    }
+    tracing::info!("running tests for Streaming");
+    streaming::run().await?;
 
     Ok(())
 }

--- a/tests/showcase/src/pqc.rs
+++ b/tests/showcase/src/pqc.rs
@@ -42,7 +42,6 @@ use anyhow::Error;
 use google_cloud_gax::options::RequestOptionsBuilder;
 use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
 use google_cloud_showcase_v1beta1::client::{Echo, Testing};
-#[cfg(google_cloud_unstable_gapic_streaming)]
 use google_cloud_showcase_v1beta1::model::EchoRequest;
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -112,11 +111,8 @@ pub async fn run() -> Result<()> {
     tracing::info!("testing PQC transport (HTTP unary)");
     test_pqc_http().await?;
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
-    {
-        tracing::info!("testing PQC transport (gRPC streaming)");
-        test_pqc_grpc().await?;
-    }
+    tracing::info!("testing PQC transport (gRPC streaming)");
+    test_pqc_grpc().await?;
 
     Ok(())
 }
@@ -188,7 +184,6 @@ async fn test_pqc_http() -> Result<()> {
 }
 
 /// Verifies that gRPC bidirectional streaming RPCs (`tonic`) succeed over a TLS channel requiring `X25519MLKEM768`.
-#[cfg(google_cloud_unstable_gapic_streaming)]
 async fn test_pqc_grpc() -> Result<()> {
     let client = Echo::builder()
         .with_endpoint(PQC_ENDPOINT)

--- a/tests/streaming/src/lib.rs
+++ b/tests/streaming/src/lib.rs
@@ -12,5 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(google_cloud_unstable_gapic_streaming)]
 pub mod speech;

--- a/tests/streaming/tests/driver.rs
+++ b/tests/streaming/tests/driver.rs
@@ -15,7 +15,6 @@
 #[cfg(all(test, feature = "run-integration-tests"))]
 mod driver {
 
-    #[cfg(google_cloud_unstable_gapic_streaming)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_speech_streaming_recognize() -> anyhow::Result<()> {
         use google_cloud_test_utils::errors::anydump;


### PR DESCRIPTION
As part of the work for exposing streaming RPCs on all GAPICs. Remove the compiler flag now that the API has stabilized.

For #2318 