### PR TITLE
test(bigquery): cover non-empty page token from polled query result

### DIFF
--- a/src/bigquery/src/query/query_handle.rs
+++ b/src/bigquery/src/query/query_handle.rs
@@ -584,7 +584,7 @@ mod tests {
                     .set_job_complete(true)
                     .set_job_reference(JobReference::new().set_job_id(req.job_id))
                     .set_schema(TableSchema::new())
-                    .set_page_token("")
+                    .set_page_token("some_page_token")
                     .set_rows(vec![wkt::Struct::new(), wkt::Struct::new()])
                     .set_cache_hit(false);
                 Ok(Response::from(res))
@@ -603,13 +603,13 @@ mod tests {
 
         let completed = query.until_done().await?;
         assert_eq!(completed.job_ref.as_ref().unwrap().job_id, "some_job_id");
-        assert_eq!(completed.page_token, None);
+        assert_eq!(completed.page_token, Some("some_page_token".to_string()));
         assert_eq!(completed.cached_rows.len(), 2);
 
         let metadata = completed.metadata();
         assert_eq!(metadata.cache_hit, Some(false));
         assert_eq!(metadata.job_complete, Some(true));
-        assert_eq!(metadata.page_token, "".to_string());
+        assert_eq!(metadata.page_token, "some_page_token");
 
         Ok(())
     }


### PR DESCRIPTION
This is just to cover https://github.com/dbolduc/google-cloud-rust/blob/eb08d7eb3f91d9006f26abbdc38bc32ecdd5d720/src/bigquery/src/query/query_handle.rs#L305

Note that the other branch of the if statement is still covered by

https://github.com/dbolduc/google-cloud-rust/blob/eb08d7eb3f91d9006f26abbdc38bc32ecdd5d720/src/bigquery/src/query/query_handle.rs#L759