### PR TITLE
refactor(gax): add streaming::ResponseStream type

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -966,10 +966,12 @@ libraries:
     version: 1.15.0
     copyright_year: "2025"
     output: src/gax
+    skip_release: true
   - name: google-cloud-gax-internal
     version: 0.7.19
     copyright_year: "2025"
     output: src/gax-internal
+    skip_release: true
     rust:
       modules:
         - module_path: google_cloud_rpc::model

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -262,6 +262,40 @@ impl Client {
         )
     }
 
+    /// Opens a bidirectional stream with automatic model <-> proto conversion and channel management.
+    pub fn execute_bidi_streaming_tmp<DomainReq, DomainResp, ProstReq, ProstResp>(
+        &self,
+        extensions: tonic::Extensions,
+        path: http::uri::PathAndQuery,
+        options: RequestOptions,
+        api_client_header: &'static str,
+        request_params: &str,
+    ) -> (
+        google_cloud_gax::streaming::RequestSender<DomainReq>,
+        google_cloud_gax::streaming::ResponseStream<DomainResp>,
+    )
+    where
+        DomainReq: crate::prost::ToProto<ProstReq, Output = ProstReq> + Send + 'static,
+        DomainResp: Send + 'static,
+        ProstReq: prost::Message + Send + 'static,
+        ProstResp: prost::Message + Default + crate::prost::FromProto<DomainResp> + 'static,
+    {
+        let (req_tx, req_stream) = streaming::create_request_channel(&options);
+        let resp_rx = self.spawn_bidi_stream::<ProstReq, ProstResp>(
+            extensions,
+            path,
+            req_stream,
+            options,
+            api_client_header,
+            request_params,
+        );
+
+        (
+            streaming::create_request_sender(req_tx),
+            streaming::create_response_receiver_tmp(resp_rx),
+        )
+    }
+
     fn spawn_bidi_stream<ProstReq, ProstResp>(
         &self,
         extensions: tonic::Extensions,
@@ -410,6 +444,45 @@ impl Client {
             .map_err(to_gax_error)?;
 
         let response_receiver = google_cloud_gax::streaming::ResponseReceiver::from_stream(
+            streaming::decode_response_stream(result.into_inner()),
+        );
+
+        Ok(response_receiver)
+    }
+
+    /// Opens a server stream with automatic model <-> proto conversion and stream mapping.
+    pub async fn execute_server_streaming_tmp<DomainReq, DomainResp, ProstReq, ProstResp>(
+        &self,
+        extensions: tonic::Extensions,
+        path: http::uri::PathAndQuery,
+        request: DomainReq,
+        options: RequestOptions,
+        api_client_header: &'static str,
+        request_params: &str,
+    ) -> Result<google_cloud_gax::streaming::ResponseStream<DomainResp>>
+    where
+        DomainReq: crate::prost::ToProto<ProstReq, Output = ProstReq>,
+        DomainResp: Send + 'static,
+        ProstReq: prost::Message + Clone + 'static,
+        ProstResp: prost::Message + Default + crate::prost::FromProto<DomainResp> + 'static,
+    {
+        let req = request
+            .to_proto()
+            .map_err(google_cloud_gax::error::Error::ser)?;
+
+        let result = self
+            .server_streaming_with_status::<ProstReq, ProstResp>(
+                extensions,
+                path,
+                req,
+                options,
+                api_client_header,
+                request_params,
+            )
+            .await?
+            .map_err(to_gax_error)?;
+
+        let response_receiver = google_cloud_gax::streaming::ResponseStream::from_stream(
             streaming::decode_response_stream(result.into_inner()),
         );
 

--- a/src/gax-internal/src/grpc/streaming.rs
+++ b/src/gax-internal/src/grpc/streaming.rs
@@ -20,7 +20,7 @@ use futures::FutureExt as _;
 use futures::stream::StreamExt as _;
 use google_cloud_gax::error::Error;
 use google_cloud_gax::options::RequestOptions;
-use google_cloud_gax::streaming::{RequestSender, ResponseReceiver, SendError};
+use google_cloud_gax::streaming::{RequestSender, ResponseReceiver, ResponseStream, SendError};
 
 /// Default buffer capacity for request streaming channels.
 pub(crate) const DEFAULT_REQUEST_CHANNEL_CAPACITY: usize = 16;
@@ -96,6 +96,27 @@ where
         ))),
     });
     ResponseReceiver::from_future(future)
+}
+
+/// Constructs a [`ResponseReceiver<DomainResp>`] from a oneshot receiver waiting for the tonic response.
+pub(crate) fn create_response_receiver_tmp<DomainResp, ProstResp>(
+    resp_rx: tokio::sync::oneshot::Receiver<
+        google_cloud_gax::Result<tonic::Response<tonic::Streaming<ProstResp>>>,
+    >,
+) -> ResponseStream<DomainResp>
+where
+    DomainResp: Send + 'static,
+    ProstResp: FromProto<DomainResp> + Send + 'static,
+{
+    let future = resp_rx.map(|res| match res {
+        Ok(Ok(response)) => Ok(decode_response_stream(response.into_inner())),
+        Ok(Err(err)) => Err(err),
+        Err(_) => Err(Error::io(std::io::Error::new(
+            std::io::ErrorKind::BrokenPipe,
+            "stream initialization task cancelled",
+        ))),
+    });
+    ResponseStream::from_future(future)
 }
 
 #[cfg(test)]

--- a/src/gax-internal/src/unimplemented.rs
+++ b/src/gax-internal/src/unimplemented.rs
@@ -14,7 +14,7 @@
 
 use google_cloud_gax::Result;
 use google_cloud_gax::response::Response;
-use google_cloud_gax::streaming::{RequestSender, ResponseReceiver};
+use google_cloud_gax::streaming::{RequestSender, ResponseReceiver, ResponseStream};
 
 pub const UNIMPLEMENTED: &str = concat!(
     "to prevent breaking changes as services gain new RPCs, the stub ",
@@ -37,6 +37,14 @@ pub fn unimplemented_bidi_stub<I, O>() -> (RequestSender<I>, ResponseReceiver<O>
 }
 
 pub async fn unimplemented_server_streaming_stub<O: Send>() -> Result<ResponseReceiver<O>> {
+    unimplemented!("{UNIMPLEMENTED}");
+}
+
+pub fn unimplemented_bidi_stub_tmp<I, O>() -> (RequestSender<I>, ResponseStream<O>) {
+    unimplemented!("{UNIMPLEMENTED}");
+}
+
+pub async fn unimplemented_server_streaming_stub_tmp<O: Send>() -> Result<ResponseStream<O>> {
     unimplemented!("{UNIMPLEMENTED}");
 }
 

--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -16,7 +16,7 @@
 //!
 //! In streaming RPCs, the client and server can stream messages to each other
 //! asynchronously. This module provides [`RequestSender`] to send outbound request
-//! messages and [`ResponseReceiver`] to receive inbound response messages.
+//! messages and [`ResponseStream`] to receive inbound response messages.
 //!
 //! Client libraries use these types to manage streaming communication without
 //! exposing raw gRPC transport or Protobuf wire models in the public API.
@@ -24,17 +24,17 @@
 //! Connection establishment begins immediately when the streaming RPC is initiated.
 //! In bidirectional streaming, the server may require initial request messages sent via
 //! [`RequestSender`] before returning response headers; completing this handshake is awaited
-//! on the first call to [`ResponseReceiver::recv()`].
+//! on the first call to [`ResponseStream::next()`].
 //!
 //! # Examples
 //!
 //! Sending requests and receiving responses in a bidirectional streaming RPC:
 //!
 //! ```
-//! # use google_cloud_gax::streaming::{RequestSender, ResponseReceiver};
+//! # use google_cloud_gax::streaming::{RequestSender, ResponseStream};
 //! async fn interact_with_bidi_stream(
 //!     sender: RequestSender<String>,
-//!     mut receiver: ResponseReceiver<String>,
+//!     mut stream: ResponseStream<String>,
 //! ) {
 //!     // Send request messages to the server:
 //!     if let Err(err) = sender.send("hello".to_string()).await {
@@ -45,7 +45,7 @@
 //!     drop(sender);
 //!
 //!     // Receive response messages from the server:
-//!     while let Some(response) = receiver.recv().await {
+//!     while let Some(response) = stream.next().await {
 //!         match response {
 //!             Ok(item) => println!("Received response: {item}"),
 //!             Err(err) => {
@@ -74,7 +74,7 @@ type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// fn handle_error(err: SendError) {
 ///     match err {
 ///         SendError::StreamClosed => {
-///             println!("Stream closed; check ResponseReceiver for server status");
+///             println!("Stream closed; check ResponseStream for server status");
 ///         }
 ///         SendError::Serialization(e) => {
 ///             println!("Failed to serialize request: {e}");
@@ -89,8 +89,8 @@ pub enum SendError {
     /// The stream was closed by the server or receiver.
     ///
     /// The underlying server status error (e.g., `InvalidArgument`, `PermissionDenied`)
-    /// is returned by [`ResponseReceiver::recv`].
-    #[error("cannot send request: stream is closed; inspect ResponseReceiver for details")]
+    /// is returned by [`ResponseStream::next`].
+    #[error("cannot send request: stream is closed; inspect ResponseStream for details")]
     StreamClosed,
 
     /// Serialization / proto conversion of the request failed.
@@ -212,22 +212,22 @@ where
 
 /// A boxed pinned future that resolves to an incoming response stream or an error.
 type ConnectingFuture<Resp> =
-    Pin<Box<dyn Future<Output = Result<ResponseStream<Resp>, crate::error::Error>> + Send>>;
+    Pin<Box<dyn Future<Output = Result<DynResponseStream<Resp>, crate::error::Error>> + Send>>;
 
 /// A type-erased stream of incoming responses from a gRPC stream.
 ///
 /// This wraps an underlying `futures::Stream` in a boxed pinned trait object,
-/// enabling [`ResponseReceiver`] to perform asynchronous transformations (such
+/// enabling [`ResponseStream`] to perform asynchronous transformations (such
 /// as Protobuf deserialization) without exposing `futures::Stream` in the public API.
-type ResponseStream<Resp> =
+type DynResponseStream<Resp> =
     Pin<Box<dyn futures::Stream<Item = Result<Resp, crate::error::Error>> + Send>>;
 
-/// Internal state machine for [`ResponseReceiver`].
+/// Internal state machine for [`ResponseStream`].
 enum ResponseState<Resp> {
     /// Awaiting the initial connection future to resolve the response stream.
     Connecting(ConnectingFuture<Resp>),
     /// Response stream established; actively streaming incoming messages.
-    Connected(ResponseStream<Resp>),
+    Connected(DynResponseStream<Resp>),
     /// Stream has completed or encountered a terminal error.
     Closed,
 }
@@ -350,7 +350,7 @@ impl<Resp> ResponseReceiver<Resp> {
     {
         let connecting: ConnectingFuture<Resp> = Box::pin(async move {
             let stream = fut.await?;
-            Ok(Box::pin(stream) as ResponseStream<Resp>)
+            Ok(Box::pin(stream) as DynResponseStream<Resp>)
         });
         Self {
             state: ResponseState::Connecting(connecting),
@@ -394,27 +394,189 @@ where
     }
 }
 
+/// A handle for receiving inbound response items from a streaming RPC.
+///
+/// Typically, you receive a `ResponseStream` as the result of initiating a streaming RPC.
+/// Unlike [`RequestSender`], `ResponseStream` cannot be cloned and represents exclusive
+/// ownership of the inbound stream. Call [`next`](Self::next) to consume incoming messages
+/// sequentially. Dropping the `ResponseStream` cancels the stream.
+///
+/// Enable the `unstable-stream` feature to convert this type into a [`Stream`][futures::Stream]
+/// via `into_stream`.
+///
+/// # Examples
+///
+/// ```
+/// # use google_cloud_gax::streaming::ResponseStream;
+/// # use google_cloud_gax::Result;
+/// # async fn sample(mut stream: ResponseStream<String>) -> Result<()> {
+/// while let Some(item) = stream.next().await {
+///     let item = item?;
+///     println!("Received: {item}");
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub struct ResponseStream<Resp> {
+    state: ResponseState<Resp>,
+}
+
+impl<Resp> std::fmt::Debug for ResponseStream<Resp> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResponseStream").finish()
+    }
+}
+
+impl<Resp> ResponseStream<Resp> {
+    /// Receives the next response message from the stream, or `None` if the stream has finished.
+    ///
+    /// Returns `Some(Err(e))` if a transport, server status, or deserialization error occurs.
+    /// Once an error or stream completion is reached, subsequent calls return `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use google_cloud_gax::streaming::ResponseStream;
+    /// # use google_cloud_gax::Result;
+    /// # async fn sample(mut stream: ResponseStream<String>) -> Result<()> {
+    /// while let Some(item) = stream.next().await {
+    ///     let item = item?;
+    ///     println!("Received: {item}");
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn next(&mut self) -> Option<Result<Resp, crate::error::Error>> {
+        use futures::StreamExt as _;
+        loop {
+            match &mut self.state {
+                ResponseState::Connecting(fut) => match fut.await {
+                    Ok(stream) => {
+                        self.state = ResponseState::Connected(stream);
+                    }
+                    Err(e) => {
+                        self.state = ResponseState::Closed;
+                        return Some(Err(e));
+                    }
+                },
+                ResponseState::Connected(stream) => {
+                    let item = stream.next().await;
+                    if item.is_none() {
+                        self.state = ResponseState::Closed;
+                    }
+                    return item;
+                }
+                ResponseState::Closed => return None,
+            }
+        }
+    }
+
+    #[cfg(feature = "unstable-stream")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-stream")))]
+    /// Converts the `ResponseStream` into an asynchronous [`Stream`][futures::Stream].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use google_cloud_gax::streaming::ResponseStream;
+    /// # use google_cloud_gax::Result;
+    /// # use futures::StreamExt as _;
+    /// # async fn sample(stream: ResponseStream<String>) -> Result<()> {
+    /// let mut stream = stream.into_stream();
+    /// while let Some(item) = stream.next().await {
+    ///     let item = item?;
+    ///     println!("Received: {item}");
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn into_stream(
+        self,
+    ) -> impl futures::Stream<Item = Result<Resp, crate::error::Error>> + Send + Unpin {
+        Box::pin(futures::stream::unfold(self, |mut s| async move {
+            let item = s.next().await?;
+            Some((item, s))
+        }))
+    }
+
+    /// Creates a [`ResponseStream`] from an asynchronous connection future.
+    ///
+    /// This constructor is `doc(hidden)` (except when `_internal-semver` is enabled)
+    /// so that generated client transports can construct [`ResponseStream`] instances
+    /// that asynchronously await HTTP/2 response headers.
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+    pub fn from_future<Fut, S>(fut: Fut) -> Self
+    where
+        Fut: Future<Output = Result<S, crate::error::Error>> + Send + 'static,
+        S: futures::Stream<Item = Result<Resp, crate::error::Error>> + Send + 'static,
+    {
+        let connecting: ConnectingFuture<Resp> = Box::pin(async move {
+            let stream = fut.await?;
+            Ok(Box::pin(stream) as DynResponseStream<Resp>)
+        });
+        Self {
+            state: ResponseState::Connecting(connecting),
+        }
+    }
+
+    /// Creates a [`ResponseStream`] from an asynchronous stream.
+    ///
+    /// This constructor is `doc(hidden)` (except when `_internal-semver` is enabled)
+    /// so that generated client transports can construct [`ResponseStream`] instances
+    /// directly from gRPC response streams without exposing `futures::Stream` in the
+    /// public API documentation.
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+    pub fn from_stream<S>(stream: S) -> Self
+    where
+        S: futures::Stream<Item = Result<Resp, crate::error::Error>> + Send + 'static,
+    {
+        Self {
+            state: ResponseState::Connected(Box::pin(stream)),
+        }
+    }
+}
+
+/// Creates a [`ResponseStream`] from a Tokio [`mpsc::Receiver`], useful for mocking in tests.
+///
+/// # Examples
+///
+/// ```
+/// # use google_cloud_gax::streaming::ResponseStream;
+/// # use google_cloud_gax::Result;
+/// # use tokio::sync::mpsc;
+/// let (tx, rx) = mpsc::channel::<Result<String>>(16);
+/// let receiver = ResponseStream::from(rx);
+/// ```
+impl<Resp> From<mpsc::Receiver<crate::Result<Resp>>> for ResponseStream<Resp>
+where
+    Resp: Send + 'static,
+{
+    fn from(rx: mpsc::Receiver<crate::Result<Resp>>) -> Self {
+        Self::from_stream(tokio_stream::wrappers::ReceiverStream::new(rx))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, Ordering};
 
     #[tokio::test]
-    async fn request_sender_and_response_receiver() -> Result<(), Box<dyn std::error::Error>> {
+    async fn request_sender_and_response_stream() -> Result<(), Box<dyn std::error::Error>> {
         let (req_tx, mut req_rx) = mpsc::channel::<String>(16);
         let (resp_tx, resp_rx) = mpsc::channel::<crate::Result<String>>(16);
 
         let sender: RequestSender<_> = req_tx.into();
-        let mut receiver: ResponseReceiver<_> = resp_rx.into();
+        let mut stream: ResponseStream<_> = resp_rx.into();
 
         sender.send("hello".to_string()).await?;
         assert_eq!(req_rx.recv().await.as_deref(), Some("hello"));
 
         resp_tx.send(Ok("world".to_string())).await?;
-        assert_eq!(receiver.recv().await.transpose()?.as_deref(), Some("world"));
+        assert_eq!(stream.next().await.transpose()?.as_deref(), Some("world"));
 
         drop(resp_tx);
-        assert!(receiver.recv().await.is_none());
+        assert!(stream.next().await.is_none());
         Ok(())
     }
 
@@ -431,7 +593,7 @@ mod tests {
         assert!(matches!(err, SendError::StreamClosed));
         assert_eq!(
             err.to_string(),
-            "cannot send request: stream is closed; inspect ResponseReceiver for details"
+            "cannot send request: stream is closed; inspect ResponseStream for details"
         );
     }
 
@@ -461,7 +623,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn response_receiver_lazy_future_success() -> Result<(), Box<dyn std::error::Error>> {
+    async fn response_stream_lazy_future_success() -> Result<(), Box<dyn std::error::Error>> {
         let future_polled = Arc::new(AtomicBool::new(false));
         let polled_clone = future_polled.clone();
 
@@ -472,32 +634,32 @@ mod tests {
             Ok(stream)
         };
 
-        let mut receiver = ResponseReceiver::from_future(lazy_fut);
-        // Ensure future is NOT polled before recv() is called
+        let mut stream = ResponseStream::from_future(lazy_fut);
+        // Ensure future is NOT polled before next() is called
         assert!(!future_polled.load(Ordering::SeqCst));
 
-        // First recv() awaits connection future and yields first item
-        let first = receiver.recv().await.expect("expected first response")?;
+        // First next() awaits connection future and yields first item
+        let first = stream.next().await.expect("expected first response")?;
         assert!(future_polled.load(Ordering::SeqCst));
         assert_eq!(first, "item-1");
 
-        // Second recv() yields second item
-        let second = receiver.recv().await.expect("expected second response")?;
+        // Second next() yields second item
+        let second = stream.next().await.expect("expected second response")?;
         assert_eq!(second, "item-2");
 
-        // Third recv() returns None (clean EOF)
-        assert!(receiver.recv().await.is_none());
+        // Third next() returns None (clean EOF)
+        assert!(stream.next().await.is_none());
 
-        // Subsequent recv() calls on closed receiver return None
-        assert!(receiver.recv().await.is_none());
-        assert!(receiver.recv().await.is_none());
-        assert_eq!(format!("{receiver:?}"), "ResponseReceiver");
+        // Subsequent next() calls on closed receiver return None
+        assert!(stream.next().await.is_none());
+        assert!(stream.next().await.is_none());
+        assert_eq!(format!("{stream:?}"), "ResponseStream");
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn response_receiver_lazy_future_connecting_error() {
+    async fn response_stream_lazy_future_connecting_error() {
         let status = crate::error::rpc::Status::default()
             .set_code(crate::error::rpc::Code::PermissionDenied)
             .set_message("permission denied");
@@ -508,11 +670,11 @@ mod tests {
             res
         };
 
-        let mut receiver = ResponseReceiver::<String>::from_future(lazy_fut);
+        let mut stream = ResponseStream::<String>::from_future(lazy_fut);
 
-        // First recv() should return the connection setup error
-        let err = receiver
-            .recv()
+        // First next() should return the connection setup error
+        let err = stream
+            .next()
             .await
             .expect("expected error item")
             .expect_err("should be Err");
@@ -522,39 +684,38 @@ mod tests {
         );
 
         // After error during connection, stream is closed and returns None
-        assert!(receiver.recv().await.is_none());
-        assert!(receiver.recv().await.is_none());
+        assert!(stream.next().await.is_none());
+        assert!(stream.next().await.is_none());
     }
 
     #[tokio::test]
-    async fn response_receiver_stream_item_error_recovery() -> Result<(), Box<dyn std::error::Error>>
-    {
+    async fn response_stream_item_error_recovery() -> Result<(), Box<dyn std::error::Error>> {
         let stream = futures::stream::iter(vec![
             Ok("item-1".to_string()),
             Err(crate::error::Error::deser("corrupted item")),
             Ok("item-2".to_string()),
         ]);
-        let mut receiver = ResponseReceiver::from_stream(stream);
+        let mut resp = ResponseStream::from_stream(stream);
 
-        let item1 = receiver.recv().await.expect("expected item 1")?;
+        let item1 = resp.next().await.expect("expected item 1")?;
         assert_eq!(item1, "item-1");
 
-        let err = receiver
-            .recv()
+        let err = resp
+            .next()
             .await
             .expect("expected item 2")
             .expect_err("item 2 should be deserialization error");
         assert!(err.is_deserialization());
 
-        let item2 = receiver.recv().await.expect("expected item 3")?;
+        let item2 = resp.next().await.expect("expected item 3")?;
         assert_eq!(item2, "item-2");
 
-        assert!(receiver.recv().await.is_none());
+        assert!(resp.next().await.is_none());
         Ok(())
     }
 
     #[tokio::test]
-    async fn response_receiver_generator_mapping_pipeline() -> Result<(), Box<dyn std::error::Error>>
+    async fn response_stream_generator_mapping_pipeline() -> Result<(), Box<dyn std::error::Error>>
     {
         use futures::StreamExt as _;
 
@@ -600,10 +761,10 @@ mod tests {
         let response_stream = raw_stream
             .map(|res| res.and_then(|raw| from_proto(raw).map_err(crate::error::Error::deser)));
 
-        let mut receiver = ResponseReceiver::from_stream(response_stream);
+        let mut stream = ResponseStream::from_stream(response_stream);
 
         // 1. Success
-        let item1 = receiver.recv().await.expect("expected item 1")?;
+        let item1 = stream.next().await.expect("expected item 1")?;
         assert_eq!(
             item1,
             DomainModel {
@@ -612,8 +773,8 @@ mod tests {
         );
 
         // 2. Stream transport error
-        let err2 = receiver
-            .recv()
+        let err2 = stream
+            .next()
             .await
             .expect("expected item 2")
             .expect_err("item 2 should be Err");
@@ -623,15 +784,15 @@ mod tests {
         );
 
         // 3. Deserialization error
-        let err3 = receiver
-            .recv()
+        let err3 = stream
+            .next()
             .await
             .expect("expected item 3")
             .expect_err("item 3 should be Err");
         assert!(err3.is_deserialization());
 
         // 4. Success after recoverable error
-        let item4 = receiver.recv().await.expect("expected item 4")?;
+        let item4 = stream.next().await.expect("expected item 4")?;
         assert_eq!(
             item4,
             DomainModel {
@@ -640,7 +801,7 @@ mod tests {
         );
 
         // 5. Stream finished
-        assert!(receiver.recv().await.is_none());
+        assert!(stream.next().await.is_none());
         Ok(())
     }
 
@@ -650,8 +811,8 @@ mod tests {
         use futures::StreamExt as _;
 
         let stream = futures::stream::iter(vec![Ok("first".to_string()), Ok("second".to_string())]);
-        let receiver = ResponseReceiver::from_stream(stream);
-        let mut stream = receiver.into_stream();
+        let stream = ResponseStream::from_stream(stream);
+        let mut stream = stream.into_stream();
 
         assert_eq!(stream.next().await.transpose()?.as_deref(), Some("first"));
         assert_eq!(stream.next().await.transpose()?.as_deref(), Some("second"));


### PR DESCRIPTION
For the first step, add the new type and add temporary helpers. The temporary helpers will be removed and the old ResponseReceiver will be removed.

For #6581 