### PR TITLE
feat(wkt): trim `wkt::DescriptorProto` fields to allow AST translation

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1816,6 +1816,13 @@ libraries:
             - descriptor.proto
           module_path: crate
           output: src/wkt/src/generated
+          skipped_ids:
+            - .google.protobuf.DescriptorProto.extension
+            - .google.protobuf.DescriptorProto.oneof_decl
+            - .google.protobuf.DescriptorProto.options
+            - .google.protobuf.DescriptorProto.reserved_range
+            - .google.protobuf.DescriptorProto.reserved_name
+            - .google.protobuf.DescriptorProto.extension_range
           api_path: google/protobuf
           template: mod
   - name: google-cloud-workflows-executions-v1

--- a/src/wkt/src/generated/debug.rs
+++ b/src/wkt/src/generated/debug.rs
@@ -102,14 +102,8 @@ impl std::fmt::Debug for super::DescriptorProto {
         let mut debug_struct = f.debug_struct("DescriptorProto");
         debug_struct.field("name", &self.name);
         debug_struct.field("field", &self.field);
-        debug_struct.field("extension", &self.extension);
         debug_struct.field("nested_type", &self.nested_type);
         debug_struct.field("enum_type", &self.enum_type);
-        debug_struct.field("extension_range", &self.extension_range);
-        debug_struct.field("oneof_decl", &self.oneof_decl);
-        debug_struct.field("options", &self.options);
-        debug_struct.field("reserved_range", &self.reserved_range);
-        debug_struct.field("reserved_name", &self.reserved_name);
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/wkt/src/generated/deserialize.rs
+++ b/src/wkt/src/generated/deserialize.rs
@@ -754,14 +754,8 @@ impl<'de> serde::de::Deserialize<'de> for super::DescriptorProto {
         enum __FieldTag {
             __name,
             __field,
-            __extension,
             __nested_type,
             __enum_type,
-            __extension_range,
-            __oneof_decl,
-            __options,
-            __reserved_range,
-            __reserved_name,
             Unknown(std::string::String),
         }
         impl<'de> serde::de::Deserialize<'de> for __FieldTag {
@@ -784,20 +778,10 @@ impl<'de> serde::de::Deserialize<'de> for super::DescriptorProto {
                         match value {
                             "name" => Ok(__FieldTag::__name),
                             "field" => Ok(__FieldTag::__field),
-                            "extension" => Ok(__FieldTag::__extension),
                             "nestedType" => Ok(__FieldTag::__nested_type),
                             "nested_type" => Ok(__FieldTag::__nested_type),
                             "enumType" => Ok(__FieldTag::__enum_type),
                             "enum_type" => Ok(__FieldTag::__enum_type),
-                            "extensionRange" => Ok(__FieldTag::__extension_range),
-                            "extension_range" => Ok(__FieldTag::__extension_range),
-                            "oneofDecl" => Ok(__FieldTag::__oneof_decl),
-                            "oneof_decl" => Ok(__FieldTag::__oneof_decl),
-                            "options" => Ok(__FieldTag::__options),
-                            "reservedRange" => Ok(__FieldTag::__reserved_range),
-                            "reserved_range" => Ok(__FieldTag::__reserved_range),
-                            "reservedName" => Ok(__FieldTag::__reserved_name),
-                            "reserved_name" => Ok(__FieldTag::__reserved_name),
                             _ => Ok(__FieldTag::Unknown(value.to_string())),
                         }
                     }
@@ -841,14 +825,6 @@ impl<'de> serde::de::Deserialize<'de> for super::DescriptorProto {
                             }
                             result.field = map.next_value::<std::option::Option<std::vec::Vec<crate::FieldDescriptorProto>>>()?.unwrap_or_default();
                         }
-                        __FieldTag::__extension => {
-                            if !fields.insert(__FieldTag::__extension) {
-                                return std::result::Result::Err(A::Error::duplicate_field(
-                                    "multiple values for extension",
-                                ));
-                            }
-                            result.extension = map.next_value::<std::option::Option<std::vec::Vec<crate::FieldDescriptorProto>>>()?.unwrap_or_default();
-                        }
                         __FieldTag::__nested_type => {
                             if !fields.insert(__FieldTag::__nested_type) {
                                 return std::result::Result::Err(A::Error::duplicate_field(
@@ -864,55 +840,6 @@ impl<'de> serde::de::Deserialize<'de> for super::DescriptorProto {
                                 ));
                             }
                             result.enum_type = map.next_value::<std::option::Option<std::vec::Vec<crate::EnumDescriptorProto>>>()?.unwrap_or_default();
-                        }
-                        __FieldTag::__extension_range => {
-                            if !fields.insert(__FieldTag::__extension_range) {
-                                return std::result::Result::Err(A::Error::duplicate_field(
-                                    "multiple values for extension_range",
-                                ));
-                            }
-                            result.extension_range = map
-                                .next_value::<std::option::Option<
-                                    std::vec::Vec<crate::descriptor_proto::ExtensionRange>,
-                                >>()?
-                                .unwrap_or_default();
-                        }
-                        __FieldTag::__oneof_decl => {
-                            if !fields.insert(__FieldTag::__oneof_decl) {
-                                return std::result::Result::Err(A::Error::duplicate_field(
-                                    "multiple values for oneof_decl",
-                                ));
-                            }
-                            result.oneof_decl = map.next_value::<std::option::Option<std::vec::Vec<crate::OneofDescriptorProto>>>()?.unwrap_or_default();
-                        }
-                        __FieldTag::__options => {
-                            if !fields.insert(__FieldTag::__options) {
-                                return std::result::Result::Err(A::Error::duplicate_field(
-                                    "multiple values for options",
-                                ));
-                            }
-                            result.options =
-                                map.next_value::<std::option::Option<crate::MessageOptions>>()?;
-                        }
-                        __FieldTag::__reserved_range => {
-                            if !fields.insert(__FieldTag::__reserved_range) {
-                                return std::result::Result::Err(A::Error::duplicate_field(
-                                    "multiple values for reserved_range",
-                                ));
-                            }
-                            result.reserved_range = map
-                                .next_value::<std::option::Option<
-                                    std::vec::Vec<crate::descriptor_proto::ReservedRange>,
-                                >>()?
-                                .unwrap_or_default();
-                        }
-                        __FieldTag::__reserved_name => {
-                            if !fields.insert(__FieldTag::__reserved_name) {
-                                return std::result::Result::Err(A::Error::duplicate_field(
-                                    "multiple values for reserved_name",
-                                ));
-                            }
-                            result.reserved_name = map.next_value::<std::option::Option<std::vec::Vec<std::string::String>>>()?.unwrap_or_default();
                         }
                         __FieldTag::Unknown(key) => {
                             let value = map.next_value::<serde_json::Value>()?;

--- a/src/wkt/src/generated/mod.rs
+++ b/src/wkt/src/generated/mod.rs
@@ -895,29 +895,10 @@ pub struct DescriptorProto {
     pub field: std::vec::Vec<crate::FieldDescriptorProto>,
 
     #[allow(missing_docs)]
-    pub extension: std::vec::Vec<crate::FieldDescriptorProto>,
-
-    #[allow(missing_docs)]
     pub nested_type: std::vec::Vec<crate::DescriptorProto>,
 
     #[allow(missing_docs)]
     pub enum_type: std::vec::Vec<crate::EnumDescriptorProto>,
-
-    #[allow(missing_docs)]
-    pub extension_range: std::vec::Vec<crate::descriptor_proto::ExtensionRange>,
-
-    #[allow(missing_docs)]
-    pub oneof_decl: std::vec::Vec<crate::OneofDescriptorProto>,
-
-    #[allow(missing_docs)]
-    pub options: std::option::Option<crate::MessageOptions>,
-
-    #[allow(missing_docs)]
-    pub reserved_range: std::vec::Vec<crate::descriptor_proto::ReservedRange>,
-
-    /// Reserved field names, which may not be used by fields in the same message.
-    /// A given name may only be reserved once.
-    pub reserved_name: std::vec::Vec<std::string::String>,
 
     pub(crate) _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
 }
@@ -962,28 +943,6 @@ impl DescriptorProto {
         self
     }
 
-    /// Sets the value of [extension][crate::DescriptorProto::extension].
-    ///
-    /// # Example
-    /// ```ignore,no_run
-    /// # use google_cloud_wkt::DescriptorProto;
-    /// use google_cloud_wkt::FieldDescriptorProto;
-    /// let x = DescriptorProto::new()
-    ///     .set_extension([
-    ///         FieldDescriptorProto::default()/* use setters */,
-    ///         FieldDescriptorProto::default()/* use (different) setters */,
-    ///     ]);
-    /// ```
-    pub fn set_extension<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::FieldDescriptorProto>,
-    {
-        use std::iter::Iterator;
-        self.extension = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [nested_type][crate::DescriptorProto::nested_type].
     ///
     /// # Example
@@ -1024,122 +983,6 @@ impl DescriptorProto {
     {
         use std::iter::Iterator;
         self.enum_type = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [extension_range][crate::DescriptorProto::extension_range].
-    ///
-    /// # Example
-    /// ```ignore,no_run
-    /// # use google_cloud_wkt::DescriptorProto;
-    /// use google_cloud_wkt::descriptor_proto::ExtensionRange;
-    /// let x = DescriptorProto::new()
-    ///     .set_extension_range([
-    ///         ExtensionRange::default()/* use setters */,
-    ///         ExtensionRange::default()/* use (different) setters */,
-    ///     ]);
-    /// ```
-    pub fn set_extension_range<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::descriptor_proto::ExtensionRange>,
-    {
-        use std::iter::Iterator;
-        self.extension_range = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [oneof_decl][crate::DescriptorProto::oneof_decl].
-    ///
-    /// # Example
-    /// ```ignore,no_run
-    /// # use google_cloud_wkt::DescriptorProto;
-    /// use google_cloud_wkt::OneofDescriptorProto;
-    /// let x = DescriptorProto::new()
-    ///     .set_oneof_decl([
-    ///         OneofDescriptorProto::default()/* use setters */,
-    ///         OneofDescriptorProto::default()/* use (different) setters */,
-    ///     ]);
-    /// ```
-    pub fn set_oneof_decl<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::OneofDescriptorProto>,
-    {
-        use std::iter::Iterator;
-        self.oneof_decl = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [options][crate::DescriptorProto::options].
-    ///
-    /// # Example
-    /// ```ignore,no_run
-    /// # use google_cloud_wkt::DescriptorProto;
-    /// use google_cloud_wkt::MessageOptions;
-    /// let x = DescriptorProto::new().set_options(MessageOptions::default()/* use setters */);
-    /// ```
-    pub fn set_options<T>(mut self, v: T) -> Self
-    where
-        T: std::convert::Into<crate::MessageOptions>,
-    {
-        self.options = std::option::Option::Some(v.into());
-        self
-    }
-
-    /// Sets or clears the value of [options][crate::DescriptorProto::options].
-    ///
-    /// # Example
-    /// ```ignore,no_run
-    /// # use google_cloud_wkt::DescriptorProto;
-    /// use google_cloud_wkt::MessageOptions;
-    /// let x = DescriptorProto::new().set_or_clear_options(Some(MessageOptions::default()/* use setters */));
-    /// let x = DescriptorProto::new().set_or_clear_options(None::<MessageOptions>);
-    /// ```
-    pub fn set_or_clear_options<T>(mut self, v: std::option::Option<T>) -> Self
-    where
-        T: std::convert::Into<crate::MessageOptions>,
-    {
-        self.options = v.map(|x| x.into());
-        self
-    }
-
-    /// Sets the value of [reserved_range][crate::DescriptorProto::reserved_range].
-    ///
-    /// # Example
-    /// ```ignore,no_run
-    /// # use google_cloud_wkt::DescriptorProto;
-    /// use google_cloud_wkt::descriptor_proto::ReservedRange;
-    /// let x = DescriptorProto::new()
-    ///     .set_reserved_range([
-    ///         ReservedRange::default()/* use setters */,
-    ///         ReservedRange::default()/* use (different) setters */,
-    ///     ]);
-    /// ```
-    pub fn set_reserved_range<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::descriptor_proto::ReservedRange>,
-    {
-        use std::iter::Iterator;
-        self.reserved_range = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [reserved_name][crate::DescriptorProto::reserved_name].
-    ///
-    /// # Example
-    /// ```ignore,no_run
-    /// # use google_cloud_wkt::DescriptorProto;
-    /// let x = DescriptorProto::new().set_reserved_name(["a", "b", "c"]);
-    /// ```
-    pub fn set_reserved_name<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.reserved_name = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/wkt/src/generated/serialize.rs
+++ b/src/wkt/src/generated/serialize.rs
@@ -240,29 +240,11 @@ impl serde::ser::Serialize for super::DescriptorProto {
         if !self.field.is_empty() {
             state.serialize_entry("field", &self.field)?;
         }
-        if !self.extension.is_empty() {
-            state.serialize_entry("extension", &self.extension)?;
-        }
         if !self.nested_type.is_empty() {
             state.serialize_entry("nestedType", &self.nested_type)?;
         }
         if !self.enum_type.is_empty() {
             state.serialize_entry("enumType", &self.enum_type)?;
-        }
-        if !self.extension_range.is_empty() {
-            state.serialize_entry("extensionRange", &self.extension_range)?;
-        }
-        if !self.oneof_decl.is_empty() {
-            state.serialize_entry("oneofDecl", &self.oneof_decl)?;
-        }
-        if self.options.is_some() {
-            state.serialize_entry("options", &self.options)?;
-        }
-        if !self.reserved_range.is_empty() {
-            state.serialize_entry("reservedRange", &self.reserved_range)?;
-        }
-        if !self.reserved_name.is_empty() {
-            state.serialize_entry("reservedName", &self.reserved_name)?;
         }
         if !self._unknown_fields.is_empty() {
             for (key, value) in self._unknown_fields.iter() {


### PR DESCRIPTION
BigQuery `TableSchema` tracks structure (names, column formats `field`, nested structs `nested_type`, and enums `enum_type`), and ignores protobuf extensions, one-ofs, and reserved namespaces.

This PR trims recursive and interconnected definitions out of `google-cloud-wkt`, allowing us to map `wkt::DescriptorProto` directly to `prost_types::DescriptorProto` without hitting recursive dependency issues in `librarian`.

For #5315 