### PR TITLE
chore(spanner): extract generic bounded ClockStore

### DIFF
--- a/src/spanner/src/routing/clock_cache.rs
+++ b/src/spanner/src/routing/clock_cache.rs
@@ -1,0 +1,784 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Generic bounded cache implementing the CLOCK (Second-Chance) replacement algorithm.
+//!
+//! Provides a bounded key-value store with lock-free atomic reference bit updates on read,
+//! and $O(1)$ amortized second-chance eviction on write when reaching configured capacity.
+
+use std::borrow::Borrow;
+use std::collections::{HashMap, VecDeque};
+use std::fmt::{self, Debug, Formatter};
+use std::hash::Hash;
+use std::mem::replace;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Default upper bound on initial startup hash map allocation for bounded caches.
+pub(crate) const DEFAULT_INITIAL_CAPACITY_BOUND: usize = 256;
+
+/// A bounded cache store implementing the CLOCK (Second-Chance) page replacement algorithm.
+///
+/// Designed to be embedded within outer synchronization primitives (e.g. `RwLock<ClockStore<K, V>>`),
+/// where concurrent readers (`&self`) can update cache reference bits lock-free via atomic flags (`AtomicBool`),
+/// while writers (`&mut self`) perform mutations and evictions.
+///
+/// Features:
+/// - $O(1)$ lock-free read reference bit updates (`Ordering::Relaxed`).
+/// - $O(1)$ amortized eviction on write when exceeding capacity.
+/// - In-place replacement semantics with reference bit refresh.
+/// - Zero heap allocations on hit.
+#[derive(Debug)]
+pub(crate) struct ClockStore<K, V> {
+    entries: HashMap<K, ClockEntry<V>>,
+    order: VecDeque<K>,
+    capacity: usize,
+}
+
+impl<K: Eq + Hash, V> ClockStore<K, V> {
+    /// Creates a new [`ClockStore`] with the given maximum entry capacity.
+    ///
+    /// Pre-allocates initial capacity bounded to at most `min(capacity, DEFAULT_INITIAL_CAPACITY_BOUND)`
+    /// to avoid excessive memory usage on startup when configuring large cache limits.
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self::with_initial_capacity(capacity.min(DEFAULT_INITIAL_CAPACITY_BOUND), capacity)
+    }
+
+    /// Creates a new [`ClockStore`] with an explicit initial pre-allocated capacity
+    /// and a maximum capacity eviction limit.
+    ///
+    /// The initial pre-allocation is bounded by `max_capacity` (`min(initial_capacity, max_capacity)`).
+    pub(crate) fn with_initial_capacity(initial_capacity: usize, max_capacity: usize) -> Self {
+        let initial_capacity = initial_capacity.min(max_capacity);
+        Self {
+            entries: HashMap::with_capacity(initial_capacity),
+            order: VecDeque::with_capacity(initial_capacity),
+            capacity: max_capacity,
+        }
+    }
+
+    /// Returns a cloned value for `key` if present, marking the entry as recently referenced.
+    ///
+    /// For reference-counted values (e.g. `Arc<T>`), cloning is an inexpensive $O(1)$ atomic increment
+    /// on the strong reference count, allowing callers to release any outer synchronization lock immediately.
+    pub(crate) fn get<Q>(&self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+        V: Clone,
+    {
+        let entry = self.entries.get(key)?;
+        if !entry.referenced.load(Ordering::Relaxed) {
+            entry.referenced.store(true, Ordering::Relaxed);
+        }
+        Some(entry.value.clone())
+    }
+
+    /// Returns a reference to the value for `key` if present, marking the entry as recently referenced.
+    ///
+    /// Performs zero heap allocations or clones, allowing in-place inspection under outer read guards.
+    #[allow(dead_code)]
+    pub(crate) fn get_ref<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let entry = self.entries.get(key)?;
+        if !entry.referenced.load(Ordering::Relaxed) {
+            entry.referenced.store(true, Ordering::Relaxed);
+        }
+        Some(&entry.value)
+    }
+
+    /// Inserts a key-value pair into the store.
+    ///
+    /// Returns `Some(previous_value)` if `key` already existed in the store.
+    pub(crate) fn insert(&mut self, key: K, value: V) -> Option<V>
+    where
+        K: Clone,
+    {
+        if self.capacity == 0 {
+            return None;
+        }
+
+        if let Some(entry) = self.entries.get_mut(&key) {
+            let previous_value = replace(&mut entry.value, value);
+            // Overwriting an existing entry marks it as recently referenced, granting it a
+            // second chance in CLOCK eviction so freshly updated entries are not prematurely evicted.
+            entry.referenced.store(true, Ordering::Relaxed);
+            return Some(previous_value);
+        }
+
+        // Evict from existing entries to make room BEFORE inserting the new entry.
+        self.evict_for_insert();
+
+        let order_key = key.clone();
+        self.entries.insert(
+            key,
+            ClockEntry {
+                value,
+                referenced: AtomicBool::new(false),
+            },
+        );
+        self.order.push_back(order_key);
+        None
+    }
+
+    /// Clears all entries from the store while preserving configured capacity.
+    #[allow(dead_code)]
+    pub(crate) fn clear(&mut self) {
+        self.entries.clear();
+        self.order.clear();
+    }
+
+    /// Returns the number of entries currently stored in the cache.
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` if the store contains no entries.
+    #[allow(dead_code)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Returns the maximum capacity of the store.
+    #[allow(dead_code)]
+    pub(crate) fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Empties the store and returns the inner entries map, allowing deallocation
+    /// of elements outside of lock guards. Preserves the configured capacity.
+    pub(crate) fn take_all(&mut self) -> HashMap<K, ClockEntry<V>> {
+        self.order.clear();
+        let initial_capacity = self.capacity.min(DEFAULT_INITIAL_CAPACITY_BOUND);
+        replace(&mut self.entries, HashMap::with_capacity(initial_capacity))
+    }
+
+    /// Evicts an unreferenced entry when `entries.len() >= capacity` using the CLOCK (Second-Chance) algorithm.
+    fn evict_for_insert(&mut self) {
+        if self.capacity == 0 {
+            return;
+        }
+        while self.entries.len() >= self.capacity {
+            let Some(candidate_key) = self.order.pop_front() else {
+                break;
+            };
+            let Some(entry) = self.entries.get(&candidate_key) else {
+                // Defensive check against queue desynchronization.
+                continue;
+            };
+            if entry.referenced.swap(false, Ordering::Relaxed) {
+                // Entry was referenced since last inspection: grant a second chance.
+                self.order.push_back(candidate_key);
+                continue;
+            }
+            // Entry was not referenced: evict from cache.
+            self.entries.remove(&candidate_key);
+            break;
+        }
+    }
+}
+
+/// An entry within [`ClockStore`], pairing a cached value with an atomic reference flag
+/// for scan-resistant CLOCK (Second-Chance) cache eviction.
+pub(crate) struct ClockEntry<V> {
+    pub(crate) value: V,
+    pub(crate) referenced: AtomicBool,
+}
+
+impl<V: Debug> Debug for ClockEntry<V> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ClockEntry")
+            .field("value", &self.value)
+            .field("referenced", &self.referenced.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn traits() {
+        static_assertions::assert_impl_all!(ClockStore<String, String>: Send, Sync, Debug);
+        static_assertions::assert_impl_all!(ClockEntry<String>: Send, Sync, Debug);
+    }
+
+    #[test]
+    fn clock_store_generic_types_and_eviction() {
+        let mut store = ClockStore::<String, i32>::with_capacity(2);
+        assert_eq!(store.capacity(), 2, "capacity must match configured value");
+        assert!(store.is_empty(), "new store must be empty");
+        assert_eq!(store.len(), 0, "new store must have length 0");
+
+        assert_eq!(
+            store.insert("item_a".to_string(), 100),
+            None,
+            "new insert must return None"
+        );
+        assert_eq!(
+            store.insert("item_b".to_string(), 200),
+            None,
+            "new insert must return None"
+        );
+        assert_eq!(store.len(), 2, "length must be 2 after two inserts");
+        assert!(!store.is_empty(), "store must not be empty after inserts");
+
+        // Access item_a to mark referenced
+        assert_eq!(
+            store.get("item_a"),
+            Some(100),
+            "get must return cached value"
+        );
+
+        // Insert item_c (evicts item_b because item_a got a second chance)
+        assert_eq!(
+            store.insert("item_c".to_string(), 300),
+            None,
+            "new insert must return None"
+        );
+        assert_eq!(store.len(), 2, "length must remain bounded at capacity");
+
+        assert_eq!(
+            store.get("item_a"),
+            Some(100),
+            "item_a must survive due to second chance"
+        );
+        assert_eq!(
+            store.get("item_b"),
+            None,
+            "item_b must be evicted as unreferenced"
+        );
+        assert_eq!(
+            store.get("item_c"),
+            Some(300),
+            "newly inserted item_c must be present"
+        );
+    }
+
+    #[test]
+    fn clock_store_insert_when_all_entries_referenced_evicts_oldest_not_new() {
+        let mut store = ClockStore::<u64, String>::with_capacity(2);
+        assert_eq!(
+            store.insert(1, "one".to_string()),
+            None,
+            "insert 1 must succeed"
+        );
+        assert_eq!(
+            store.insert(2, "two".to_string()),
+            None,
+            "insert 2 must succeed"
+        );
+
+        // Reference both existing entries
+        assert_eq!(store.get(&1), Some("one".to_string()), "get 1 must succeed");
+        assert_eq!(store.get(&2), Some("two".to_string()), "get 2 must succeed");
+
+        // Inserting 3 when all entries are referenced must evict oldest entry 1 (after second chance cycle)
+        // and must NOT evict newly inserted entry 3
+        assert_eq!(
+            store.insert(3, "three".to_string()),
+            None,
+            "insert 3 into full cache must succeed"
+        );
+        assert_eq!(
+            store.get(&3),
+            Some("three".to_string()),
+            "newly inserted entry 3 must NOT be evicted on insertion"
+        );
+        assert_eq!(
+            store.get(&1),
+            None,
+            "oldest entry 1 must be evicted after receiving second chance"
+        );
+        assert_eq!(
+            store.get(&2),
+            Some("two".to_string()),
+            "entry 2 must survive in cache"
+        );
+    }
+
+    #[test]
+    fn clock_store_insert_evict_and_reinsert_lifecycle() {
+        let mut store = ClockStore::<u64, String>::with_capacity(2);
+        // 1. Insert key 1 and 2 (cache at capacity 2)
+        assert_eq!(
+            store.insert(1, "one_v1".to_string()),
+            None,
+            "initial insert 1 must succeed"
+        );
+        assert_eq!(
+            store.insert(2, "two".to_string()),
+            None,
+            "initial insert 2 must succeed"
+        );
+        assert_eq!(store.len(), 2, "cache length must be 2");
+
+        // 2. Insert key 3: key 1 is unreferenced and evicted
+        assert_eq!(
+            store.insert(3, "three".to_string()),
+            None,
+            "insert 3 into full cache must succeed"
+        );
+        assert_eq!(store.len(), 2, "cache length must remain 2");
+        assert_eq!(store.get(&1), None, "key 1 must be evicted");
+
+        // 3. Re-insert key 1 with new value: key 2 is unreferenced and evicted
+        assert_eq!(
+            store.insert(1, "one_v2".to_string()),
+            None,
+            "re-inserting key 1 must succeed"
+        );
+        assert_eq!(store.len(), 2, "cache length must remain 2");
+        assert_eq!(store.get(&2), None, "key 2 must be evicted");
+        assert_eq!(
+            store.get(&1),
+            Some("one_v2".to_string()),
+            "key 1 must be active with new value"
+        );
+
+        // 4. Key 1 is now referenced (from step 3 get). Insert key 4: key 3 is evicted, key 1 survives
+        assert_eq!(
+            store.insert(4, "four".to_string()),
+            None,
+            "insert 4 into full cache must succeed"
+        );
+        assert_eq!(store.len(), 2, "cache length must remain 2");
+        assert_eq!(store.get(&3), None, "key 3 must be evicted");
+        assert_eq!(
+            store.get(&1),
+            Some("one_v2".to_string()),
+            "key 1 must survive via second chance"
+        );
+        assert_eq!(
+            store.get(&4),
+            Some("four".to_string()),
+            "key 4 must be present"
+        );
+    }
+
+    #[test]
+    fn clock_store_zero_capacity() {
+        let mut store = ClockStore::<u64, String>::with_capacity(0);
+        assert_eq!(store.capacity(), 0, "capacity must be 0");
+        assert_eq!(
+            store.insert(1, "val".to_string()),
+            None,
+            "insert into zero capacity cache must return None"
+        );
+        assert_eq!(store.len(), 0, "length must remain 0");
+        assert!(store.is_empty(), "store must be empty");
+        assert_eq!(
+            store.get(&1),
+            None,
+            "get from zero capacity cache must return None"
+        );
+    }
+
+    #[test]
+    fn clock_store_zero_initial_and_max_capacity() {
+        let mut store = ClockStore::<u64, String>::with_initial_capacity(0, 0);
+        assert_eq!(store.capacity(), 0, "capacity must be 0");
+        assert_eq!(
+            store.insert(1, "val".to_string()),
+            None,
+            "insert into zero capacity cache must return None"
+        );
+        assert_eq!(store.len(), 0, "length must remain 0");
+        assert!(store.is_empty(), "store must be empty");
+        assert_eq!(
+            store.get(&1),
+            None,
+            "get from zero capacity cache must return None"
+        );
+    }
+
+    #[test]
+    fn clock_store_overwrite_returns_previous_value_and_refreshes_referenced() {
+        let mut store = ClockStore::<u64, String>::with_capacity(2);
+        assert_eq!(
+            store.insert(1, "initial".to_string()),
+            None,
+            "initial insert must return None"
+        );
+        assert_eq!(
+            store.insert(1, "updated".to_string()),
+            Some("initial".to_string()),
+            "overwrite must return the displaced previous value"
+        );
+        assert_eq!(store.len(), 1, "length must be 1 after overwrite");
+
+        // Overwritten entry should have referenced = true, giving it a second chance
+        assert_eq!(
+            store.insert(2, "two".to_string()),
+            None,
+            "insert 2 must return None"
+        );
+        // Insert 3 -> 2 should be evicted because 1 got a second chance from overwrite
+        assert_eq!(
+            store.insert(3, "three".to_string()),
+            None,
+            "insert 3 must return None"
+        );
+        assert_eq!(
+            store.get(&1),
+            Some("updated".to_string()),
+            "overwritten entry 1 must survive due to refreshed reference bit"
+        );
+        assert_eq!(
+            store.get(&2),
+            None,
+            "entry 2 must be evicted as unreferenced"
+        );
+        assert_eq!(
+            store.get(&3),
+            Some("three".to_string()),
+            "entry 3 must be present"
+        );
+    }
+
+    #[test]
+    fn clock_store_clear_empties_entries_and_preserves_capacity() {
+        let mut store = ClockStore::<u64, String>::with_capacity(3);
+        store.insert(1, "one".to_string());
+        store.insert(2, "two".to_string());
+        assert_eq!(store.len(), 2, "length must be 2 after two inserts");
+
+        store.clear();
+        assert!(store.is_empty(), "store must be empty after clear");
+        assert_eq!(store.len(), 0, "length must be 0 after clear");
+        assert_eq!(
+            store.capacity(),
+            3,
+            "capacity must be preserved after clear"
+        );
+        assert_eq!(store.get(&1), None, "get on cleared key must return None");
+        assert_eq!(store.get(&2), None, "get on cleared key must return None");
+    }
+
+    #[test]
+    fn clock_store_get_ref_marks_referenced() {
+        let mut store = ClockStore::<u64, String>::with_capacity(2);
+        store.insert(1, "one".to_string());
+        store.insert(2, "two".to_string());
+
+        assert_eq!(store.get_ref(&999), None, "get_ref miss returns None");
+
+        // Use get_ref on 1 to mark referenced
+        assert_eq!(
+            store.get_ref(&1).map(String::as_str),
+            Some("one"),
+            "get_ref on key 1 must return reference to value"
+        );
+
+        // Insert 3 -> 2 evicted, 1 survives
+        assert_eq!(
+            store.insert(3, "three".to_string()),
+            None,
+            "insert 3 must return None"
+        );
+        assert_eq!(
+            store.get(&1),
+            Some("one".to_string()),
+            "entry 1 must survive due to get_ref reference bit update"
+        );
+        assert_eq!(
+            store.get(&2),
+            None,
+            "entry 2 must be evicted as unreferenced"
+        );
+        assert_eq!(
+            store.get(&3),
+            Some("three".to_string()),
+            "entry 3 must be present"
+        );
+    }
+
+    #[test]
+    fn clock_store_take_all_empties_entries_and_preserves_capacity() {
+        let mut store = ClockStore::<u64, String>::with_capacity(5);
+        store.insert(1, "one".to_string());
+        store.insert(2, "two".to_string());
+        assert_eq!(store.len(), 2, "length must be 2 after two inserts");
+
+        let extracted = store.take_all();
+        assert_eq!(extracted.len(), 2, "extracted map must contain 2 entries");
+        assert!(
+            extracted.contains_key(&1),
+            "extracted map must contain key 1"
+        );
+        assert!(
+            extracted.contains_key(&2),
+            "extracted map must contain key 2"
+        );
+
+        assert!(store.is_empty(), "store must be empty after take_all");
+        assert_eq!(store.len(), 0, "length must be 0 after take_all");
+        assert_eq!(
+            store.capacity(),
+            5,
+            "capacity must be preserved after take_all"
+        );
+        assert!(
+            store.entries.capacity() >= store.capacity().min(DEFAULT_INITIAL_CAPACITY_BOUND),
+            "entries map must preserve pre-allocated capacity after take_all"
+        );
+    }
+
+    #[test]
+    fn clock_store_debug_formatting() {
+        let mut store = ClockStore::<u64, i32>::with_capacity(2);
+        store.insert(42, 100);
+        let entry = store
+            .entries
+            .get(&42)
+            .expect("entry 42 must exist in entries");
+        let entry_debug = format!("{entry:?}");
+        assert!(
+            entry_debug.contains("ClockEntry"),
+            "debug format must contain ClockEntry name"
+        );
+        assert!(
+            entry_debug.contains("value: 100"),
+            "debug format must contain value"
+        );
+
+        let store_debug = format!("{store:?}");
+        assert!(
+            store_debug.contains("ClockStore"),
+            "debug format must contain ClockStore name"
+        );
+        assert!(
+            store_debug.contains("capacity: 2"),
+            "debug format must contain capacity"
+        );
+    }
+
+    #[test]
+    fn clock_store_initial_capacity_larger_than_max_capacity_evicts_at_max() {
+        let mut store = ClockStore::<u64, String>::with_initial_capacity(100, 2);
+        assert_eq!(store.capacity(), 2, "capacity must match max_capacity");
+        assert!(store.is_empty(), "new store must be empty");
+
+        assert_eq!(
+            store.insert(1, "one".to_string()),
+            None,
+            "insert 1 must return None"
+        );
+        assert_eq!(
+            store.insert(2, "two".to_string()),
+            None,
+            "insert 2 must return None"
+        );
+        assert_eq!(store.len(), 2, "length must be 2 after two inserts");
+
+        // Third insert must trigger eviction at max_capacity (2), not initial_capacity (100)
+        assert_eq!(
+            store.insert(3, "three".to_string()),
+            None,
+            "insert 3 must return None"
+        );
+        assert_eq!(store.len(), 2, "length must remain bounded at capacity 2");
+        assert_eq!(store.get(&1), None, "key 1 must be evicted at capacity 2");
+        assert_eq!(
+            store.get(&2),
+            Some("two".to_string()),
+            "key 2 must be present"
+        );
+        assert_eq!(
+            store.get(&3),
+            Some("three".to_string()),
+            "key 3 must be present"
+        );
+    }
+
+    #[test]
+    fn clock_store_zero_max_capacity_with_positive_initial_capacity() {
+        let mut store = ClockStore::<u64, String>::with_initial_capacity(50, 0);
+        assert_eq!(store.capacity(), 0, "capacity must be 0");
+        assert!(store.is_empty(), "store must be empty");
+        assert_eq!(store.len(), 0, "length must be 0");
+
+        assert_eq!(
+            store.insert(1, "one".to_string()),
+            None,
+            "insert into 0 max capacity must return None"
+        );
+        assert_eq!(store.len(), 0, "length must remain 0");
+        assert!(store.is_empty(), "store must remain empty");
+        assert_eq!(store.get(&1), None, "get must return None");
+    }
+
+    #[test]
+    fn clock_store_zero_initial_capacity_with_positive_max_capacity() {
+        let mut store = ClockStore::<u64, String>::with_initial_capacity(0, 3);
+        assert_eq!(store.capacity(), 3, "capacity must be 3");
+        assert!(store.is_empty(), "store must be empty");
+
+        store.insert(1, "one".to_string());
+        store.insert(2, "two".to_string());
+        store.insert(3, "three".to_string());
+        assert_eq!(store.len(), 3, "length must be 3 after three inserts");
+
+        // Fourth insert triggers eviction
+        assert_eq!(
+            store.insert(4, "four".to_string()),
+            None,
+            "insert 4 must return None"
+        );
+        assert_eq!(store.len(), 3, "length must remain bounded at capacity 3");
+        assert_eq!(store.get(&1), None, "key 1 must be evicted");
+        assert_eq!(
+            store.get(&2),
+            Some("two".to_string()),
+            "key 2 must be present"
+        );
+        assert_eq!(
+            store.get(&3),
+            Some("three".to_string()),
+            "key 3 must be present"
+        );
+        assert_eq!(
+            store.get(&4),
+            Some("four".to_string()),
+            "key 4 must be present"
+        );
+    }
+
+    #[test]
+    fn clock_store_with_capacity_bounds_initial_allocation_below_and_above_threshold() {
+        // Below 256 threshold: initial allocation is min(2, 256) = 2
+        let mut store_small = ClockStore::<u64, String>::with_capacity(2);
+        assert_eq!(store_small.capacity(), 2, "capacity must be 2");
+        store_small.insert(1, "one".to_string());
+        store_small.insert(2, "two".to_string());
+        store_small.insert(3, "three".to_string());
+        assert_eq!(store_small.len(), 2, "length must be 2");
+        assert_eq!(store_small.get(&1), None, "key 1 must be evicted");
+
+        // Above 256 threshold: initial allocation is min(300, 256) = 256, max capacity is 300
+        let mut store_large = ClockStore::<usize, usize>::with_capacity(300);
+        assert_eq!(store_large.capacity(), 300, "capacity must be 300");
+        for i in 0..300 {
+            store_large.insert(i, i * 10);
+        }
+        assert_eq!(store_large.len(), 300, "length must be 300");
+        // 301st insert triggers eviction at max capacity 300
+        assert_eq!(
+            store_large.insert(300, 3000),
+            None,
+            "insert 300 must succeed and return None"
+        );
+        assert_eq!(store_large.len(), 300, "length must remain 300");
+        assert_eq!(
+            store_large.get(&0),
+            None,
+            "oldest entry 0 must be evicted at capacity 300"
+        );
+        assert_eq!(
+            store_large.get(&300),
+            Some(3000),
+            "newly inserted entry 300 must be present"
+        );
+    }
+
+    #[test]
+    fn clock_store_huge_initial_capacity_clamped_to_max_capacity() {
+        // usize::MAX initial capacity must be safely clamped to max_capacity (2) without OOM
+        let mut store = ClockStore::<u64, String>::with_initial_capacity(usize::MAX, 2);
+        assert_eq!(store.capacity(), 2, "capacity must be 2");
+        store.insert(1, "one".to_string());
+        store.insert(2, "two".to_string());
+        store.insert(3, "three".to_string());
+        assert_eq!(store.len(), 2, "length must be 2");
+        assert_eq!(store.get(&1), None, "key 1 must be evicted");
+        assert_eq!(
+            store.get(&2),
+            Some("two".to_string()),
+            "key 2 must be present"
+        );
+        assert_eq!(
+            store.get(&3),
+            Some("three".to_string()),
+            "key 3 must be present"
+        );
+    }
+
+    #[test]
+    fn clock_store_get_and_get_ref_reference_flag_transitions() {
+        let mut store = ClockStore::<u64, String>::with_capacity(3);
+        store.insert(1, "one".to_string());
+        store.insert(2, "two".to_string());
+
+        // Newly inserted entries have referenced set to false initially
+        let entry_1 = store.entries.get(&1).expect("entry 1 must exist in store");
+        assert!(
+            !entry_1.referenced.load(Ordering::Relaxed),
+            "newly inserted entry 1 must have referenced = false"
+        );
+
+        let entry_2 = store.entries.get(&2).expect("entry 2 must exist in store");
+        assert!(
+            !entry_2.referenced.load(Ordering::Relaxed),
+            "newly inserted entry 2 must have referenced = false"
+        );
+
+        // First get(&1) transitions referenced from false to true
+        assert_eq!(
+            store.get(&1),
+            Some("one".to_string()),
+            "get(&1) must return cached value"
+        );
+        assert!(
+            entry_1.referenced.load(Ordering::Relaxed),
+            "entry 1 referenced bit must be true after get"
+        );
+
+        // Subsequent get(&1) when already true preserves true and avoids unnecessary write
+        assert_eq!(
+            store.get(&1),
+            Some("one".to_string()),
+            "second get(&1) must return cached value"
+        );
+        assert!(
+            entry_1.referenced.load(Ordering::Relaxed),
+            "entry 1 referenced bit must remain true on subsequent get"
+        );
+
+        // First get_ref(&2) transitions referenced from false to true
+        assert_eq!(
+            store.get_ref(&2).map(String::as_str),
+            Some("two"),
+            "get_ref(&2) must return cached reference"
+        );
+        assert!(
+            entry_2.referenced.load(Ordering::Relaxed),
+            "entry 2 referenced bit must be true after get_ref"
+        );
+
+        // Subsequent get_ref(&2) when already true preserves true
+        assert_eq!(
+            store.get_ref(&2).map(String::as_str),
+            Some("two"),
+            "second get_ref(&2) must return cached reference"
+        );
+        assert!(
+            entry_2.referenced.load(Ordering::Relaxed),
+            "entry 2 referenced bit must remain true on subsequent get_ref"
+        );
+    }
+}

--- a/src/spanner/src/routing/key_recipe_cache.rs
+++ b/src/spanner/src/routing/key_recipe_cache.rs
@@ -23,12 +23,12 @@
 
 use crate::model::key_recipe::Target;
 use crate::model::{KeyRecipe, RecipeList};
+use crate::routing::clock_cache::{ClockEntry, ClockStore};
 use bytes::Bytes;
-use std::collections::hash_map::Entry;
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
 use std::mem::take;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// Default maximum number of SQL query recipes cached simultaneously.
@@ -42,9 +42,15 @@ pub(crate) const DEFAULT_QUERY_RECIPE_CACHE_CAPACITY: usize = 2_000;
 /// Backed by [`RwLock`] around separate hash maps for tables, indexes, and queries, enabling
 /// zero-allocation `&str` lookups, non-blocking concurrent reads across Tokio tasks, and
 /// scan-resistant CLOCK (Second-Chance) eviction for query recipes.
-#[derive(Default)]
 pub(crate) struct KeyRecipeCache {
     store: RwLock<RecipeStore>,
+    next_operation_uid: AtomicU64,
+}
+
+impl Default for KeyRecipeCache {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Debug for KeyRecipeCache {
@@ -60,16 +66,20 @@ impl Debug for KeyRecipeCache {
 impl KeyRecipeCache {
     /// Creates a new, empty [`KeyRecipeCache`] with the default query recipe capacity (`2,000`).
     pub(crate) fn new() -> Self {
-        Self {
-            store: RwLock::new(RecipeStore::default()),
-        }
+        Self::with_query_capacity(DEFAULT_QUERY_RECIPE_CACHE_CAPACITY)
     }
 
     /// Creates a new, empty [`KeyRecipeCache`] with the specified query recipe capacity limit.
     pub(crate) fn with_query_capacity(query_capacity: usize) -> Self {
         Self {
             store: RwLock::new(RecipeStore::with_query_capacity(query_capacity)),
+            next_operation_uid: AtomicU64::new(1),
         }
+    }
+
+    /// Generates and returns a monotonically increasing operation UID for SQL query operations and prepared operations.
+    pub(crate) fn next_operation_uid(&self) -> u64 {
+        self.next_operation_uid.fetch_add(1, Ordering::Relaxed)
     }
 
     fn read_store(&self) -> RwLockReadGuard<'_, RecipeStore> {
@@ -117,10 +127,7 @@ impl KeyRecipeCache {
     /// is a lookup operation, consistent with `HashMap::get`, `ConnectionCache::get_if_present`, and
     /// `KeyRangeCache::get_group`.
     pub(crate) fn get_query_recipe(&self, operation_uid: u64) -> Option<Arc<KeyRecipe>> {
-        let guard = self.read_store();
-        let entry = guard.queries.get(&operation_uid)?;
-        entry.referenced.store(true, Ordering::Relaxed);
-        Some(Arc::clone(&entry.recipe))
+        self.read_store().queries.get(&operation_uid)
     }
 
     /// Inserts a [`KeyRecipe`] into the cache.
@@ -131,8 +138,10 @@ impl KeyRecipeCache {
     /// heap allocations occur outside the critical section, reducing lock hold duration to a pure
     /// $O(1)$ hashmap insertion.
     ///
-    /// The lock guard is explicitly dropped before any displaced previous recipe is deallocated,
-    /// ensuring heap deallocations also occur outside the critical section.
+    /// The lock guard is explicitly dropped before any displaced overwritten recipe is deallocated,
+    /// ensuring heap deallocations for overwritten entries occur outside the critical section.
+    /// (Evicted entries from bounded query store capacity limits are dropped on removal under the write guard,
+    /// which is an $O(1)$ atomic reference counter decrement).
     ///
     /// Returns `true` if the recipe contained a target and was stored in the cache;
     /// returns `false` if `recipe.target` was `None`.
@@ -142,48 +151,52 @@ impl KeyRecipeCache {
         };
         let recipe_arc = Arc::new(recipe);
         let mut guard = self.write_store();
-        let _old = match target {
+        let _previous_recipe = match target {
             Target::TableName(name) => guard.tables.insert(name, recipe_arc),
             Target::IndexName(name) => guard.indexes.insert(name, recipe_arc),
-            Target::OperationUid(operation_uid) => guard.insert_query(operation_uid, recipe_arc),
+            Target::OperationUid(operation_uid) => guard.queries.insert(operation_uid, recipe_arc),
         };
-        // Explicitly drop the lock guard before `_old` is dropped so that if an existing
+        // Explicitly drop the lock guard before `_previous_recipe` is dropped so that if an existing
         // recipe with reference count 1 was overwritten, its heap deallocation occurs
         // outside the critical section.
         drop(guard);
         true
     }
 
-    /// Ingests a slice of [`KeyRecipe`]s into the cache in a single batch,
+    /// Ingests an iterator of [`KeyRecipe`]s into the cache in a single batch,
     /// acquiring the write lock only once.
-    pub(crate) fn insert_batch(&self, recipes: &[KeyRecipe]) {
-        if recipes.is_empty() {
-            return;
-        }
+    pub(crate) fn insert_batch<I>(&self, recipes: I)
+    where
+        I: IntoIterator<Item = KeyRecipe>,
+    {
+        let iterator = recipes.into_iter();
+        let (lower_bound, _) = iterator.size_hint();
         // Prepare target and Arc outside the write lock to minimize lock hold duration.
-        let mut prepared = Vec::with_capacity(recipes.len());
-        for recipe in recipes {
+        let mut prepared = Vec::with_capacity(lower_bound);
+        for recipe in iterator {
             if let Some(target) = recipe.target.clone() {
-                prepared.push((target, Arc::new(recipe.clone())));
+                prepared.push((target, Arc::new(recipe)));
             }
         }
         if prepared.is_empty() {
             return;
         }
+        let mut displaced_recipes = Vec::new();
         let mut guard = self.write_store();
         for (target, recipe_arc) in prepared {
-            match target {
-                Target::TableName(name) => {
-                    guard.tables.insert(name, recipe_arc);
-                }
-                Target::IndexName(name) => {
-                    guard.indexes.insert(name, recipe_arc);
-                }
+            let previous_recipe = match target {
+                Target::TableName(name) => guard.tables.insert(name, recipe_arc),
+                Target::IndexName(name) => guard.indexes.insert(name, recipe_arc),
                 Target::OperationUid(operation_uid) => {
-                    guard.insert_query(operation_uid, recipe_arc);
+                    guard.queries.insert(operation_uid, recipe_arc)
                 }
+            };
+            if let Some(displaced) = previous_recipe {
+                displaced_recipes.push(displaced);
             }
         }
+        drop(guard);
+        drop(displaced_recipes);
     }
 
     /// Ingests all recipes and schema generation from a [`RecipeList`] returned in [`CacheUpdate`](crate::model::CacheUpdate).
@@ -197,6 +210,14 @@ impl KeyRecipeCache {
         let incoming_generation = recipe_list.schema_generation;
         if recipe_list.recipe.is_empty() && incoming_generation.is_empty() {
             return;
+        }
+
+        // Prepare targets and Arcs outside the write lock to minimize lock hold duration.
+        let mut prepared = Vec::with_capacity(recipe_list.recipe.len());
+        for recipe in recipe_list.recipe {
+            if let Some(target) = recipe.target.clone() {
+                prepared.push((target, Arc::new(recipe)));
+            }
         }
 
         let mut guard = self.write_store();
@@ -217,35 +238,24 @@ impl KeyRecipeCache {
             _ => None,
         };
 
-        let mut displaced = Vec::new();
-        for recipe in recipe_list.recipe {
-            if let Some(target) = &recipe.target {
-                let target = target.clone();
-                let recipe_arc = Arc::new(recipe);
-                match target {
-                    Target::TableName(name) => {
-                        if let Some(old) = guard.tables.insert(name, recipe_arc) {
-                            displaced.push(old);
-                        }
-                    }
-                    Target::IndexName(name) => {
-                        if let Some(old) = guard.indexes.insert(name, recipe_arc) {
-                            displaced.push(old);
-                        }
-                    }
-                    Target::OperationUid(operation_uid) => {
-                        if let Some(old) = guard.insert_query(operation_uid, recipe_arc) {
-                            displaced.push(old);
-                        }
-                    }
+        let mut displaced_recipes = Vec::new();
+        for (target, recipe_arc) in prepared {
+            let previous_recipe = match target {
+                Target::TableName(name) => guard.tables.insert(name, recipe_arc),
+                Target::IndexName(name) => guard.indexes.insert(name, recipe_arc),
+                Target::OperationUid(operation_uid) => {
+                    guard.queries.insert(operation_uid, recipe_arc)
                 }
+            };
+            if let Some(displaced) = previous_recipe {
+                displaced_recipes.push(displaced);
             }
         }
 
         // Release write lock before deallocating any old invalidated recipe collections or displaced recipes.
         drop(guard);
         drop(_dropped_entries);
-        drop(displaced);
+        drop(displaced_recipes);
     }
 
     /// Returns the schema generation of the most recently ingested [`RecipeList`], if any.
@@ -259,6 +269,10 @@ impl KeyRecipeCache {
     }
 
     /// Clears all entries from the cache while preserving configured capacity limits.
+    ///
+    /// Note: Intentionally retains `next_operation_uid` monotonically increasing to ensure
+    /// operation UIDs remain globally unique across the client lifecycle, preventing collisions
+    /// with in-flight asynchronous queries.
     pub(crate) fn clear(&self) {
         let old_entries = {
             let mut guard = self.write_store();
@@ -284,14 +298,7 @@ impl KeyRecipeCache {
 struct InvalidatedEntries {
     tables: HashMap<String, Arc<KeyRecipe>>,
     indexes: HashMap<String, Arc<KeyRecipe>>,
-    queries: HashMap<u64, QueryRecipeEntry>,
-}
-
-/// Entry for a cached query recipe, pairing the recipe pointer with an atomic reference flag
-/// for CLOCK (Second-Chance) cache eviction.
-struct QueryRecipeEntry {
-    recipe: Arc<KeyRecipe>,
-    referenced: AtomicBool,
+    queries: HashMap<u64, ClockEntry<Arc<KeyRecipe>>>,
 }
 
 /// Internal storage for key recipes, separated by target type to allow zero-allocation
@@ -299,16 +306,8 @@ struct QueryRecipeEntry {
 struct RecipeStore {
     tables: HashMap<String, Arc<KeyRecipe>>,
     indexes: HashMap<String, Arc<KeyRecipe>>,
-    queries: HashMap<u64, QueryRecipeEntry>,
-    query_order: VecDeque<u64>,
-    query_capacity: usize,
+    queries: ClockStore<u64, Arc<KeyRecipe>>,
     schema_generation: Option<Bytes>,
-}
-
-impl Default for RecipeStore {
-    fn default() -> Self {
-        Self::with_query_capacity(DEFAULT_QUERY_RECIPE_CACHE_CAPACITY)
-    }
 }
 
 impl RecipeStore {
@@ -316,9 +315,7 @@ impl RecipeStore {
         Self {
             tables: HashMap::new(),
             indexes: HashMap::new(),
-            queries: HashMap::new(),
-            query_order: VecDeque::new(),
-            query_capacity,
+            queries: ClockStore::with_capacity(query_capacity),
             schema_generation: None,
         }
     }
@@ -333,63 +330,12 @@ impl RecipeStore {
     fn invalidate_all(&mut self, new_schema_generation: Option<Bytes>) -> InvalidatedEntries {
         let tables = take(&mut self.tables);
         let indexes = take(&mut self.indexes);
-        let queries = take(&mut self.queries);
-        self.query_order.clear();
+        let queries = self.queries.take_all();
         self.schema_generation = new_schema_generation;
         InvalidatedEntries {
             tables,
             indexes,
             queries,
-        }
-    }
-
-    fn insert_query(
-        &mut self,
-        operation_uid: u64,
-        recipe: Arc<KeyRecipe>,
-    ) -> Option<Arc<KeyRecipe>> {
-        if self.query_capacity == 0 {
-            return None;
-        }
-        match self.queries.entry(operation_uid) {
-            Entry::Occupied(mut occupied) => {
-                let entry = occupied.get_mut();
-                let previous_recipe = Arc::clone(&entry.recipe);
-                entry.recipe = recipe;
-                // Overwriting an existing entry marks it as recently referenced, granting it a
-                // second chance in CLOCK eviction so freshly updated recipes are not prematurely evicted.
-                entry.referenced.store(true, Ordering::Relaxed);
-                Some(previous_recipe)
-            }
-            Entry::Vacant(vacant) => {
-                vacant.insert(QueryRecipeEntry {
-                    recipe,
-                    referenced: AtomicBool::new(false),
-                });
-                self.query_order.push_back(operation_uid);
-                self.evict_excess_queries();
-                None
-            }
-        }
-    }
-
-    /// Evicts excess query recipes beyond `query_capacity` using the CLOCK (Second-Chance) algorithm.
-    fn evict_excess_queries(&mut self) {
-        while self.queries.len() > self.query_capacity {
-            let Some(candidate_uid) = self.query_order.pop_front() else {
-                break;
-            };
-            let Some(entry) = self.queries.get(&candidate_uid) else {
-                // Stale queue entry (already removed/overwritten): discard and continue.
-                continue;
-            };
-            if entry.referenced.swap(false, Ordering::Relaxed) {
-                // Entry was referenced since last inspection: grant a second chance.
-                self.query_order.push_back(candidate_uid);
-            } else {
-                // Entry was not referenced: evict from cache.
-                self.queries.remove(&candidate_uid);
-            }
         }
     }
 }
@@ -543,14 +489,14 @@ mod tests {
     #[test]
     fn insert_batch_empty_or_no_targets() {
         let cache = KeyRecipeCache::new();
-        cache.insert_batch(&[]);
+        cache.insert_batch(Vec::new());
         assert!(
             cache.is_empty(),
             "cache must remain empty after empty batch"
         );
 
         let untargeted_recipe = KeyRecipe::new();
-        cache.insert_batch(&[untargeted_recipe]);
+        cache.insert_batch(vec![untargeted_recipe]);
         assert!(
             cache.is_empty(),
             "cache must remain empty when batch contains only untargeted recipes"
@@ -565,7 +511,12 @@ mod tests {
         let query_recipe = KeyRecipe::new().set_operation_uid(42u64);
         let untargeted_recipe = KeyRecipe::new();
 
-        cache.insert_batch(&[table_recipe, index_recipe, query_recipe, untargeted_recipe]);
+        cache.insert_batch(vec![
+            table_recipe,
+            index_recipe,
+            query_recipe,
+            untargeted_recipe,
+        ]);
 
         assert_eq!(
             cache.len(),
@@ -663,7 +614,7 @@ mod tests {
             KeyRecipe::new().set_table_name("UnboundedTable"),
         ];
 
-        cache.insert_batch(&batch);
+        cache.insert_batch(batch);
 
         // Table recipe is stored, but queries are bounded to 2 (100 is evicted, 200 and 300 remain)
         assert_eq!(
@@ -692,12 +643,21 @@ mod tests {
     #[test]
     fn query_recipe_cache_overwrite_does_not_evict() {
         let cache = KeyRecipeCache::with_query_capacity(2);
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(1u64)));
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(2u64)));
-        assert_eq!(cache.len(), 2);
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(1u64)),
+            "insert query 1 must succeed"
+        );
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(2u64)),
+            "insert query 2 must succeed"
+        );
+        assert_eq!(cache.len(), 2, "length must be 2 after two inserts");
 
         // Overwrite query 1
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(1u64)));
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(1u64)),
+            "overwrite query 1 must succeed"
+        );
         assert_eq!(
             cache.len(),
             2,
@@ -705,8 +665,14 @@ mod tests {
         );
 
         // Both queries 1 and 2 must still be present
-        assert!(cache.get_query_recipe(1).is_some());
-        assert!(cache.get_query_recipe(2).is_some());
+        assert!(
+            cache.get_query_recipe(1).is_some(),
+            "query 1 must be present"
+        );
+        assert!(
+            cache.get_query_recipe(2).is_some(),
+            "query 2 must be present"
+        );
     }
 
     #[test]
@@ -714,17 +680,29 @@ mod tests {
         let cache = KeyRecipeCache::with_query_capacity(2);
 
         // Insert query 1 (head of FIFO queue) and query 2 (tail of FIFO queue) without reading them
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(1u64)));
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(2u64)));
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(1u64)),
+            "insert query 1 must succeed"
+        );
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(2u64)),
+            "insert query 2 must succeed"
+        );
 
         // Overwrite query 1 with an updated recipe (without calling get_query_recipe)
         let updated_recipe = KeyRecipe::new()
             .set_operation_uid(1u64)
             .set_part(vec![Part::new()]);
-        assert!(cache.insert(updated_recipe));
+        assert!(
+            cache.insert(updated_recipe),
+            "overwrite query 1 must succeed"
+        );
 
         // Insert query 3 to trigger eviction under capacity limit of 2
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(3u64)));
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(3u64)),
+            "insert query 3 must succeed"
+        );
 
         assert_eq!(cache.len(), 2, "cache length must remain at capacity 2");
 
@@ -764,37 +742,70 @@ mod tests {
             0,
             "cache with zero query capacity must store 0 query recipes"
         );
-        assert!(cache.get_query_recipe(1).is_none());
+        assert!(
+            cache.get_query_recipe(1).is_none(),
+            "query 1 must not be stored"
+        );
 
         // Tables and indexes can still be stored
-        assert!(cache.insert(KeyRecipe::new().set_table_name("Users")));
-        assert_eq!(cache.len(), 1);
-        assert!(cache.get_table_recipe("Users").is_some());
+        assert!(
+            cache.insert(KeyRecipe::new().set_table_name("Users")),
+            "insert table recipe must succeed"
+        );
+        assert_eq!(cache.len(), 1, "table recipe must be stored in cache");
+        assert!(
+            cache.get_table_recipe("Users").is_some(),
+            "table recipe must be retrieved"
+        );
     }
 
     #[test]
     fn clear_preserves_query_capacity() {
         let cache = KeyRecipeCache::with_query_capacity(2);
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(1u64)));
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(2u64)));
-        assert_eq!(cache.len(), 2);
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(1u64)),
+            "insert query 1 must succeed"
+        );
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(2u64)),
+            "insert query 2 must succeed"
+        );
+        assert_eq!(cache.len(), 2, "cache length must be 2");
 
         cache.clear();
-        assert!(cache.is_empty());
+        assert!(cache.is_empty(), "cache must be empty after clear");
 
         // Insert 3 new queries, capacity limit of 2 must still be enforced
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(10u64)));
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(20u64)));
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(30u64)));
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(10u64)),
+            "insert query 10 must succeed"
+        );
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(20u64)),
+            "insert query 20 must succeed"
+        );
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(30u64)),
+            "insert query 30 must succeed"
+        );
 
         assert_eq!(
             cache.len(),
             2,
             "capacity limit of 2 must be preserved after clear"
         );
-        assert!(cache.get_query_recipe(10).is_none());
-        assert!(cache.get_query_recipe(20).is_some());
-        assert!(cache.get_query_recipe(30).is_some());
+        assert!(
+            cache.get_query_recipe(10).is_none(),
+            "query 10 must be evicted"
+        );
+        assert!(
+            cache.get_query_recipe(20).is_some(),
+            "query 20 must be present"
+        );
+        assert!(
+            cache.get_query_recipe(30).is_some(),
+            "query 30 must be present"
+        );
     }
 
     #[test]
@@ -802,8 +813,14 @@ mod tests {
         let cache = KeyRecipeCache::with_query_capacity(2);
 
         // Insert query 1 and query 2
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(1u64)));
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(2u64)));
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(1u64)),
+            "insert query 1 must succeed"
+        );
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(2u64)),
+            "insert query 2 must succeed"
+        );
 
         // Read query 1 (marks query 1 as referenced)
         let query_1 = cache.get_query_recipe(1);
@@ -812,7 +829,10 @@ mod tests {
         // Query 2 is NOT accessed (referenced = false)
 
         // Insert query 3 (triggers eviction)
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(3u64)));
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(3u64)),
+            "insert query 3 must succeed"
+        );
 
         // Cache must still hold at most 2 queries
         assert_eq!(cache.len(), 2, "cache length must remain at capacity 2");
@@ -841,20 +861,35 @@ mod tests {
         let cache = KeyRecipeCache::with_query_capacity(3);
 
         // Insert hot queries 1 and 2
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(1u64)));
-        assert!(cache.insert(KeyRecipe::new().set_operation_uid(2u64)));
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(1u64)),
+            "insert query 1 must succeed"
+        );
+        assert!(
+            cache.insert(KeyRecipe::new().set_operation_uid(2u64)),
+            "insert query 2 must succeed"
+        );
 
         // Repeatedly hit hot queries 1 and 2
-        assert!(cache.get_query_recipe(1).is_some());
-        assert!(cache.get_query_recipe(2).is_some());
+        assert!(cache.get_query_recipe(1).is_some(), "query 1 must be hit");
+        assert!(cache.get_query_recipe(2).is_some(), "query 2 must be hit");
 
         // Simulate a burst of 10 ad-hoc / one-off queries (100..110)
         for i in 100u64..110u64 {
-            assert!(cache.insert(KeyRecipe::new().set_operation_uid(i)));
+            assert!(
+                cache.insert(KeyRecipe::new().set_operation_uid(i)),
+                "insert ad-hoc query must succeed"
+            );
             // Note: Ad-hoc queries are never read, so their referenced bit remains false
             // Keep refreshing hot queries 1 and 2 during the workload
-            assert!(cache.get_query_recipe(1).is_some());
-            assert!(cache.get_query_recipe(2).is_some());
+            assert!(
+                cache.get_query_recipe(1).is_some(),
+                "query 1 must remain hit"
+            );
+            assert!(
+                cache.get_query_recipe(2).is_some(),
+                "query 2 must remain hit"
+            );
         }
 
         // Cache must not exceed capacity 3
@@ -1160,5 +1195,89 @@ mod tests {
         );
 
         assert_eq!(cache.len(), 3, "total cached recipe count must remain 3");
+    }
+
+    #[test]
+    fn key_recipe_cache_next_operation_uid_increments_monotonically() {
+        let cache = KeyRecipeCache::new();
+        assert_eq!(cache.next_operation_uid(), 1, "first UID must be 1");
+        assert_eq!(cache.next_operation_uid(), 2, "second UID must be 2");
+        assert_eq!(cache.next_operation_uid(), 3, "third UID must be 3");
+    }
+
+    #[test]
+    fn key_recipe_cache_next_operation_uid_concurrent_access() {
+        let cache = Arc::new(KeyRecipeCache::new());
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let cache_clone = Arc::clone(&cache);
+            handles.push(thread::spawn(move || {
+                let mut uids = Vec::with_capacity(100);
+                for _ in 0..100 {
+                    uids.push(cache_clone.next_operation_uid());
+                }
+                uids
+            }));
+        }
+
+        let mut all_uids = Vec::new();
+        for handle in handles {
+            let uids = handle.join().expect("thread should join cleanly");
+            all_uids.extend(uids);
+        }
+
+        assert_eq!(all_uids.len(), 1000, "must collect 1000 total UIDs");
+        all_uids.sort_unstable();
+        all_uids.dedup();
+        assert_eq!(
+            all_uids.len(),
+            1000,
+            "all 1000 generated UIDs must be unique and monotonic"
+        );
+        assert_eq!(all_uids.first(), Some(&1), "first UID generated must be 1");
+        assert_eq!(
+            all_uids.last(),
+            Some(&1000),
+            "last UID generated must be 1000"
+        );
+    }
+
+    #[test]
+    fn key_recipe_cache_default_is_empty() {
+        let cache = KeyRecipeCache::default();
+        assert!(cache.is_empty(), "default cache must be empty");
+        assert_eq!(cache.len(), 0, "default cache length must be zero");
+    }
+
+    #[test]
+    fn update_from_recipe_list_empty_list_noops() {
+        let cache = KeyRecipeCache::new();
+        cache.update_from_recipe_list(RecipeList::new());
+        assert!(
+            cache.is_empty(),
+            "cache must remain empty after empty RecipeList update"
+        );
+        assert!(
+            cache.schema_generation().is_none(),
+            "schema generation must remain None"
+        );
+    }
+
+    #[test]
+    fn update_from_recipe_list_skips_untargeted_recipes() {
+        let cache = KeyRecipeCache::new();
+        let recipe_list = RecipeList::new()
+            .set_schema_generation(Bytes::from_static(b"v1"))
+            .set_recipe(vec![KeyRecipe::new()]);
+        cache.update_from_recipe_list(recipe_list);
+        assert!(
+            cache.is_empty(),
+            "cache must remain empty when RecipeList contains only untargeted recipes"
+        );
+        assert_eq!(
+            cache.schema_generation(),
+            Some(Bytes::from_static(b"v1")),
+            "schema generation must still be recorded"
+        );
     }
 }

--- a/src/spanner/src/routing/mod.rs
+++ b/src/spanner/src/routing/mod.rs
@@ -16,6 +16,7 @@
 
 pub(crate) mod cache_subscriber;
 pub(crate) mod cache_updater;
+pub(crate) mod clock_cache;
 pub(crate) mod connection_cache;
 pub(crate) mod directed_read;
 pub(crate) mod endpoint_cooldown;


### PR DESCRIPTION
Extracts the bounded CLOCK (Second-Chance) replacement cache logic from KeyRecipeCache into a standalone, generic `ClockStore<K, V>` module, and adds an atomic monotonic `operation_uid` generator.

Key changes:
- Implement generic `ClockStore<K, V>` with lock-free atomic reference bit marking on read, $O(1)$ amortized second-chance eviction on insert, and move-based deallocation outside locks via `take_all()`.
- Refactor `KeyRecipeCache` query recipe storage to use `ClockStore`.
- Add `next_operation_uid()` atomic generator on `KeyRecipeCache`.

Note: The generic `ClockStore` and `operation_uid` generator are designed to be reused for caching prepared operation descriptors (`PreparedQuery` and `PreparedRead`) in upcoming location-aware routing PRs.