### PR TITLE
feat(gax-internal): propagate trace context and instrument streaming RPCs

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -48,6 +48,7 @@ use http::HeaderMap;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
+use tracing::Instrument as _;
 use transport_policies::TransportPolicies;
 
 // A tonic::transport::Channel always has a Buffer layer.
@@ -208,6 +209,7 @@ impl Client {
         )?;
         let mut headers = add_auth_headers(headers, &self.credentials).await?;
         self.intercept(&mut headers, 1);
+        crate::observability::propagation::inject_context(&tracing::Span::current(), &mut headers);
         let metadata = tonic::MetadataMap::from_headers(headers);
         let request = ::tonic::Request::from_parts(metadata, extensions, request);
         let codec = tonic_prost::ProstCodec::<Request, Response>::default();
@@ -278,25 +280,37 @@ impl Client {
         let (mut resp_tx, resp_rx) = tokio::sync::oneshot::channel();
         let client = self.clone();
         let request_params = request_params.to_string();
-        // TODO(#2318): Propagate tracing Span and RequestRecorder task-local context into the spawned task.
-        tokio::spawn(async move {
-            tokio::select! {
-                result = client.bidi_stream::<ProstReq, ProstResp>(
-                    extensions,
-                    path,
-                    req_stream,
-                    options,
-                    api_client_header,
-                    &request_params,
-                ) => {
-                    let _ = resp_tx.send(result);
-                }
-                _ = resp_tx.closed() => {
-                    // ResponseStream was dropped before the stream was established;
-                    // abort the connection attempt immediately.
+        let span = tracing::Span::current();
+        let recorder = crate::observability::RequestRecorder::current();
+        tokio::spawn(
+            async move {
+                let stream_fut = async move {
+                    tokio::select! {
+                        result = client.bidi_stream::<ProstReq, ProstResp>(
+                            extensions,
+                            path,
+                            req_stream,
+                            options,
+                            api_client_header,
+                            &request_params,
+                        ) => {
+                            let _ = resp_tx.send(result);
+                        }
+                        _ = resp_tx.closed() => {
+                            // ResponseStream was dropped before the stream was established;
+                            // abort the connection attempt immediately.
+                        }
+                    }
+                    Ok::<(), Error>(())
+                };
+                if let Some(recorder) = recorder {
+                    let _ = recorder.scope(stream_fut).await;
+                } else {
+                    let _ = stream_fut.await;
                 }
             }
-        });
+            .instrument(span),
+        );
         resp_rx
     }
 
@@ -350,6 +364,7 @@ impl Client {
         )?;
         let mut headers = add_auth_headers(headers, &self.credentials).await?;
         self.intercept(&mut headers, 1);
+        crate::observability::propagation::inject_context(&tracing::Span::current(), &mut headers);
         let metadata = tonic::MetadataMap::from_headers(headers);
         let mut request = ::tonic::Request::from_parts(metadata, extensions, request);
         if let Some(timeout) = crate::options::resolve_effective_timeout(

--- a/src/gax-internal/tests/grpc_observability.rs
+++ b/src/gax-internal/tests/grpc_observability.rs
@@ -691,4 +691,119 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn propagate_trace_context_bidi_streaming() -> anyhow::Result<()> {
+        let (endpoint, _server) = start_echo_server().await?;
+
+        let mut config = google_cloud_gax_internal::options::ClientConfig::default();
+        config.tracing = true;
+        config.cred = Some(test_credentials());
+        let client = grpc::Client::new(config, &endpoint).await?;
+
+        let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder().build();
+        let tracer = opentelemetry::trace::TracerProvider::tracer(&tracer_provider, "test");
+        let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+        use tracing_subscriber::layer::SubscriberExt;
+        let subscriber = tracing_subscriber::registry().with(telemetry);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.test.v1.EchoServices",
+                "Chat",
+            ));
+            e
+        };
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        let request_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
+
+        use tracing::Instrument;
+        let span = tracing::info_span!("parent_span");
+        let mut response_stream = client
+            .bidi_stream::<_, google::test::v1::EchoResponse>(
+                extensions,
+                http::uri::PathAndQuery::from_static("/google.test.v1.EchoService/Chat"),
+                request_stream,
+                RequestOptions::default(),
+                "test-client",
+                "name=test-only",
+            )
+            .instrument(span)
+            .await?
+            .into_inner();
+
+        let request = google::test::v1::EchoRequest {
+            message: "test message".into(),
+            ..Default::default()
+        };
+        tx.send(request).await?;
+
+        let response = response_stream.next().await.expect("stream closed")?;
+        drop(tx);
+
+        assert!(
+            response.metadata.contains_key("traceparent"),
+            "Metadata should contain traceparent. Metadata: {:?}",
+            response.metadata
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn propagate_trace_context_server_streaming() -> anyhow::Result<()> {
+        let (endpoint, _server) = start_echo_server().await?;
+
+        let mut config = google_cloud_gax_internal::options::ClientConfig::default();
+        config.tracing = true;
+        config.cred = Some(test_credentials());
+        let client = grpc::Client::new(config, &endpoint).await?;
+
+        let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder().build();
+        let tracer = opentelemetry::trace::TracerProvider::tracer(&tracer_provider, "test");
+        let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+        use tracing_subscriber::layer::SubscriberExt;
+        let subscriber = tracing_subscriber::registry().with(telemetry);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.test.v1.EchoServices",
+                "Expand",
+            ));
+            e
+        };
+        let request = google::test::v1::EchoRequest {
+            message: "test message".into(),
+            ..Default::default()
+        };
+
+        use tracing::Instrument;
+        let span = tracing::info_span!("parent_span");
+        let mut response_stream = client
+            .server_streaming::<_, google::test::v1::EchoResponse>(
+                extensions,
+                http::uri::PathAndQuery::from_static("/google.test.v1.EchoService/Expand"),
+                request,
+                RequestOptions::default(),
+                "test-client",
+                "name=test-only",
+            )
+            .instrument(span)
+            .await?
+            .into_inner();
+
+        let response = response_stream.next().await.expect("stream closed")?;
+
+        assert!(
+            response.metadata.contains_key("traceparent"),
+            "Metadata should contain traceparent. Metadata: {:?}",
+            response.metadata
+        );
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Inject trace context into HTTP/2 metadata headers for bidirectional and server streaming RPCs.

Instrument background `tokio::spawn` task in `spawn_bidi_stream` with the current tracing span and scope `RequestRecorder` so child logs, events, and metrics remain attached to the parent span.

Add integration tests asserting `traceparent` propagation for bidirectional and server streaming RPCs.