### PR TITLE
impl(bigquery)!: Row::get should not panic and remove try_get

### DIFF
--- a/src/bigquery/examples/src/query/batch.rs
+++ b/src/bigquery/examples/src/query/batch.rs
@@ -33,7 +33,7 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let name: String = row.get("name");
+        let name: String = row.get("name")?;
         println!("Name: {name}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/browse_table.rs
+++ b/src/bigquery/examples/src/query/browse_table.rs
@@ -34,9 +34,9 @@ LIMIT 10
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let name: String = row.get("name");
-        let gender: String = row.get("gender");
-        let number: i64 = row.get("number");
+        let name: String = row.get("name")?;
+        let gender: String = row.get("gender")?;
+        let number: i64 = row.get("number")?;
         println!("Name: {name}, Gender: {gender}, Number: {number}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/clustered_table.rs
+++ b/src/bigquery/examples/src/query/clustered_table.rs
@@ -32,8 +32,8 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let title: String = row.get("title");
-        let views: i64 = row.get("views");
+        let title: String = row.get("title")?;
+        let views: i64 = row.get("views")?;
         println!("Title: {title}, Views: {views}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/destination_table.rs
+++ b/src/bigquery/examples/src/query/destination_table.rs
@@ -39,7 +39,7 @@ pub async fn sample(project_id: &str, dataset_id: &str, table_id: &str) -> anyho
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let name: String = row.get("name");
+        let name: String = row.get("name")?;
         println!("Name: {name}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/job_optional.rs
+++ b/src/bigquery/examples/src/query/job_optional.rs
@@ -54,9 +54,9 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
     let mut rows = query.until_done().await?.read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let name: String = row.get("name");
-        let gender: String = row.get("gender");
-        let total: i64 = row.get("total");
+        let name: String = row.get("name")?;
+        let gender: String = row.get("gender")?;
+        let total: i64 = row.get("total")?;
         println!("Name: {name}, Gender: {gender}, Total: {total}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/label_job.rs
+++ b/src/bigquery/examples/src/query/label_job.rs
@@ -38,7 +38,7 @@ LIMIT 10
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let name: String = row.get("name");
+        let name: String = row.get("name")?;
         println!("Name: {name}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/legacy.rs
+++ b/src/bigquery/examples/src/query/legacy.rs
@@ -33,7 +33,7 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let name: String = row.get("name");
+        let name: String = row.get("name")?;
         println!("Name: {name}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/legacy_large_results.rs
+++ b/src/bigquery/examples/src/query/legacy_large_results.rs
@@ -41,7 +41,7 @@ pub async fn sample(project_id: &str, dataset_id: &str, table_id: &str) -> anyho
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let name: String = row.get("name");
+        let name: String = row.get("name")?;
         println!("Name: {name}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/no_cache.rs
+++ b/src/bigquery/examples/src/query/no_cache.rs
@@ -33,7 +33,7 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let name: String = row.get("name");
+        let name: String = row.get("name")?;
         println!("Name: {name}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/pagination.rs
+++ b/src/bigquery/examples/src/query/pagination.rs
@@ -37,7 +37,7 @@ LIMIT 2500
 
     let mut count = 0;
     while let Some(row) = rows.next().await.transpose()? {
-        let _name: String = row.get("name");
+        let _name: String = row.get("name")?;
         count += 1;
     }
     println!("Total rows fetched via pagination: {count}");

--- a/src/bigquery/examples/src/query/params_arrays.rs
+++ b/src/bigquery/examples/src/query/params_arrays.rs
@@ -47,7 +47,7 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let name: String = row.get("name");
+        let name: String = row.get("name")?;
         println!("Name: {name}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/params_named.rs
+++ b/src/bigquery/examples/src/query/params_named.rs
@@ -40,7 +40,7 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let name: String = row.get("name");
+        let name: String = row.get("name")?;
         println!("Name: {name}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/params_named_types.rs
+++ b/src/bigquery/examples/src/query/params_named_types.rs
@@ -48,9 +48,9 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let date_col: String = row.get("date_col");
-        let num_col: String = row.get("num_col");
-        let bool_col: bool = row.get("bool_col");
+        let date_col: String = row.get("date_col")?;
+        let num_col: String = row.get("num_col")?;
+        let bool_col: bool = row.get("bool_col")?;
         println!("Date: {date_col}, Numeric: {num_col}, Bool: {bool_col}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/params_positional.rs
+++ b/src/bigquery/examples/src/query/params_positional.rs
@@ -39,7 +39,7 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let name: String = row.get("name");
+        let name: String = row.get("name")?;
         println!("Name: {name}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/params_positional_types.rs
+++ b/src/bigquery/examples/src/query/params_positional_types.rs
@@ -40,9 +40,9 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let str_col: String = row.get("str_col");
-        let int_col: i64 = row.get("int_col");
-        let float_col: f64 = row.get("float_col");
+        let str_col: String = row.get("str_col")?;
+        let int_col: i64 = row.get("int_col")?;
+        let float_col: f64 = row.get("float_col")?;
         println!("String: {str_col}, Int: {int_col}, Float: {float_col}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/params_timestamps.rs
+++ b/src/bigquery/examples/src/query/params_timestamps.rs
@@ -35,7 +35,7 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .read();
 
     if let Some(row) = rows.next().await.transpose()? {
-        let next_hour: String = row.get("next_hour");
+        let next_hour: String = row.get("next_hour")?;
         println!("Next hour: {next_hour}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/partitioned_table.rs
+++ b/src/bigquery/examples/src/query/partitioned_table.rs
@@ -32,7 +32,7 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let block_num: i64 = row.get("block_number");
+        let block_num: i64 = row.get("block_number")?;
         println!("Block number: {block_num}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/query.rs
+++ b/src/bigquery/examples/src/query/query.rs
@@ -32,7 +32,7 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let name: String = row.get("name");
+        let name: String = row.get("name")?;
         println!("Name: {name}");
     }
     Ok(())

--- a/src/bigquery/examples/src/query/script.rs
+++ b/src/bigquery/examples/src/query/script.rs
@@ -34,7 +34,7 @@ LIMIT 10;
         .read();
 
     while let Some(row) = rows.next().await.transpose()? {
-        let name: String = row.get("name");
+        let name: String = row.get("name")?;
         println!("Name: {name}");
     }
     Ok(())

--- a/src/bigquery/src/datatypes.rs
+++ b/src/bigquery/src/datatypes.rs
@@ -43,7 +43,7 @@ use crate::query::from_sql::parse_time;
 ///     .read();
 ///
 /// if let Some(row) = rows.next().await.transpose()? {
-///     let interval: Interval = row.get("duration");
+///     let interval: Interval = row.get("duration")?;
 ///     println!("{} years, {} months, {} days", interval.years, interval.months, interval.days);
 /// }
 /// # Ok(())
@@ -169,7 +169,7 @@ impl FromSql for Interval {
 ///     .read();
 ///
 /// if let Some(row) = rows.next().await.transpose()? {
-///     let date_range: Range<Date> = row.get("date_range");
+///     let date_range: Range<Date> = row.get("date_range")?;
 ///     println!("Start: {:?}, End: {:?}", date_range.start, date_range.end);
 /// }
 /// # Ok(())

--- a/src/bigquery/src/lib.rs
+++ b/src/bigquery/src/lib.rs
@@ -51,7 +51,7 @@
 //!     .read();
 //!
 //! while let Some(row) = rows.next().await.transpose()? {
-//!     let greeting: String = row.get("greeting");
+//!     let greeting: String = row.get("greeting")?;
 //!     println!("Greeting: {greeting}");
 //! }
 //! # Ok(())

--- a/src/bigquery/src/query/builder.rs
+++ b/src/bigquery/src/query/builder.rs
@@ -48,7 +48,7 @@ pub(crate) const QUERY_REQUEST_ID_PREFIX: &str = "req_";
 ///     .read();
 ///
 /// while let Some(row) = rows.next().await.transpose()? {
-///     let name: String = row.get("name");
+///     let name: String = row.get("name")?;
 ///     println!("Name: {name}");
 /// }
 /// # Ok(())
@@ -133,7 +133,7 @@ impl Query {
     ///
     /// let mut rows = completed_query.read();
     /// if let Some(row) = rows.next().await.transpose()? {
-    ///     let now: String = row.get("now");
+    ///     let now: String = row.get("now")?;
     ///     println!("Current time: {now}");
     /// }
     /// # Ok(())
@@ -168,7 +168,7 @@ impl Query {
     ///
     /// let mut rows = completed_query.read();
     /// if let Some(row) = rows.next().await.transpose()? {
-    ///     let now: String = row.get("now");
+    ///     let now: String = row.get("now")?;
     ///     println!("Current time: {now}");
     /// }
     /// # Ok(())

--- a/src/bigquery/src/query/client.rs
+++ b/src/bigquery/src/query/client.rs
@@ -55,8 +55,8 @@ use std::sync::Arc;
 ///     .read();
 ///
 /// while let Some(row) = rows.next().await.transpose()? {
-///     let name: String = row.get("name");
-///     let count: i64 = row.get("count");
+///     let name: String = row.get("name")?;
+///     let count: i64 = row.get("count")?;
 ///     println!("{name}: {count}");
 /// }
 /// # Ok(()) }
@@ -144,8 +144,8 @@ impl BigQuery {
     ///     .read();
     ///
     /// while let Some(row) = rows.next().await.transpose()? {
-    ///     let name: String = row.get("name");
-    ///     let count: i64 = row.get("count");
+    ///     let name: String = row.get("name")?;
+    ///     let count: i64 = row.get("count")?;
     ///     println!("{name}: {count}");
     /// }
     /// # Ok(())

--- a/src/bigquery/src/query/from_sql.rs
+++ b/src/bigquery/src/query/from_sql.rs
@@ -36,10 +36,9 @@ pub(crate) const BIGQUERY_DATETIME_SUBSEC_FORMAT: &[time::format_description::Fo
 /// A trait for converting BigQuery [`wkt::Value`] representations into Rust
 /// types.
 ///
-/// [`Row::get()`](crate::query::Row::get) and
-/// [`Row::try_get()`](crate::query::Row::try_get) use this trait to convert cell
-/// values, and the [`FromRow`](crate::query::FromRow) derive macro uses it for field
-/// deserialization.
+/// [`Row::get()`](crate::query::Row::get) or [`Row::take()`](crate::query::Row::take)
+/// use this trait to convert cell values, and the [`FromRow`](crate::query::FromRow)
+/// derive macro uses it for field deserialization.
 ///
 /// # Supported Types
 ///
@@ -63,8 +62,8 @@ pub(crate) const BIGQUERY_DATETIME_SUBSEC_FORMAT: &[time::format_description::Fo
 ///     .read();
 ///
 /// while let Some(row) = rows.next().await.transpose()? {
-///     let num: i64 = row.get("integer_col");
-///     let txt: String = row.get("string_col");
+///     let num: i64 = row.get("integer_col")?;
+///     let txt: String = row.get("string_col")?;
 ///     println!("{txt}: {num}");
 /// }
 /// # Ok(())

--- a/src/bigquery/src/query/iterator.rs
+++ b/src/bigquery/src/query/iterator.rs
@@ -40,8 +40,8 @@ pub type Result<T> = std::result::Result<T, RowError>;
 ///     .read();
 ///
 /// while let Some(row) = rows.next().await.transpose()? {
-///     let name: String = row.get("name");
-///     let state: String = row.get("state");
+///     let name: String = row.get("name")?;
+///     let state: String = row.get("state")?;
 ///     println!("{name} from {state}");
 /// }
 /// # Ok(())
@@ -103,7 +103,7 @@ impl RowIterator {
     /// # use google_cloud_bigquery::query::RowIterator;
     /// # async fn sample(mut rows: RowIterator) -> anyhow::Result<()> {
     /// while let Some(row) = rows.next().await.transpose()? {
-    ///     let msg: String = row.get("msg");
+    ///     let msg: String = row.get("msg")?;
     ///     println!("Message: {msg}");
     /// }
     /// # Ok(())
@@ -244,10 +244,10 @@ mod tests {
         let mut iter = q.read();
 
         let row1 = iter.next().await.expect("should have row 1")?;
-        assert_eq!(row1.get::<String, _>("col"), "first");
+        assert_eq!(row1.get::<String, _>("col")?, "first");
 
         let row2 = iter.next().await.expect("should have row 2")?;
-        assert_eq!(row2.get::<String, _>("col"), "second");
+        assert_eq!(row2.get::<String, _>("col")?, "second");
 
         assert!(iter.next().await.is_none(), "{iter:?}");
         Ok(())
@@ -311,16 +311,16 @@ mod tests {
         let mut iter = q.read();
 
         let row1 = iter.next().await.expect("should have row 1")?;
-        assert_eq!(row1.get::<String, _>("col"), "cached_row");
+        assert_eq!(row1.get::<String, _>("col")?, "cached_row");
 
         let row2 = iter.next().await.expect("should have row 2")?;
-        assert_eq!(row2.get::<String, _>("col"), "page_1_row_1");
+        assert_eq!(row2.get::<String, _>("col")?, "page_1_row_1");
 
         let row3 = iter.next().await.expect("should have row 3")?;
-        assert_eq!(row3.get::<String, _>("col"), "page_1_row_2");
+        assert_eq!(row3.get::<String, _>("col")?, "page_1_row_2");
 
         let row4 = iter.next().await.expect("should have row 4")?;
-        assert_eq!(row4.get::<String, _>("col"), "page_2_row_1");
+        assert_eq!(row4.get::<String, _>("col")?, "page_2_row_1");
 
         assert!(iter.next().await.is_none(), "{iter:?}");
         Ok(())
@@ -357,7 +357,7 @@ mod tests {
         let mut iter = q.read().set_max_results(50);
 
         let row = iter.next().await.expect("should have row")?;
-        assert_eq!(row.get::<String, _>("col"), "page_row");
+        assert_eq!(row.get::<String, _>("col")?, "page_row");
 
         assert!(iter.next().await.is_none(), "{iter:?}");
         Ok(())
@@ -385,7 +385,7 @@ mod tests {
         let mut iter = q.read();
 
         let row = iter.next().await.expect("should have row")?;
-        assert_eq!(row.get::<String, _>("col"), "page_row");
+        assert_eq!(row.get::<String, _>("col")?, "page_row");
         assert!(iter.next().await.is_none(), "{iter:?}");
         Ok(())
     }

--- a/src/bigquery/src/query/query_handle.rs
+++ b/src/bigquery/src/query/query_handle.rs
@@ -356,7 +356,7 @@ impl CompleteQuery {
     ///     .read();
     ///
     /// while let Some(row) = rows.next().await.transpose()? {
-    ///     let score: i64 = row.get("score");
+    ///     let score: i64 = row.get("score")?;
     ///     println!("Score: {score}");
     /// }
     /// # Ok(())
@@ -749,7 +749,7 @@ mod tests {
 
         let mut iter = complete_query.read();
         let row = iter.next().await.expect("should return first row")?;
-        assert_eq!(row.get::<String, _>("name"), "test_name");
+        assert_eq!(row.get::<String, _>("name")?, "test_name");
         assert!(iter.next().await.is_none(), "{iter:?}");
 
         Ok(())

--- a/src/bigquery/src/query/row.rs
+++ b/src/bigquery/src/query/row.rs
@@ -49,15 +49,15 @@ pub type Result<T> = std::result::Result<T, RowError>;
 /// # Field Extraction by Name or Index
 ///
 /// Retrieve individual cell values by column name (`&str`) or index (`usize`)
-/// using [`get()`](Row::get), [`try_get()`](Row::try_get), or
-/// [`take()`](Row::take):
+/// using [`get()`](Row::get) or [`take()`](Row::take):
 ///
 /// ```
 /// # use google_cloud_bigquery::query::Row;
-/// # fn sample(row: Row) {
-/// let name: String = row.get("name");
-/// let age: i64 = row.get(1);
+/// # fn sample(row: Row) -> anyhow::Result<()> {
+/// let name: String = row.get("name")?;
+/// let age: i64 = row.get(1)?;
 /// println!("{name} is {age} years old");
+/// # Ok(())
 /// # }
 /// ```
 #[derive(Clone, Debug)]
@@ -134,26 +134,17 @@ impl Row {
     ///
     /// The return type must implement [`FromSql`](crate::query::FromSql).
     ///
-    /// # Errors
-    ///
-    /// Returns [`RowError::ColumnNotFound`](crate::error::RowError::ColumnNotFound)
-    /// if the column does not exist,
-    /// [`RowError::IndexOutOfRange`](crate::error::RowError::IndexOutOfRange) if
-    /// the index exceeds schema bounds, or
-    /// [`RowError::TypeConversion`](crate::error::RowError::TypeConversion) if
-    /// the value cannot be converted to `T`.
-    ///
     /// # Example
     ///
     /// ```
     /// # use google_cloud_bigquery::query::Row;
     /// # fn sample(row: Row) -> anyhow::Result<()> {
-    /// let msg: String = row.try_get("msg")?;
+    /// let msg: String = row.get("msg")?;
     /// println!("Value: {msg}");
     /// # Ok(())
     /// # }
     /// ```
-    pub fn try_get<T: FromSql, I: ColumnIndex>(&self, index: I) -> Result<T> {
+    pub fn get<T: FromSql, I: ColumnIndex>(&self, index: I) -> Result<T> {
         let idx = self.resolve_index(&index)?;
         let val = self
             .values
@@ -172,10 +163,6 @@ impl Row {
     /// This replaces the cell value in the row with `Value::Null` in-place to
     /// avoid cloning. Attempting to read the column again after calling `take()`
     /// yields `Value::Null`.
-    ///
-    /// # Errors
-    ///
-    /// Returns the same errors as [`try_get()`](Row::try_get).
     ///
     /// # Example
     ///
@@ -201,26 +188,6 @@ impl Row {
         // swap out the value in-place to avoid clones
         let owned_val = std::mem::replace(val, Value::Null);
         self.convert_value_at(idx, owned_val)
-    }
-
-    /// Retrieves a value from the row by column name or zero-based index.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the column does not exist or if the value cannot be converted
-    /// to type `T`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use google_cloud_bigquery::query::Row;
-    /// # fn sample(row: Row) {
-    /// let count: i64 = row.get("count");
-    /// println!("Count: {count}");
-    /// # }
-    /// ```
-    pub fn get<T: FromSql, I: ColumnIndex>(&self, index: I) -> T {
-        self.try_get(index).unwrap()
     }
 }
 
@@ -386,39 +353,39 @@ mod tests {
         let schema = Arc::new(Schema::new(schema));
         let mut row = Row::try_new(raw_row, &schema)?;
 
-        assert_eq!(row.get::<String, _>(0), "James");
-        assert_eq!(row.get::<String, _>("name"), "James");
+        assert_eq!(row.get::<String, _>(0)?, "James");
+        assert_eq!(row.get::<String, _>("name")?, "James");
 
-        assert_eq!(row.get::<i32, _>(1), 272793);
-        assert_eq!(row.get::<i32, _>("some_int"), 272793);
-        assert_eq!(row.get::<i64, _>(1), 272793);
-        assert_eq!(row.get::<i64, _>("some_int"), 272793);
+        assert_eq!(row.get::<i32, _>(1)?, 272793);
+        assert_eq!(row.get::<i32, _>("some_int")?, 272793);
+        assert_eq!(row.get::<i64, _>(1)?, 272793);
+        assert_eq!(row.get::<i64, _>("some_int")?, 272793);
 
-        assert!(row.get::<bool, _>(2));
-        assert!(row.get::<bool, _>("some_bool"));
+        assert!(row.get::<bool, _>(2)?);
+        assert!(row.get::<bool, _>("some_bool")?);
 
-        assert_eq!(row.get::<Option<i64>, _>(3), None);
-        assert_eq!(row.get::<Option<i64>, _>("some_null"), None);
+        assert_eq!(row.get::<Option<i64>, _>(3)?, None);
+        assert_eq!(row.get::<Option<i64>, _>("some_null")?, None);
 
-        assert_eq!(row.get::<f32, _>(4), 64.0);
-        assert_eq!(row.get::<f32, _>("some_float"), 64.0);
-        assert_eq!(row.get::<f64, _>(4), 64.0);
-        assert_eq!(row.get::<f64, _>("some_float"), 64.0);
+        assert_eq!(row.get::<f32, _>(4)?, 64.0);
+        assert_eq!(row.get::<f32, _>("some_float")?, 64.0);
+        assert_eq!(row.get::<f64, _>(4)?, 64.0);
+        assert_eq!(row.get::<f64, _>("some_float")?, 64.0);
 
         assert_eq!(row.take::<String, _>(0)?, "James");
-        assert_eq!(row.try_get::<Option<String>, _>(0)?, None);
+        assert_eq!(row.get::<Option<String>, _>(0)?, None);
 
         assert_eq!(row.take::<i32, _>(1)?, 272793);
-        assert_eq!(row.try_get::<Option<i32>, _>(1)?, None);
+        assert_eq!(row.get::<Option<i32>, _>(1)?, None);
 
         assert!(row.take::<bool, _>(2)?);
-        assert_eq!(row.try_get::<Option<bool>, _>(2)?, None);
+        assert_eq!(row.get::<Option<bool>, _>(2)?, None);
 
         assert_eq!(row.take::<Option<i64>, _>(3)?, None);
-        assert_eq!(row.try_get::<Option<i64>, _>(3)?, None);
+        assert_eq!(row.get::<Option<i64>, _>(3)?, None);
 
         assert_eq!(row.take::<f32, _>(4)?, 64.0);
-        assert_eq!(row.try_get::<Option<f32>, _>(4)?, None);
+        assert_eq!(row.get::<Option<f32>, _>(4)?, None);
 
         Ok(())
     }
@@ -451,59 +418,59 @@ mod tests {
         let mut row = Row::try_new(raw_row, &schema)?;
 
         assert_eq!(
-            row.get::<Decimal, _>(0),
+            row.get::<Decimal, _>(0)?,
             Decimal::new().set_value("123.456")
         );
         assert_eq!(
-            row.get::<Decimal, _>("price"),
+            row.get::<Decimal, _>("price")?,
             Decimal::new().set_value("123.456")
         );
 
         assert_eq!(
-            row.get::<Decimal, _>(1),
+            row.get::<Decimal, _>(1)?,
             Decimal::new().set_value("99999999999999999999.123456789")
         );
         assert_eq!(
-            row.get::<Decimal, _>("big_amount"),
+            row.get::<Decimal, _>("big_amount")?,
             Decimal::new().set_value("99999999999999999999.123456789")
         );
 
         assert_eq!(
-            row.get::<RustDecimal, _>(0),
+            row.get::<RustDecimal, _>(0)?,
             "123.456".parse().expect("valid decimal")
         );
         assert_eq!(
-            row.get::<RustDecimal, _>("price"),
+            row.get::<RustDecimal, _>("price")?,
             "123.456".parse().expect("valid decimal")
         );
 
         assert_eq!(
-            row.get::<RustDecimal, _>(1),
+            row.get::<RustDecimal, _>(1)?,
             "99999999999999999999.123456789"
                 .parse()
                 .expect("valid decimal")
         );
         assert_eq!(
-            row.get::<RustDecimal, _>("big_amount"),
+            row.get::<RustDecimal, _>("big_amount")?,
             "99999999999999999999.123456789"
                 .parse()
                 .expect("valid decimal")
         );
 
-        assert!(row.try_get::<RustDecimal, _>(2).is_err());
-        assert!(row.try_get::<RustDecimal, _>("overflow_amount").is_err());
+        assert!(row.get::<RustDecimal, _>(2).is_err());
+        assert!(row.get::<RustDecimal, _>("overflow_amount").is_err());
 
         assert_eq!(
             row.take::<Decimal, _>(0)?,
             Decimal::new().set_value("123.456")
         );
-        assert_eq!(row.try_get::<Option<Decimal>, _>(0)?, None);
+        assert_eq!(row.get::<Option<Decimal>, _>(0)?, None);
 
         assert_eq!(
             row.take::<RustDecimal, _>(1)?,
             "99999999999999999999.123456789".parse()?
         );
-        assert_eq!(row.try_get::<Option<RustDecimal>, _>(1)?, None);
+        assert_eq!(row.get::<Option<RustDecimal>, _>(1)?, None);
 
         Ok(())
     }
@@ -535,29 +502,29 @@ mod tests {
         let schema = Arc::new(Schema::new(schema));
         let mut row = Row::try_new(raw_row, &schema)?;
 
-        assert_eq!(row.get::<Vec<u8>, _>(0), vec![1, 2, 3, 4]);
-        assert_eq!(row.get::<Vec<u8>, _>("payload_vec"), vec![1, 2, 3, 4]);
+        assert_eq!(row.get::<Vec<u8>, _>(0)?, vec![1, 2, 3, 4]);
+        assert_eq!(row.get::<Vec<u8>, _>("payload_vec")?, vec![1, 2, 3, 4]);
 
         assert_eq!(
-            row.get::<bytes::Bytes, _>(1),
+            row.get::<bytes::Bytes, _>(1)?,
             bytes::Bytes::from_static(b"Hello")
         );
         assert_eq!(
-            row.get::<bytes::Bytes, _>("payload_bytes"),
+            row.get::<bytes::Bytes, _>("payload_bytes")?,
             bytes::Bytes::from_static(b"Hello")
         );
 
-        assert_eq!(row.get::<Option<Vec<u8>>, _>(2), None);
-        assert_eq!(row.get::<Option<bytes::Bytes>, _>("null_bytes"), None);
+        assert_eq!(row.get::<Option<Vec<u8>>, _>(2)?, None);
+        assert_eq!(row.get::<Option<bytes::Bytes>, _>("null_bytes")?, None);
 
         assert_eq!(row.take::<Vec<u8>, _>(0)?, vec![1, 2, 3, 4]);
-        assert_eq!(row.try_get::<Option<Vec<u8>>, _>(0)?, None);
+        assert_eq!(row.get::<Option<Vec<u8>>, _>(0)?, None);
 
         assert_eq!(
             row.take::<bytes::Bytes, _>(1)?,
             bytes::Bytes::from_static(b"Hello")
         );
-        assert_eq!(row.try_get::<Option<bytes::Bytes>, _>(1)?, None);
+        assert_eq!(row.get::<Option<bytes::Bytes>, _>(1)?, None);
 
         Ok(())
     }
@@ -598,10 +565,10 @@ mod tests {
             "name": "Alice",
             "age": 25,
         }))?;
-        assert_eq!(row.get::<Struct, _>(0), expected);
-        assert_eq!(row.get::<Struct, _>("user"), expected);
+        assert_eq!(row.get::<Struct, _>(0)?, expected);
+        assert_eq!(row.get::<Struct, _>("user")?, expected);
         assert_eq!(row.take::<Struct, _>("user")?, expected);
-        assert_eq!(row.try_get::<Option<Struct>, _>("user")?, None);
+        assert_eq!(row.get::<Option<Struct>, _>("user")?, None);
 
         Ok(())
     }
@@ -627,10 +594,10 @@ mod tests {
         let schema = Arc::new(Schema::new(schema));
         let mut row = Row::try_new(raw_row, &schema)?;
 
-        assert_eq!(row.get::<Vec<i64>, _>(0), vec![1, 2, 3]);
-        assert_eq!(row.get::<Vec<i64>, _>("numbers"), vec![1, 2, 3]);
+        assert_eq!(row.get::<Vec<i64>, _>(0)?, vec![1, 2, 3]);
+        assert_eq!(row.get::<Vec<i64>, _>("numbers")?, vec![1, 2, 3]);
         assert_eq!(row.take::<Vec<i64>, _>("numbers")?, vec![1, 2, 3]);
-        assert_eq!(row.try_get::<Option<Vec<i64>>, _>("numbers")?, None);
+        assert_eq!(row.get::<Option<Vec<i64>>, _>("numbers")?, None);
 
         Ok(())
     }
@@ -689,10 +656,10 @@ mod tests {
                 "age": 31,
             },
         ]))?;
-        assert_eq!(row.get::<Vec<Struct>, _>(0), expected);
-        assert_eq!(row.get::<Vec<Struct>, _>("users"), expected);
+        assert_eq!(row.get::<Vec<Struct>, _>(0)?, expected);
+        assert_eq!(row.get::<Vec<Struct>, _>("users")?, expected);
         assert_eq!(row.take::<Vec<Struct>, _>("users")?, expected);
-        assert_eq!(row.try_get::<Option<Vec<Struct>>, _>("users")?, None);
+        assert_eq!(row.get::<Option<Vec<Struct>>, _>("users")?, None);
 
         Ok(())
     }

--- a/tests/bigquery/src/query.rs
+++ b/tests/bigquery/src/query.rs
@@ -43,7 +43,7 @@ pub async fn query_client() -> Result<()> {
 
     let mut iter = complete_query.read();
     let row = iter.next().await.expect("should return first row")?;
-    assert_eq!(row.get::<i64, _>("one"), 1);
+    assert_eq!(row.get::<i64, _>("one")?, 1);
     assert!(iter.next().await.is_none(), "{iter:?}");
 
     Ok(())
@@ -163,54 +163,54 @@ pub async fn query_client_datatypes() -> Result<()> {
         },
     };
 
-    assert_eq!(row.get::<String, _>("name"), expected.name);
-    assert_eq!(row.get::<i64, _>("age"), expected.age);
-    assert_eq!(row.get::<f64, _>("height"), expected.height);
-    assert_eq!(row.get::<bool, _>("active"), expected.active);
-    assert_eq!(row.get::<Vec<i64>, _>("numbers"), expected.numbers);
+    assert_eq!(row.get::<String, _>("name")?, expected.name);
+    assert_eq!(row.get::<i64, _>("age")?, expected.age);
+    assert_eq!(row.get::<f64, _>("height")?, expected.height);
+    assert_eq!(row.get::<bool, _>("active")?, expected.active);
+    assert_eq!(row.get::<Vec<i64>, _>("numbers")?, expected.numbers);
     assert_eq!(
-        row.get::<wkt::Timestamp, _>("created_at"),
+        row.get::<wkt::Timestamp, _>("created_at")?,
         expected.created_at
     );
     assert_eq!(
-        row.get::<google_cloud_type::model::Date, _>("birth_date"),
+        row.get::<google_cloud_type::model::Date, _>("birth_date")?,
         expected.birth_date
     );
     assert_eq!(
-        row.get::<google_cloud_type::model::TimeOfDay, _>("daily_alarm"),
+        row.get::<google_cloud_type::model::TimeOfDay, _>("daily_alarm")?,
         expected.daily_alarm
     );
     assert_eq!(
-        row.get::<google_cloud_type::model::DateTime, _>("event_time"),
+        row.get::<google_cloud_type::model::DateTime, _>("event_time")?,
         expected.event_time
     );
     assert_eq!(
-        row.get::<Range<google_cloud_type::model::Date>, _>("date_range"),
+        row.get::<Range<google_cloud_type::model::Date>, _>("date_range")?,
         expected.date_range
     );
     assert_eq!(
-        row.get::<Range<wkt::Timestamp>, _>("timestamp_range"),
+        row.get::<Range<wkt::Timestamp>, _>("timestamp_range")?,
         expected.timestamp_range
     );
     assert_eq!(
-        row.get::<Option<String>, _>("nullable_name"),
+        row.get::<Option<String>, _>("nullable_name")?,
         expected.nullable_name
     );
     assert_eq!(
-        row.get::<Option<i64>, _>("nullable_age"),
+        row.get::<Option<i64>, _>("nullable_age")?,
         expected.nullable_age
     );
-    assert_eq!(row.get::<Vec<u8>, _>("raw_bytes"), expected.raw_bytes);
+    assert_eq!(row.get::<Vec<u8>, _>("raw_bytes")?, expected.raw_bytes);
     assert_eq!(
-        row.get::<bytes::Bytes, _>("payload_bytes"),
+        row.get::<bytes::Bytes, _>("payload_bytes")?,
         expected.payload_bytes
     );
     assert_eq!(
-        row.get::<Option<Vec<u8>>, _>("nullable_bytes"),
+        row.get::<Option<Vec<u8>>, _>("nullable_bytes")?,
         expected.nullable_bytes
     );
     assert_eq!(
-        row.get::<Interval, _>("interval_val"),
+        row.get::<Interval, _>("interval_val")?,
         expected.interval_val
     );
 
@@ -246,11 +246,11 @@ pub async fn query_client_numeric_limits() -> Result<()> {
 
     // Verify google_cloud_type::model::Decimal preserves values for NUMERIC (38 digits) and BIGNUMERIC (76 digits).
     assert_eq!(
-        row.get::<Decimal, _>("max_numeric"),
+        row.get::<Decimal, _>("max_numeric")?,
         Decimal::new().set_value("99999999999999999999999999999.999999999")
     );
     assert_eq!(
-        row.get::<Decimal, _>("max_bignumeric"),
+        row.get::<Decimal, _>("max_bignumeric")?,
         Decimal::new().set_value(
             "99999999999999999999999999999999999999.99999999999999999999999999999999999999"
         )
@@ -259,15 +259,15 @@ pub async fn query_client_numeric_limits() -> Result<()> {
     // Verify rust_decimal handles numbers within its 96-bit bounds (around 28 digits)
     // and errors on out-of-range values.
     assert_eq!(
-        row.get::<RustDecimal, _>("standard_numeric"),
+        row.get::<RustDecimal, _>("standard_numeric")?,
         "123.123456789".parse().expect("valid decimal")
     );
     assert_eq!(
-        row.get::<RustDecimal, _>("standard_bignumeric"),
+        row.get::<RustDecimal, _>("standard_bignumeric")?,
         "1234567890.1234567890".parse().expect("valid decimal")
     );
-    assert!(row.try_get::<RustDecimal, _>("max_numeric").is_err());
-    assert!(row.try_get::<RustDecimal, _>("max_bignumeric").is_err());
+    assert!(row.get::<RustDecimal, _>("max_numeric").is_err());
+    assert!(row.get::<RustDecimal, _>("max_bignumeric").is_err());
 
     assert!(iter.next().await.is_none());
 
@@ -338,7 +338,7 @@ pub async fn query_client_job() -> Result<()> {
     // read the results
     let mut iter = query.read();
     let row = iter.next().await.expect("should return first row")?;
-    assert_eq!(row.get::<i64, _>("two"), 2);
+    assert_eq!(row.get::<i64, _>("two")?, 2);
     assert!(iter.next().await.is_none(), "{iter:?}");
 
     Ok(())


### PR DESCRIPTION
After discussion on API review, we think we should remove a methods that panics. Overall is pretty easy for customers to just call `.unwrap` or `.expect` and be aware that the method needs error handling.