### PR TITLE
fix(storage): avoid precondition flake in object examples test

### DIFF
--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -705,7 +705,9 @@ async fn make_object(client: &Storage, bucket_id: &str, name: &str) -> anyhow::R
     const VEXING: &str = "how vexingly quick daft zebras jump\n";
     let object = client
         .write_object(format!("projects/_/buckets/{bucket_id}"), name, VEXING)
-        .set_if_generation_match(0)
+        // Creating test objects in a temporary test bucket is safe to
+        // retry on transient network errors by overwriting with the same data.
+        .with_idempotency(true)
         .send_buffered()
         .await?;
     Ok(object)


### PR DESCRIPTION
Fixes #4582

We avoid `set_if_generation_match(0)` because if an initial write_object attempt succeeds on the server but the response is lost to a transient network error, retrying with a precondition causes an "HTTP 412 Precondition Failed." Since these are test objects written to a test bucket, it's safe for a retry to simply overwrite the object.