### PR TITLE
chore(spanner): wire prepared queries and reads to location-aware routing

### DIFF
--- a/src/spanner/src/database_client.rs
+++ b/src/spanner/src/database_client.rs
@@ -35,8 +35,9 @@ use crate::routing::cache_updater::CacheUpdater;
 use crate::routing::connection_cache::ConnectionCache;
 use crate::routing::endpoint_cooldown::EndpointCooldownTracker;
 use crate::routing::key_extractor::{
-    extract_mutation_routing_key, extract_mutations_routing_key,
-    extract_proto_partition_read_request_routing_key, extract_proto_read_request_routing_key,
+    extract_execute_sql_request_routing, extract_mutation_routing_key,
+    extract_mutations_routing_key, extract_proto_partition_read_request_routing_key,
+    extract_proto_read_request_routing,
 };
 use crate::routing::key_range_cache::KeyRangeCache;
 use crate::routing::key_recipe_cache::KeyRecipeCache;
@@ -97,11 +98,11 @@ macro_rules! define_db_rpc {
     ) => {
         pub(crate) async fn $method(
             &self,
-            request: $request_type,
+            mut request: $request_type,
             options: RequestOptions,
             channel_hint: usize,
         ) -> Result<$response_type> {
-            let (connection, routing_context) = $pre_route(self, &request);
+            let (connection, routing_context) = $pre_route(self, &mut request);
             let channel = match &connection {
                 Some(connection) => connection.channel(),
                 None => self.spanner.get_channel(channel_hint),
@@ -139,20 +140,19 @@ macro_rules! define_db_streaming_rpc {
         ) -> $builder_type {
             // Step 1: When location-aware routing is disabled (standard Cloud Spanner),
             // `self.location_routing` is `None` so `$extract_key` is skipped immediately.
-            // When enabled (Spanner Omni), extract the binary routing key from the request if present.
-            let routing_key = self
-                .location_routing
-                .as_ref()
-                .and_then(|routing| $extract_key(routing, &request));
+            // When enabled (Spanner Omni), extract the operation UID and binary routing key.
+            let (operation_uid, routing_key) = match &self.location_routing {
+                Some(routing) => $extract_key(routing, &request),
+                None => (UNASSIGNED_OPERATION_UID, None),
+            };
 
-            // Step 2: Resolve the optimal server connection and routing hint in a single atomic pass.
-            let (connection, routing_hint) =
-                self.resolve_streaming_route(request.transaction.as_ref(), routing_key.as_deref());
-
-            // Step 3: Attach the routing hint if present.
-            if let Some(hint) = routing_hint {
-                request.routing_hint = Some(hint);
-            }
+            // Step 2: Resolve the optimal server connection and attach the routing hint (or bootstrap hint).
+            let connection = self.route_and_attach_hint(
+                request.transaction.as_ref(),
+                operation_uid,
+                routing_key.as_deref(),
+                &mut request.routing_hint,
+            );
 
             // Step 4: Select the gRPC channel:
             // - If location-aware routing resolved a direct node connection (`Some(connection)`), use `connection.channel()`.
@@ -236,7 +236,9 @@ macro_rules! for_all_streaming_db_rpcs {
             expect_execute_streaming_sql,
             ExecuteSqlRequest,
             ExecuteStreamingSql,
-            |_routing, _request| None::<Vec<u8>>
+            |routing: &LocationRoutingState, request: &ExecuteSqlRequest| {
+                extract_execute_sql_request_routing(&routing.key_recipe_cache, request)
+            }
         );
         $macro!(
             streaming_read,
@@ -244,7 +246,7 @@ macro_rules! for_all_streaming_db_rpcs {
             ReadRequest,
             StreamingRead,
             |routing: &LocationRoutingState, request: &ReadRequest| {
-                extract_proto_read_request_routing_key(&routing.key_recipe_cache, request)
+                extract_proto_read_request_routing(&routing.key_recipe_cache, request)
             }
         );
         $macro!(
@@ -575,17 +577,21 @@ impl DatabaseClient {
             .as_ref()
             .map(|routing| &routing.cache_subscriber)
     }
-    /// Resolves the optimal [`ServerConnection`] and [`RoutingHint`] in a single pass for a streaming request.
-    fn resolve_streaming_route(
+    /// Resolves the optimal [`ServerConnection`] and [`RoutingHint`] in a single pass for a request.
+    fn resolve_request_route(
         &self,
         transaction: Option<&TransactionSelector>,
+        operation_uid: u64,
         routing_key: Option<&[u8]>,
     ) -> (Option<ServerConnection>, Option<RoutingHint>) {
         let Some(routing) = &self.location_routing else {
             return (None, None);
         };
         let context = routing_context_from_selector(transaction, routing_key);
-        if context.transaction_id.is_none() && context.routing_key.is_none() {
+        if context.transaction_id.is_none()
+            && context.routing_key.is_none()
+            && operation_uid == UNASSIGNED_OPERATION_UID
+        {
             return (None, None);
         }
         let database_id = routing.cache_updater.database_id();
@@ -594,10 +600,54 @@ impl DatabaseClient {
             &context,
             database_id,
             schema_generation,
-            0,
+            operation_uid,
             None,
         );
-        (Some(resolved.connection), resolved.routing_hint)
+        let connection = if context.transaction_id.is_some() || context.routing_key.is_some() {
+            Some(resolved.connection)
+        } else {
+            None
+        };
+        (connection, resolved.routing_hint)
+    }
+
+    /// Resolves the optimal route and attaches either the tablet-routed [`RoutingHint`] or the cold-start
+    /// bootstrap [`RoutingHint`] to the request's `routing_hint` field.
+    fn route_and_attach_hint(
+        &self,
+        transaction: Option<&TransactionSelector>,
+        operation_uid: u64,
+        routing_key: Option<&[u8]>,
+        routing_hint: &mut Option<RoutingHint>,
+    ) -> Option<ServerConnection> {
+        let (connection, resolved_hint) =
+            self.resolve_request_route(transaction, operation_uid, routing_key);
+
+        if let Some(hint) = resolved_hint {
+            *routing_hint = Some(hint);
+        } else if operation_uid > UNASSIGNED_OPERATION_UID
+            && let Some(routing) = &self.location_routing
+        {
+            // Cold-start query recipe discovery:
+            // When executing a query shape for the first time, no matching `KeyRecipe` is cached yet,
+            // so no routing key can be extracted and `routing_hint` is `None`.
+            //
+            // We attach a bootstrap `RoutingHint` containing `operation_uid` (plus `database_id` and
+            // `schema_generation` if known). The Spanner server includes the query `KeyRecipe` in the
+            // stream response (`PartialResultSet.cache_update`), allowing subsequent executions of this
+            // query shape to resolve routing keys and route directly to tablet replicas.
+            let database_id = routing.cache_updater.database_id();
+            let mut hint = RoutingHint::new().set_operation_uid(operation_uid);
+            if database_id != 0 {
+                hint = hint.set_database_id(database_id);
+            }
+            if let Some(schema_generation) = routing.key_recipe_cache.schema_generation() {
+                hint = hint.set_schema_generation(schema_generation);
+            }
+            *routing_hint = Some(hint);
+        }
+
+        connection
     }
 
     /// Observes an incoming [`CacheUpdate`], updating routing ranges, pre-warming connections, and caching key recipes.
@@ -610,7 +660,7 @@ impl DatabaseClient {
 
     fn pre_route_begin_transaction(
         &self,
-        request: &BeginTransactionRequest,
+        request: &mut BeginTransactionRequest,
     ) -> (Option<ServerConnection>, bool) {
         let Some(routing) = &self.location_routing else {
             return (None, false);
@@ -647,7 +697,7 @@ impl DatabaseClient {
 
     fn pre_route_commit(
         &self,
-        request: &CommitRequest,
+        request: &mut CommitRequest,
     ) -> (Option<ServerConnection>, Option<Bytes>) {
         let Some(routing) = &self.location_routing else {
             return (None, None);
@@ -682,7 +732,7 @@ impl DatabaseClient {
 
     fn pre_route_execute_batch_dml(
         &self,
-        request: &ExecuteBatchDmlRequest,
+        request: &mut ExecuteBatchDmlRequest,
     ) -> (Option<ServerConnection>, bool) {
         self.pre_route_transaction_selector(request.transaction.as_ref())
     }
@@ -703,11 +753,29 @@ impl DatabaseClient {
         self.record_transaction_affinity_routing(is_read_write_begin, transaction_id, connection);
     }
 
+    /// Intercepts unary [`ExecuteSqlRequest`] calls to resolve node routing before dispatch.
+    ///
+    /// Prepares the query in [`KeyRecipeCache`] to assign or retrieve an operation UID and extract
+    /// any cached routing key, then delegates to [`DatabaseClient::route_and_attach_hint`] to resolve
+    /// an existing transaction affinity or direct replica connection and attach the [`RoutingHint`].
     fn pre_route_execute_sql(
         &self,
-        request: &ExecuteSqlRequest,
+        request: &mut ExecuteSqlRequest,
     ) -> (Option<ServerConnection>, bool) {
-        self.pre_route_transaction_selector(request.transaction.as_ref())
+        let is_read_write_begin = is_read_write_begin(request.transaction.as_ref());
+        let (operation_uid, routing_key) = match &self.location_routing {
+            Some(routing) => {
+                extract_execute_sql_request_routing(&routing.key_recipe_cache, request)
+            }
+            None => (UNASSIGNED_OPERATION_UID, None),
+        };
+        let connection = self.route_and_attach_hint(
+            request.transaction.as_ref(),
+            operation_uid,
+            routing_key.as_deref(),
+            &mut request.routing_hint,
+        );
+        (connection, is_read_write_begin)
     }
 
     fn post_route_execute_sql(
@@ -727,7 +795,7 @@ impl DatabaseClient {
 
     fn pre_route_rollback(
         &self,
-        request: &RollbackRequest,
+        request: &mut RollbackRequest,
     ) -> (Option<ServerConnection>, Option<Bytes>) {
         let Some(_routing) = &self.location_routing else {
             return (None, None);
@@ -755,7 +823,7 @@ impl DatabaseClient {
 
     fn pre_route_partition_query(
         &self,
-        request: &PartitionQueryRequest,
+        request: &mut PartitionQueryRequest,
     ) -> (Option<ServerConnection>, ()) {
         (
             self.pre_route_transaction_selector(request.transaction.as_ref())
@@ -766,7 +834,7 @@ impl DatabaseClient {
 
     fn pre_route_partition_read(
         &self,
-        request: &PartitionReadRequest,
+        request: &mut PartitionReadRequest,
     ) -> (Option<ServerConnection>, ()) {
         let Some(routing) = &self.location_routing else {
             return (None, ());
@@ -1071,6 +1139,8 @@ pub(crate) struct LocationRoutingState {
 }
 
 const DEFAULT_ENDPOINT: &str = "spanner.googleapis.com:443";
+/// Sentinel value representing an unassigned or absent operation UID.
+const UNASSIGNED_OPERATION_UID: u64 = 0;
 
 impl LocationRoutingState {
     fn new(database_name: String, spanner: &Spanner) -> Self {
@@ -1168,13 +1238,17 @@ mod tests {
     use crate::client::SpannerBuilderExt;
     use crate::model::key_recipe::Part;
     use crate::model::key_recipe::part::{NullOrder, Order};
+    use crate::model::tablet::Role;
     use crate::model::transaction_options::{PartitionedDml, ReadOnly, ReadWrite};
     use crate::model::{
         CacheUpdate, CommitResponse, Group, KeyRecipe, KeySet, Range, RecipeList, Tablet,
         TransactionOptions, Type, TypeCode,
     };
     use crate::result_set::tests::adapt;
+    use crate::routing::key_extractor::extract_proto_read_request_routing_key;
     use crate::routing::key_range_cache::RangeMode;
+    use crate::statement::Statement;
+    use bytes::Bytes;
     use gaxi::grpc::tonic::Response;
     use gaxi::options::ClientConfig;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
@@ -2706,6 +2780,353 @@ mod tests {
     }
 
     #[tokio_test_no_panics]
+    async fn execute_streaming_sql_attaches_operation_uid_on_cold_start_and_routes_to_tablet_on_cache_hit()
+     {
+        use std::sync::Mutex;
+
+        let captured_gateway_requests = Arc::new(Mutex::new(Vec::new()));
+        let mut mock_gateway = create_test_mock();
+
+        let captured_gateway = Arc::clone(&captured_gateway_requests);
+        mock_gateway
+            .expect_execute_streaming_sql()
+            .returning(move |request| {
+                captured_gateway
+                    .lock()
+                    .expect("lock captured gateway requests")
+                    .push(request.into_inner());
+                Ok(Response::from(adapt([])))
+            });
+
+        let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway)
+            .await
+            .expect("start mock gateway");
+
+        let captured_tablet_requests = Arc::new(Mutex::new(Vec::new()));
+        let mut mock_tablet = create_test_mock();
+        let captured_tablet = Arc::clone(&captured_tablet_requests);
+        mock_tablet
+            .expect_execute_streaming_sql()
+            .returning(move |request| {
+                captured_tablet
+                    .lock()
+                    .expect("lock captured tablet requests")
+                    .push(request.into_inner());
+                Ok(Response::from(adapt([])))
+            });
+
+        let (tablet_address, _tablet_server) = start("127.0.0.1:0", mock_tablet)
+            .await
+            .expect("start mock tablet");
+
+        let spanner = Spanner::builder()
+            .with_endpoint(gateway_address)
+            .with_instance_type(InstanceType::Omni)
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await
+            .expect("build spanner client");
+
+        let database_client = spanner
+            .database_client("projects/p/instances/i/databases/d")
+            .with_location_aware_routing(true)
+            .build()
+            .await
+            .expect("build database client");
+
+        let statement = Statement::builder("SELECT * FROM Accounts WHERE account_id = @id")
+            .add_param("id", 12345i64)
+            .build();
+        let request = statement.clone().into_request();
+
+        // 1. Cold start: routes to gateway, attaches discovery routing hint with operation_uid
+        let _ = database_client
+            .execute_streaming_sql(request.clone(), RequestOptions::default(), 0)
+            .send()
+            .await;
+
+        let gateway_requests = captured_gateway_requests
+            .lock()
+            .expect("lock gateway requests")
+            .clone();
+        assert_eq!(
+            gateway_requests.len(),
+            1,
+            "cold-start query must be dispatched to the gateway"
+        );
+        let cold_request = &gateway_requests[0];
+        let cold_hint = cold_request
+            .routing_hint
+            .as_ref()
+            .expect("cold-start query must attach bootstrap routing hint");
+        assert_ne!(
+            cold_hint.operation_uid, 0,
+            "bootstrap hint must contain assigned operation UID"
+        );
+        let allocated_operation_uid = cold_hint.operation_uid;
+
+        // 2. Pre-warm tablet connection in connection cache
+        let router = database_client
+            .location_router()
+            .expect("location router present");
+        let client_config = database_client
+            .cache_updater()
+            .expect("cache updater present")
+            .client_config();
+        let _ = router
+            .connection_cache()
+            .get(&tablet_address, client_config)
+            .await
+            .expect("pre-warm tablet connection");
+
+        // 3. Ingest CacheUpdate with recipe for allocated_operation_uid and range mapping to tablet
+        let cache_update = CacheUpdate::new()
+            .set_database_id(8888u64)
+            .set_key_recipes(
+                RecipeList::new()
+                    .set_schema_generation(Bytes::from_static(b"v1"))
+                    .set_recipe(vec![
+                        KeyRecipe::new()
+                            .set_operation_uid(allocated_operation_uid)
+                            .set_part(vec![
+                                Part::new().set_tag(10u32),
+                                Part::new()
+                                    .set_identifier("id")
+                                    .set_order(Order::Ascending)
+                                    .set_null_order(NullOrder::NullsFirst)
+                                    .set_type(Type::default().set_code(TypeCode::Int64)),
+                            ]),
+                    ]),
+            )
+            .set_group(vec![Group::new().set_group_uid(7001u64).set_tablets(vec![
+                        Tablet::new()
+                            .set_tablet_uid(7001u64)
+                            .set_server_address(tablet_address)
+                            .set_role(Role::ReadOnly)
+                            .set_distance(0u32),
+                    ])])
+            .set_range(vec![
+                Range::new()
+                    .set_group_uid(7001u64)
+                    .set_start_key(vec![0x01])
+                    .set_limit_key(vec![0xff, 0xff]),
+            ]);
+
+        database_client.observe_cache_update(Some(cache_update));
+
+        // 4. Cache hit: routes directly to tablet mock with full routing hint
+        let _ = database_client
+            .execute_streaming_sql(request, RequestOptions::default(), 0)
+            .send()
+            .await;
+
+        let tablet_requests = captured_tablet_requests
+            .lock()
+            .expect("lock tablet requests")
+            .clone();
+        assert_eq!(
+            tablet_requests.len(),
+            1,
+            "keyed query after recipe and range caching must route directly to tablet"
+        );
+        let tablet_request = &tablet_requests[0];
+        let tablet_hint = tablet_request
+            .routing_hint
+            .as_ref()
+            .expect("tablet-routed query must attach routing hint");
+        assert_eq!(
+            tablet_hint.operation_uid, allocated_operation_uid,
+            "tablet hint operation UID must match assigned UID"
+        );
+        assert_eq!(
+            tablet_hint.tablet_uid, 7001,
+            "tablet hint tablet UID must match target tablet"
+        );
+        assert_eq!(
+            tablet_hint.database_id, 8888,
+            "tablet hint database ID must match updated database ID"
+        );
+        assert!(
+            !tablet_hint.key.is_empty(),
+            "tablet hint must contain encoded routing key"
+        );
+    }
+
+    #[tokio_test_no_panics]
+    async fn streaming_read_routes_to_gateway_on_cold_start_and_tablet_on_cache_hit() {
+        use std::sync::Mutex;
+
+        let captured_gateway_requests = Arc::new(Mutex::new(Vec::new()));
+        let mut mock_gateway = create_test_mock();
+
+        let captured_gateway = Arc::clone(&captured_gateway_requests);
+        mock_gateway
+            .expect_streaming_read()
+            .returning(move |request| {
+                captured_gateway
+                    .lock()
+                    .expect("lock captured gateway requests")
+                    .push(request.into_inner());
+                Ok(Response::from(adapt([])))
+            });
+
+        let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway)
+            .await
+            .expect("start mock gateway");
+
+        let captured_tablet_requests = Arc::new(Mutex::new(Vec::new()));
+        let mut mock_tablet = create_test_mock();
+        let captured_tablet = Arc::clone(&captured_tablet_requests);
+        mock_tablet
+            .expect_streaming_read()
+            .returning(move |request| {
+                captured_tablet
+                    .lock()
+                    .expect("lock captured tablet requests")
+                    .push(request.into_inner());
+                Ok(Response::from(adapt([])))
+            });
+
+        let (tablet_address, _tablet_server) = start("127.0.0.1:0", mock_tablet)
+            .await
+            .expect("start mock tablet");
+
+        let spanner = Spanner::builder()
+            .with_endpoint(gateway_address)
+            .with_instance_type(InstanceType::Omni)
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await
+            .expect("build spanner client");
+
+        let database_client = spanner
+            .database_client("projects/p/instances/i/databases/d")
+            .with_location_aware_routing(true)
+            .build()
+            .await
+            .expect("build database client");
+
+        let mut key_set = KeySet::new();
+        key_set
+            .keys
+            .push(vec![serde_json::Value::String("user123".to_string())]);
+        let read_request = ReadRequest::new()
+            .set_table("Users")
+            .set_columns(vec!["name".to_string()])
+            .set_key_set(key_set);
+
+        // 1. Cold start: without cached recipe or range, routes to gateway and attaches bootstrap routing hint
+        let _ = database_client
+            .streaming_read(read_request.clone(), RequestOptions::default(), 0)
+            .send()
+            .await;
+
+        let gateway_requests = captured_gateway_requests
+            .lock()
+            .expect("lock gateway requests")
+            .clone();
+        assert_eq!(
+            gateway_requests.len(),
+            1,
+            "cold-start table read must be dispatched to the gateway"
+        );
+        let cold_request = &gateway_requests[0];
+        let cold_hint = cold_request
+            .routing_hint
+            .as_ref()
+            .expect("cold-start read must attach RoutingHint with assigned operation_uid");
+        assert_ne!(
+            cold_hint.operation_uid, UNASSIGNED_OPERATION_UID,
+            "cold-start read must assign dynamic operation UID"
+        );
+
+        // 2. Pre-warm tablet connection in connection cache
+        let router = database_client
+            .location_router()
+            .expect("location router present");
+        let client_config = database_client
+            .cache_updater()
+            .expect("cache updater present")
+            .client_config();
+        let _ = router
+            .connection_cache()
+            .get(&tablet_address, client_config)
+            .await
+            .expect("pre-warm tablet connection");
+
+        // 3. Ingest CacheUpdate with table recipe and covering range pointing to tablet
+        let cache_update = CacheUpdate::new()
+            .set_database_id(9999u64)
+            .set_key_recipes(
+                RecipeList::new()
+                    .set_schema_generation(Bytes::from_static(b"v1"))
+                    .set_recipe(vec![KeyRecipe::new().set_table_name("Users").set_part(
+                        vec![
+                                Part::new().set_tag(50020u32),
+                                Part::new()
+                                    .set_tag(1u32)
+                                    .set_identifier("id")
+                                    .set_type(Type::new().set_code(TypeCode::String))
+                                    .set_order(Order::Ascending)
+                                    .set_null_order(NullOrder::NotNull),
+                            ],
+                    )]),
+            )
+            .set_group(vec![Group::new().set_group_uid(8001u64).set_tablets(vec![
+                Tablet::new()
+                    .set_tablet_uid(8001u64)
+                    .set_server_address(tablet_address)
+                    .set_role(Role::ReadOnly)
+                    .set_distance(0u32),
+            ])])
+            .set_range(vec![
+                Range::new()
+                    .set_group_uid(8001u64)
+                    .set_start_key(vec![0x00])
+                    .set_limit_key(vec![0xff]),
+            ]);
+
+        database_client.observe_cache_update(Some(cache_update));
+
+        // 4. Cache hit: routes directly to tablet mock with full routing hint
+        let _ = database_client
+            .streaming_read(read_request, RequestOptions::default(), 0)
+            .send()
+            .await;
+
+        let tablet_requests = captured_tablet_requests
+            .lock()
+            .expect("lock tablet requests")
+            .clone();
+        assert_eq!(
+            tablet_requests.len(),
+            1,
+            "keyed table read after recipe and range caching must route directly to tablet"
+        );
+        let tablet_request = &tablet_requests[0];
+        let tablet_hint = tablet_request
+            .routing_hint
+            .as_ref()
+            .expect("tablet-routed read must attach routing hint");
+        assert_eq!(
+            tablet_hint.operation_uid, cold_hint.operation_uid,
+            "tablet hint operation UID must match assigned UID"
+        );
+        assert_eq!(
+            tablet_hint.tablet_uid, 8001,
+            "tablet hint tablet UID must match target tablet"
+        );
+        assert_eq!(
+            tablet_hint.database_id, 9999,
+            "tablet hint database ID must match updated database ID"
+        );
+        assert!(
+            !tablet_hint.key.is_empty(),
+            "tablet hint must contain encoded routing key"
+        );
+    }
+
+    #[tokio_test_no_panics]
     async fn database_client_latency_recording_and_error_tracking() {
         let mock = create_test_mock();
 
@@ -2961,9 +3382,12 @@ mod tests {
             1,
             "exactly one initial request must be captured"
         );
-        assert!(
-            hints[0].is_none(),
-            "cold cache without database_id must not attach RoutingHint"
+        let cold_hint = hints[0]
+            .as_ref()
+            .expect("cold-start read must attach RoutingHint with operation_uid");
+        assert_eq!(
+            cold_hint.operation_uid, 1,
+            "cold-start read must assign operation UID 1"
         );
 
         // 2. Ingest CacheUpdate with database_id, recipe list, and key range
@@ -3022,8 +3446,8 @@ mod tests {
             "database_id must match active database"
         );
         assert_eq!(
-            hint.operation_uid, 0,
-            "operation_uid is 0 for unshaped read"
+            hint.operation_uid, 1,
+            "operation_uid matches prepared read UID"
         );
         assert_eq!(hint.database_id, 999, "database_id must match CacheUpdate");
         assert_eq!(

--- a/src/spanner/src/routing/key_extractor.rs
+++ b/src/spanner/src/routing/key_extractor.rs
@@ -638,6 +638,43 @@ pub(crate) fn extract_statement_routing_key(
     extract_statement_params_routing_key(key_recipe_cache, operation_uid, &statement.params)
 }
 
+/// Prepares or resolves the operation UID for an [`ExecuteSqlRequest`] and extracts the binary
+/// routing key from query parameters if a matching query [`KeyRecipe`] is already cached.
+///
+/// Returns `(operation_uid, maybe_routing_key)`:
+/// - On cold start (recipe not yet cached): returns `(operation_uid, None)`.
+/// - On cache hit: returns `(operation_uid, Some(routing_key))`.
+/// - If unkeyed / partitioned / invalid: returns `(0, None)`.
+pub(crate) fn extract_execute_sql_request_routing(
+    key_recipe_cache: &KeyRecipeCache,
+    request: &ExecuteSqlRequest,
+) -> (u64, Option<Vec<u8>>) {
+    let Some(operation_uid) = key_recipe_cache.get_or_prepare_query(request) else {
+        return (0, None);
+    };
+    let routing_key =
+        extract_execute_sql_request_routing_key(key_recipe_cache, operation_uid, request);
+    (operation_uid, routing_key)
+}
+
+/// Prepares or resolves the operation UID for a protobuf [`ProtoReadRequest`] and extracts the binary
+/// routing key from request keys if a matching table or index [`KeyRecipe`] is already cached.
+///
+/// Returns `(operation_uid, maybe_routing_key)`:
+/// - On cold start (recipe not yet cached): returns `(operation_uid, None)`.
+/// - On cache hit: returns `(operation_uid, Some(routing_key))`.
+/// - If unkeyed / partitioned / invalid: returns `(0, None)`.
+pub(crate) fn extract_proto_read_request_routing(
+    key_recipe_cache: &KeyRecipeCache,
+    request: &ProtoReadRequest,
+) -> (u64, Option<Vec<u8>>) {
+    let Some(operation_uid) = key_recipe_cache.get_or_prepare_read(request) else {
+        return (0, None);
+    };
+    let routing_key = extract_proto_read_request_routing_key(key_recipe_cache, request);
+    (operation_uid, routing_key)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2042,6 +2079,75 @@ mod tests {
         assert_eq!(
             routing_key, statement_key,
             "json params None and empty statement params must produce the identical tag-only routing key"
+        );
+    }
+
+    #[test]
+    fn extract_execute_sql_request_routing_cold_start_and_cache_hit() {
+        let cache = KeyRecipeCache::new();
+
+        let statement = Statement::builder("SELECT * FROM Users WHERE account_id = @account_id")
+            .add_param("account_id", 42i64)
+            .build();
+        let request = statement.clone().into_request();
+
+        // 1. Cold start: prepares query and allocates operation UID, but recipe is not yet cached
+        let (operation_uid, routing_key) = extract_execute_sql_request_routing(&cache, &request);
+        assert_ne!(operation_uid, 0, "operation UID must be assigned");
+        assert!(
+            routing_key.is_none(),
+            "routing key must be None on cold start"
+        );
+
+        // 2. Cache recipe under the allocated operation UID
+        let recipe = sample_query_recipe(operation_uid, "account_id");
+        cache.insert(recipe);
+
+        // 3. Cache hit: returns assigned operation UID and encoded routing key
+        let (hit_operation_uid, hit_routing_key) =
+            extract_execute_sql_request_routing(&cache, &request);
+        assert_eq!(
+            hit_operation_uid, operation_uid,
+            "operation UID must be preserved"
+        );
+        assert!(
+            hit_routing_key.is_some(),
+            "routing key must be resolved after recipe insertion"
+        );
+    }
+
+    #[test]
+    fn extract_proto_read_request_routing_cold_start_and_cache_hit() {
+        let cache = KeyRecipeCache::new();
+
+        let read_request = ReadRequest::builder("Accounts", vec!["Balance"])
+            .with_keys(key!["acc_999"])
+            .build();
+        let proto_request = read_request.into_request();
+
+        // 1. Cold start: prepares read and allocates operation UID, but recipe is not yet cached
+        let (operation_uid, routing_key) =
+            extract_proto_read_request_routing(&cache, &proto_request);
+        assert_ne!(operation_uid, 0, "operation UID must be assigned");
+        assert!(
+            routing_key.is_none(),
+            "routing key must be None on cold start"
+        );
+
+        // 2. Cache recipe for table "Accounts"
+        let recipe = sample_table_recipe("Accounts", vec![string_part(Order::Ascending)]);
+        cache.insert(recipe);
+
+        // 3. Cache hit: returns assigned operation UID and encoded routing key
+        let (hit_operation_uid, hit_routing_key) =
+            extract_proto_read_request_routing(&cache, &proto_request);
+        assert_eq!(
+            hit_operation_uid, operation_uid,
+            "operation UID must be preserved"
+        );
+        assert!(
+            hit_routing_key.is_some(),
+            "routing key must be resolved after recipe insertion"
         );
     }
 }

--- a/src/spanner/src/routing/key_recipe_cache.rs
+++ b/src/spanner/src/routing/key_recipe_cache.rs
@@ -22,8 +22,11 @@
 #![allow(dead_code)]
 
 use crate::model::key_recipe::Target;
-use crate::model::{KeyRecipe, RecipeList};
+use crate::model::{ExecuteSqlRequest, KeyRecipe, ReadRequest, RecipeList};
 use crate::routing::clock_cache::{ClockEntry, ClockStore};
+use crate::routing::prepared_operation::{
+    PreparedQuery, PreparedRead, fingerprint_execute_sql_request, fingerprint_proto_read_request,
+};
 use bytes::Bytes;
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
@@ -128,6 +131,75 @@ impl KeyRecipeCache {
     /// `KeyRangeCache::get_group`.
     pub(crate) fn get_query_recipe(&self, operation_uid: u64) -> Option<Arc<KeyRecipe>> {
         self.read_store().queries.get(&operation_uid)
+    }
+
+    fn get_or_prepare_operation<T: PreparedOperation>(
+        &self,
+        fingerprint: u64,
+        matches: impl Fn(&T) -> bool,
+        create: impl FnOnce(u64) -> T,
+    ) -> Option<u64> {
+        // Optimistic read path: lookup existing prepared descriptor under read lock.
+        if let Some(prepared) = T::clock_store(&self.read_store()).get_ref(&fingerprint) {
+            if matches(prepared) {
+                return Some(prepared.operation_uid());
+            }
+            return None;
+        }
+
+        // Slow write path: allocate new operation UID and insert descriptor.
+        let operation_uid = self.next_operation_uid();
+        let prepared = create(operation_uid);
+
+        let mut guard = self.write_store();
+        if let Some(existing) = T::clock_store_mut(&mut guard).get_ref(&fingerprint) {
+            if matches(existing) {
+                return Some(existing.operation_uid());
+            }
+            return None;
+        }
+
+        T::clock_store_mut(&mut guard).insert(fingerprint, prepared);
+        Some(operation_uid)
+    }
+
+    /// Returns the cached `operation_uid` for an [`ExecuteSqlRequest`], preparing and caching
+    /// a new [`PreparedQuery`] descriptor if this query shape has not been encountered yet.
+    ///
+    /// Returns `None` if the request has empty SQL, is a partitioned query, or if a fingerprint
+    /// hash collision occurs with an existing query of different shape.
+    pub(crate) fn get_or_prepare_query(&self, request: &ExecuteSqlRequest) -> Option<u64> {
+        // Fast path: partitioned queries and empty queries cannot have prepared operation UIDs.
+        if request.sql.is_empty() || !request.partition_token.is_empty() {
+            return None;
+        }
+
+        let fingerprint = fingerprint_execute_sql_request(request);
+        self.get_or_prepare_operation::<PreparedQuery>(
+            fingerprint,
+            |prepared| prepared.matches(request),
+            |operation_uid| PreparedQuery::new(request, operation_uid),
+        )
+    }
+
+    /// Returns the cached `operation_uid` for a [`ReadRequest`], preparing and caching
+    /// a new [`PreparedRead`] descriptor if this read shape has not been encountered yet.
+    ///
+    /// Returns `None` if the request has an empty table name, is a partitioned read, or if a fingerprint
+    /// hash collision occurs with an existing read of different shape.
+    pub(crate) fn get_or_prepare_read(&self, request: &ReadRequest) -> Option<u64> {
+        // Fast path: partitioned reads and reads missing a target table name cannot have prepared operation UIDs.
+        // In Cloud Spanner, the `table` field is mandatory for all reads, including secondary index reads.
+        if request.table.is_empty() || !request.partition_token.is_empty() {
+            return None;
+        }
+
+        let fingerprint = fingerprint_proto_read_request(request);
+        self.get_or_prepare_operation::<PreparedRead>(
+            fingerprint,
+            |prepared| prepared.matches_proto_read_request(request),
+            |operation_uid| PreparedRead::from_proto_read_request(request, operation_uid),
+        )
     }
 
     /// Inserts a [`KeyRecipe`] into the cache.
@@ -274,12 +346,17 @@ impl KeyRecipeCache {
     /// operation UIDs remain globally unique across the client lifecycle, preventing collisions
     /// with in-flight asynchronous queries.
     pub(crate) fn clear(&self) {
-        let old_entries = {
+        let (old_entries, old_prepared_queries, old_prepared_reads) = {
             let mut guard = self.write_store();
-            guard.invalidate_all(None)
+            let old_prepared_queries = guard.prepared_queries.take_all();
+            let old_prepared_reads = guard.prepared_reads.take_all();
+            let old_entries = guard.invalidate_all(None);
+            (old_entries, old_prepared_queries, old_prepared_reads)
         };
-        // Drop old collections (and cached Arc<KeyRecipe> entries) outside the write lock.
+        // Drop old collections outside the write lock.
         drop(old_entries);
+        drop(old_prepared_queries);
+        drop(old_prepared_reads);
     }
 
     /// Returns the total number of recipes stored in the cache.
@@ -287,9 +364,56 @@ impl KeyRecipeCache {
         self.read_store().len()
     }
 
+    /// Returns the number of prepared query descriptors currently stored in the cache.
+    #[allow(dead_code)]
+    pub(crate) fn prepared_queries_len(&self) -> usize {
+        self.read_store().prepared_queries.len()
+    }
+
+    /// Returns the number of prepared read descriptors currently stored in the cache.
+    #[allow(dead_code)]
+    pub(crate) fn prepared_reads_len(&self) -> usize {
+        self.read_store().prepared_reads.len()
+    }
+
     /// Returns `true` if the cache is empty.
     pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+}
+
+/// Trait abstracting over prepared query and read descriptors to enable unified cache lookup and preparation.
+trait PreparedOperation: Sized {
+    fn operation_uid(&self) -> u64;
+    fn clock_store(store: &RecipeStore) -> &ClockStore<u64, Self>;
+    fn clock_store_mut(store: &mut RecipeStore) -> &mut ClockStore<u64, Self>;
+}
+
+impl PreparedOperation for PreparedQuery {
+    fn operation_uid(&self) -> u64 {
+        self.operation_uid
+    }
+
+    fn clock_store(store: &RecipeStore) -> &ClockStore<u64, Self> {
+        &store.prepared_queries
+    }
+
+    fn clock_store_mut(store: &mut RecipeStore) -> &mut ClockStore<u64, Self> {
+        &mut store.prepared_queries
+    }
+}
+
+impl PreparedOperation for PreparedRead {
+    fn operation_uid(&self) -> u64 {
+        self.operation_uid
+    }
+
+    fn clock_store(store: &RecipeStore) -> &ClockStore<u64, Self> {
+        &store.prepared_reads
+    }
+
+    fn clock_store_mut(store: &mut RecipeStore) -> &mut ClockStore<u64, Self> {
+        &mut store.prepared_reads
     }
 }
 
@@ -307,6 +431,8 @@ struct RecipeStore {
     tables: HashMap<String, Arc<KeyRecipe>>,
     indexes: HashMap<String, Arc<KeyRecipe>>,
     queries: ClockStore<u64, Arc<KeyRecipe>>,
+    prepared_queries: ClockStore<u64, PreparedQuery>,
+    prepared_reads: ClockStore<u64, PreparedRead>,
     schema_generation: Option<Bytes>,
 }
 
@@ -316,6 +442,8 @@ impl RecipeStore {
             tables: HashMap::new(),
             indexes: HashMap::new(),
             queries: ClockStore::with_capacity(query_capacity),
+            prepared_queries: ClockStore::with_capacity(query_capacity),
+            prepared_reads: ClockStore::with_capacity(query_capacity),
             schema_generation: None,
         }
     }
@@ -325,6 +453,13 @@ impl RecipeStore {
     }
 
     /// Invalidates all cached tables, indexes, and query recipes, and transitions to the new schema generation.
+    ///
+    /// # Prepared Operations Lifecycle Retention:
+    /// Does not invalidate `prepared_queries` or `prepared_reads`. Schema generation updates
+    /// indicate database DDL changes that invalidate server-compiled key recipes, but the structural
+    /// shape of application queries/reads and their assigned `operation_uid`s remain valid. Retaining
+    /// them allows the client to immediately re-request updated recipes under the new schema generation
+    /// using their existing operation UIDs without thrashing or reallocation.
     ///
     /// Returns the previous collections using [`take`] so deallocation can occur outside the write lock.
     fn invalidate_all(&mut self, new_schema_generation: Option<Bytes>) -> InvalidatedEntries {
@@ -442,9 +577,63 @@ mod tests {
         assert!(cache.insert(KeyRecipe::new().set_index_name("IndexA")));
         assert_eq!(cache.len(), 2, "cache length must be 2");
 
+        let request = ExecuteSqlRequest::new().set_sql("SELECT 1");
+        let initial_query_uid = cache.get_or_prepare_query(&request).expect("prepare query");
+        assert_eq!(
+            initial_query_uid, 1,
+            "initial query must allocate operation UID 1"
+        );
+
+        let read_request = ReadRequest::new()
+            .set_table("Users")
+            .set_columns(vec!["Id".to_string()]);
+        let initial_read_uid = cache
+            .get_or_prepare_read(&read_request)
+            .expect("prepare read");
+        assert_eq!(
+            initial_read_uid, 2,
+            "initial read must allocate operation UID 2"
+        );
+        assert_eq!(
+            cache.prepared_queries_len(),
+            1,
+            "prepared queries count must be 1 before clear"
+        );
+        assert_eq!(
+            cache.prepared_reads_len(),
+            1,
+            "prepared reads count must be 1 before clear"
+        );
+
         cache.clear();
         assert!(cache.is_empty(), "cache must be empty after clear");
         assert_eq!(cache.len(), 0, "cache length must be zero after clear");
+        assert_eq!(
+            cache.prepared_queries_len(),
+            0,
+            "prepared queries count must be 0 after clear"
+        );
+        assert_eq!(
+            cache.prepared_reads_len(),
+            0,
+            "prepared reads count must be 0 after clear"
+        );
+
+        // After clear, prepared operations are cleared, so re-preparing allocates new monotonically increasing UIDs
+        let post_clear_query_uid = cache
+            .get_or_prepare_query(&request)
+            .expect("prepare query after clear");
+        assert_eq!(
+            post_clear_query_uid, 3,
+            "prepared queries must be cleared so query is re-prepared with a new UID"
+        );
+        let post_clear_read_uid = cache
+            .get_or_prepare_read(&read_request)
+            .expect("prepare read after clear");
+        assert_eq!(
+            post_clear_read_uid, 4,
+            "prepared reads must be cleared so read is re-prepared with a new UID"
+        );
     }
 
     #[test]
@@ -996,6 +1185,17 @@ mod tests {
         let cache = KeyRecipeCache::new();
 
         // 1. Initial schema generation v1 with Users table and a cached query
+        let query_request = ExecuteSqlRequest::new().set_sql("SELECT 1");
+        let query_uid = cache
+            .get_or_prepare_query(&query_request)
+            .expect("prepare query");
+        let read_request = ReadRequest::new()
+            .set_table("Users")
+            .set_columns(vec!["Id".to_string()]);
+        let read_uid = cache
+            .get_or_prepare_read(&read_request)
+            .expect("prepare read");
+
         let v1_list = RecipeList::new()
             .set_schema_generation(Bytes::from_static(b"v1"))
             .set_recipe(vec![
@@ -1038,6 +1238,28 @@ mod tests {
         assert!(
             cache.get_query_recipe(42).is_none(),
             "Query 42 recipe from v1 must be invalidated"
+        );
+
+        // Prepared queries and reads must be retained across schema generation updates
+        assert_eq!(
+            cache.prepared_queries_len(),
+            1,
+            "prepared queries must be retained across schema updates"
+        );
+        assert_eq!(
+            cache.prepared_reads_len(),
+            1,
+            "prepared reads must be retained across schema updates"
+        );
+        assert_eq!(
+            cache.get_or_prepare_query(&query_request),
+            Some(query_uid),
+            "re-preparing same query after schema bump must reuse existing operation UID"
+        );
+        assert_eq!(
+            cache.get_or_prepare_read(&read_request),
+            Some(read_uid),
+            "re-preparing same read after schema bump must reuse existing operation UID"
         );
     }
 
@@ -1278,6 +1500,144 @@ mod tests {
             cache.schema_generation(),
             Some(Bytes::from_static(b"v1")),
             "schema generation must still be recorded"
+        );
+    }
+
+    #[test]
+    fn get_or_prepare_query_caches_and_reuses_operation_uid() {
+        let cache = KeyRecipeCache::new();
+
+        // 1. Empty SQL returns None
+        let empty_request = ExecuteSqlRequest::default();
+        assert_eq!(
+            cache.get_or_prepare_query(&empty_request),
+            None,
+            "empty SQL query must return None"
+        );
+
+        // 2. Partitioned query returns None
+        let partitioned_request = ExecuteSqlRequest::new()
+            .set_sql("SELECT * FROM Singers WHERE SingerId = @id")
+            .set_partition_token(Bytes::from_static(b"token_1"));
+        assert_eq!(
+            cache.get_or_prepare_query(&partitioned_request),
+            None,
+            "partitioned query must return None"
+        );
+
+        // 3. First execution allocates initial operation UID
+        let mut params = serde_json::Map::new();
+        params.insert("id".to_string(), serde_json::Value::from(100));
+        let first_request = ExecuteSqlRequest::new()
+            .set_sql("SELECT * FROM Singers WHERE SingerId = @id")
+            .set_params(params);
+
+        let first_uid = cache
+            .get_or_prepare_query(&first_request)
+            .expect("first query must allocate operation UID");
+        assert_eq!(first_uid, 1, "first operation UID allocated must be 1");
+
+        // 4. Repeated query with different parameter value returns same operation UID
+        let mut second_params = serde_json::Map::new();
+        second_params.insert("id".to_string(), serde_json::Value::from(200));
+        let second_request = ExecuteSqlRequest::new()
+            .set_sql("SELECT * FROM Singers WHERE SingerId = @id")
+            .set_params(second_params);
+
+        let second_uid = cache
+            .get_or_prepare_query(&second_request)
+            .expect("repeated query must resolve cached operation UID");
+        assert_eq!(
+            second_uid, first_uid,
+            "repeated query with identical shape must reuse operation UID"
+        );
+
+        // 5. Structurally distinct query allocates new operation UID
+        let mut distinct_params = serde_json::Map::new();
+        distinct_params.insert("album_id".to_string(), serde_json::Value::from(42));
+        let distinct_request = ExecuteSqlRequest::new()
+            .set_sql("SELECT * FROM Albums WHERE AlbumId = @album_id")
+            .set_params(distinct_params);
+
+        let distinct_uid = cache
+            .get_or_prepare_query(&distinct_request)
+            .expect("distinct query must allocate operation UID");
+        assert_ne!(
+            distinct_uid, first_uid,
+            "distinct query shape must allocate distinct operation UID"
+        );
+    }
+
+    #[test]
+    fn get_or_prepare_read_caches_and_reuses_operation_uid() {
+        let cache = KeyRecipeCache::new();
+
+        // 1. Empty table returns None
+        let empty_request = ReadRequest::default();
+        assert_eq!(
+            cache.get_or_prepare_read(&empty_request),
+            None,
+            "empty table read must return None"
+        );
+
+        // 2. Partitioned read returns None
+        let partitioned_request = ReadRequest::new()
+            .set_table("Singers")
+            .set_columns(vec!["SingerId".to_string()])
+            .set_partition_token(Bytes::from_static(b"token_read_1"));
+        assert_eq!(
+            cache.get_or_prepare_read(&partitioned_request),
+            None,
+            "partitioned read must return None"
+        );
+
+        // 3. First execution allocates initial operation UID
+        let first_request = ReadRequest::new()
+            .set_table("Singers")
+            .set_columns(vec!["SingerId".to_string(), "Name".to_string()]);
+
+        let first_uid = cache
+            .get_or_prepare_read(&first_request)
+            .expect("first read must allocate operation UID");
+        assert_eq!(first_uid, 1, "first operation UID allocated must be 1");
+
+        // 4. Repeated read with identical shape returns same operation UID
+        let second_request = ReadRequest::new()
+            .set_table("Singers")
+            .set_columns(vec!["SingerId".to_string(), "Name".to_string()]);
+
+        let second_uid = cache
+            .get_or_prepare_read(&second_request)
+            .expect("repeated read must resolve cached operation UID");
+        assert_eq!(
+            second_uid, first_uid,
+            "repeated read with identical shape must reuse operation UID"
+        );
+
+        // 5. Structurally distinct read (different table) allocates new operation UID
+        let distinct_table_request = ReadRequest::new()
+            .set_table("Albums")
+            .set_columns(vec!["AlbumId".to_string(), "Title".to_string()]);
+
+        let distinct_table_uid = cache
+            .get_or_prepare_read(&distinct_table_request)
+            .expect("distinct table read must allocate operation UID");
+        assert_ne!(
+            distinct_table_uid, first_uid,
+            "distinct table read must allocate distinct operation UID"
+        );
+
+        // 6. Structurally distinct read (same table, different columns) allocates new operation UID
+        let distinct_columns_request = ReadRequest::new()
+            .set_table("Singers")
+            .set_columns(vec!["SingerId".to_string()]);
+
+        let distinct_columns_uid = cache
+            .get_or_prepare_read(&distinct_columns_request)
+            .expect("distinct columns read must allocate operation UID");
+        assert_ne!(
+            distinct_columns_uid, first_uid,
+            "distinct columns read must allocate distinct operation UID"
         );
     }
 }

--- a/src/spanner/src/routing/mock_tests.rs
+++ b/src/spanner/src/routing/mock_tests.rs
@@ -54,7 +54,7 @@ use crate::routing::key_range_cache::RangeMode;
 use crate::routing::location_router::RoutingContext;
 use crate::statement::Statement;
 use bytes::Bytes;
-use gaxi::grpc::tonic::Response;
+use gaxi::grpc::tonic::{Response, Status as TonicStatus};
 use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
 use google_cloud_test_macros::tokio_test_no_panics;
 use prost_types::{Timestamp, Value};
@@ -62,8 +62,8 @@ use spanner_grpc_mock::MockSpanner;
 use spanner_grpc_mock::google::rpc::Status;
 use spanner_grpc_mock::google::spanner::v1 as mock_v1;
 use spanner_grpc_mock::start;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
@@ -3578,4 +3578,355 @@ fn sample_model_cache_update(
         }),
         _unknown_fields: Default::default(),
     }
+}
+
+fn single_row_streaming_response(
+    column_name: &str,
+    value: &str,
+    cache_update: Option<mock_v1::CacheUpdate>,
+) -> Result<Response<mpsc::Receiver<Result<mock_v1::PartialResultSet, TonicStatus>>>, TonicStatus> {
+    let partial_result_set = sample_int64_partial_result_set(column_name, value, cache_update);
+    let (sender, receiver) = mpsc::channel(1);
+    sender
+        .try_send(Ok(partial_result_set))
+        .expect("send partial result set");
+    Ok(Response::from(receiver))
+}
+
+fn sample_query_mock_cache_update(
+    database_id: u64,
+    operation_uid: u64,
+    group_uid: u64,
+    tablet_address: &str,
+) -> mock_v1::CacheUpdate {
+    mock_v1::CacheUpdate {
+        database_id,
+        range: vec![mock_v1::Range {
+            start_key: Vec::new(),
+            limit_key: vec![0xff, 0xff],
+            group_uid,
+            split_id: group_uid,
+            generation: b"gen_1".to_vec(),
+        }],
+        group: vec![mock_v1::Group {
+            group_uid,
+            leader_index: 0,
+            tablets: vec![mock_v1::Tablet {
+                tablet_uid: group_uid,
+                server_address: tablet_address.to_string(),
+                location: "us-central1".to_string(),
+                role: mock_v1::tablet::Role::ReadOnly as i32,
+                incarnation: b"inc_1".to_vec(),
+                distance: 0,
+                skip: false,
+            }],
+            generation: b"gen_1".to_vec(),
+        }],
+        key_recipes: Some(mock_v1::RecipeList {
+            schema_generation: b"schema_v1".to_vec(),
+            recipe: vec![mock_v1::KeyRecipe {
+                target: Some(mock_v1::key_recipe::Target::OperationUid(operation_uid)),
+                part: vec![
+                    mock_v1::key_recipe::Part {
+                        tag: 10,
+                        order: 0,
+                        null_order: 0,
+                        r#type: None,
+                        struct_identifiers: Vec::new(),
+                        value_type: None,
+                    },
+                    mock_v1::key_recipe::Part {
+                        tag: 0,
+                        order: mock_v1::key_recipe::part::Order::Ascending as i32,
+                        null_order: mock_v1::key_recipe::part::NullOrder::NullsFirst as i32,
+                        r#type: Some(mock_v1::Type {
+                            code: mock_v1::TypeCode::Int64 as i32,
+                            ..Default::default()
+                        }),
+                        struct_identifiers: Vec::new(),
+                        value_type: Some(mock_v1::key_recipe::part::ValueType::Identifier(
+                            "account_id".to_string(),
+                        )),
+                    },
+                ],
+            }],
+        }),
+    }
+}
+
+#[tokio_test_no_panics]
+async fn end_to_end_execute_query_with_key_recipe_routes_to_tablet_replica() -> anyhow::Result<()> {
+    let mut mock_gateway = create_base_mock();
+    let mut mock_tablet = create_base_mock();
+
+    // 1. Tablet mock expects direct execute_streaming_sql on cache hit
+    let tablet_called = Arc::new(AtomicBool::new(false));
+    let tablet_called_clone = Arc::clone(&tablet_called);
+    let captured_tablet_hint = Arc::new(Mutex::new(None));
+    let captured_tablet_hint_clone = Arc::clone(&captured_tablet_hint);
+
+    mock_tablet
+        .expect_execute_streaming_sql()
+        .times(1)
+        .returning(move |request| {
+            tablet_called_clone.store(true, Ordering::SeqCst);
+            *captured_tablet_hint_clone
+                .lock()
+                .expect("lock captured tablet hint") = request.get_ref().routing_hint.clone();
+            single_row_streaming_response("account_id", "42", None)
+        });
+
+    let (tablet_address, _tablet_server) = start("127.0.0.1:0", mock_tablet).await?;
+
+    // 2. Gateway mock expects initial cold-start query, capturing operation UID and returning recipe
+    let gateway_called = Arc::new(AtomicBool::new(false));
+    let gateway_called_clone = Arc::clone(&gateway_called);
+    let captured_gateway_hint = Arc::new(Mutex::new(None));
+    let captured_gateway_hint_clone = Arc::clone(&captured_gateway_hint);
+    let tablet_address_for_update = tablet_address.clone();
+
+    mock_gateway
+        .expect_execute_streaming_sql()
+        .times(1)
+        .returning(move |request| {
+            gateway_called_clone.store(true, Ordering::SeqCst);
+            *captured_gateway_hint_clone
+                .lock()
+                .expect("lock captured gateway hint") = request.get_ref().routing_hint.clone();
+
+            let operation_uid = request
+                .get_ref()
+                .routing_hint
+                .as_ref()
+                .map(|hint| hint.operation_uid)
+                .unwrap_or(1);
+
+            let cache_update = sample_query_mock_cache_update(
+                5555,
+                operation_uid,
+                9001,
+                &tablet_address_for_update,
+            );
+            single_row_streaming_response("account_id", "42", Some(cache_update))
+        });
+
+    let (database_client, _spanner, _gateway_server) =
+        setup_mock_database_client(mock_gateway).await?;
+
+    // 3. First execution (cold start): routes to gateway, assigns operation UID
+    let statement = Statement::builder("SELECT * FROM Users WHERE account_id = @account_id")
+        .add_param("account_id", 42i64)
+        .build();
+
+    let transaction = database_client.single_use().build();
+    let mut result_set = transaction.execute_query(statement.clone()).await?;
+    let row = result_set.next().await;
+    assert!(row.is_some(), "first query should yield a row from gateway");
+
+    assert!(
+        gateway_called.load(Ordering::SeqCst),
+        "gateway must be called on initial query execution"
+    );
+    let gateway_hint = captured_gateway_hint
+        .lock()
+        .expect("lock captured gateway hint")
+        .take()
+        .expect("routing hint must be attached on initial query execution");
+    assert_ne!(
+        gateway_hint.operation_uid, 0,
+        "operation UID must be assigned and sent on initial query execution"
+    );
+
+    // Pre-warm tablet connection in background/connection cache
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+    let client_config = database_client
+        .cache_updater()
+        .expect("cache updater must be present")
+        .client_config();
+    let _ = router
+        .connection_cache()
+        .get(&tablet_address, client_config)
+        .await?;
+
+    // Reset gateway flag to verify it is NOT called for subsequent keyed query
+    gateway_called.store(false, Ordering::SeqCst);
+
+    // 4. Second execution (cache hit): routes directly to tablet mock
+    let transaction2 = database_client.single_use().build();
+    let mut result_set2 = transaction2.execute_query(statement).await?;
+    let row2 = result_set2.next().await;
+    assert!(
+        row2.is_some(),
+        "second query should yield a row from tablet"
+    );
+
+    assert!(
+        tablet_called.load(Ordering::SeqCst),
+        "tablet mock must receive the query on cache hit"
+    );
+    assert!(
+        !gateway_called.load(Ordering::SeqCst),
+        "gateway mock must NOT receive the query after recipe and range are cached"
+    );
+
+    let tablet_hint = captured_tablet_hint
+        .lock()
+        .expect("lock captured tablet hint")
+        .take()
+        .expect("routing hint must be attached on tablet routed query");
+    assert_eq!(
+        tablet_hint.operation_uid, gateway_hint.operation_uid,
+        "operation UID must match the initially assigned UID"
+    );
+    assert_eq!(
+        tablet_hint.tablet_uid, 9001,
+        "routing hint tablet UID must match target tablet"
+    );
+    assert_eq!(
+        tablet_hint.database_id, 5555,
+        "routing hint database ID must match updated database ID"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn end_to_end_unary_execute_sql_with_key_recipe_routes_to_tablet_replica()
+-> anyhow::Result<()> {
+    let mut mock_gateway = create_base_mock();
+    let mut mock_tablet = create_base_mock();
+
+    // 1. Tablet mock expects direct unary execute_sql on cache hit
+    let tablet_called = Arc::new(AtomicBool::new(false));
+    let tablet_called_clone = Arc::clone(&tablet_called);
+    let captured_tablet_hint = Arc::new(Mutex::new(None));
+    let captured_tablet_hint_clone = Arc::clone(&captured_tablet_hint);
+
+    mock_tablet
+        .expect_execute_sql()
+        .times(1)
+        .returning(move |request| {
+            tablet_called_clone.store(true, Ordering::SeqCst);
+            *captured_tablet_hint_clone
+                .lock()
+                .expect("lock captured tablet hint") = request.get_ref().routing_hint.clone();
+            Ok(Response::new(mock_v1::ResultSet::default()))
+        });
+
+    let (tablet_address, _tablet_server) = start("127.0.0.1:0", mock_tablet).await?;
+
+    // 2. Gateway mock expects initial cold-start unary execute_sql, capturing operation UID and returning recipe
+    let gateway_called = Arc::new(AtomicBool::new(false));
+    let gateway_called_clone = Arc::clone(&gateway_called);
+    let captured_gateway_hint = Arc::new(Mutex::new(None));
+    let captured_gateway_hint_clone = Arc::clone(&captured_gateway_hint);
+    let tablet_address_for_update = tablet_address.clone();
+
+    mock_gateway
+        .expect_execute_sql()
+        .times(1)
+        .returning(move |request| {
+            gateway_called_clone.store(true, Ordering::SeqCst);
+            *captured_gateway_hint_clone
+                .lock()
+                .expect("lock captured gateway hint") = request.get_ref().routing_hint.clone();
+
+            let operation_uid = request
+                .get_ref()
+                .routing_hint
+                .as_ref()
+                .map(|hint| hint.operation_uid)
+                .unwrap_or(1);
+
+            let cache_update = sample_query_mock_cache_update(
+                5555,
+                operation_uid,
+                9001,
+                &tablet_address_for_update,
+            );
+            Ok(Response::new(mock_v1::ResultSet {
+                cache_update: Some(cache_update),
+                ..Default::default()
+            }))
+        });
+
+    let (database_client, _spanner, _gateway_server) =
+        setup_mock_database_client(mock_gateway).await?;
+
+    // 3. First execution (cold start): routes to gateway, assigns operation UID in bootstrap hint
+    let statement = Statement::builder("SELECT * FROM Users WHERE account_id = @account_id")
+        .add_param("account_id", 42i64)
+        .build();
+    let request1 = statement.clone().into_request();
+
+    let _ = database_client
+        .execute_sql(request1, RequestOptions::default(), 0)
+        .await?;
+
+    assert!(
+        gateway_called.load(Ordering::SeqCst),
+        "gateway must be called on initial unary execute_sql execution"
+    );
+    let gateway_hint = captured_gateway_hint
+        .lock()
+        .expect("lock captured gateway hint")
+        .take()
+        .expect("routing hint must be attached on initial unary execution");
+    assert_ne!(
+        gateway_hint.operation_uid, 0,
+        "operation UID must be assigned and sent on initial unary execution"
+    );
+
+    // Pre-warm tablet connection in background/connection cache
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+    let client_config = database_client
+        .cache_updater()
+        .expect("cache updater must be present")
+        .client_config();
+    let _ = router
+        .connection_cache()
+        .get(&tablet_address, client_config)
+        .await?;
+
+    // Reset gateway flag to verify it is NOT called for subsequent keyed query
+    gateway_called.store(false, Ordering::SeqCst);
+
+    // 4. Second execution (cache hit): routes directly to tablet mock with attached routing hint
+    let request2 = statement.into_request();
+    let _ = database_client
+        .execute_sql(request2, RequestOptions::default(), 0)
+        .await?;
+
+    assert!(
+        tablet_called.load(Ordering::SeqCst),
+        "tablet mock must receive unary execute_sql on cache hit"
+    );
+    assert!(
+        !gateway_called.load(Ordering::SeqCst),
+        "gateway mock must NOT receive unary execute_sql after recipe and range are cached"
+    );
+
+    let tablet_hint = captured_tablet_hint
+        .lock()
+        .expect("lock captured tablet hint")
+        .take()
+        .expect("routing hint must be attached on tablet routed unary query");
+    assert_eq!(
+        tablet_hint.operation_uid, gateway_hint.operation_uid,
+        "operation UID must match the initially assigned UID"
+    );
+    assert_eq!(
+        tablet_hint.tablet_uid, 9001,
+        "routing hint tablet UID must match target tablet"
+    );
+    assert_eq!(
+        tablet_hint.database_id, 5555,
+        "routing hint database ID must match updated database ID"
+    );
+
+    Ok(())
 }


### PR DESCRIPTION
Integrate prepared operations (`PreparedQuery` and `PreparedRead`) into `KeyRecipeCache` and wire them through `DatabaseClient` for unary and streaming queries and reads in Omni location-aware routing.

- Add `get_or_prepare_query` and `get_or_prepare_read` to `KeyRecipeCache`, storing descriptors in bounded `ClockStore` caches with monotonic UID generation and retention across schema updates.
- Add `extract_execute_sql_request_routing` and `extract_proto_read_request_routing` to resolve operation UIDs and binary routing keys.
- Unify routing hint resolution in `DatabaseClient::route_and_attach_hint`:
  - On cold start, attach a bootstrap `RoutingHint` (`operation_uid`, `database_id`, and `schema_generation`) to trigger server-side recipe learning.
  - On cache hit, attach the resolved tablet `RoutingHint` and route directly to the target tablet replica connection.
- Wire pre-routing across unary `execute_sql`, `execute_streaming_sql`, and `streaming_read`.