### PR TITLE
cleanup(storage): allow streaming types generation

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1568,8 +1568,6 @@ libraries:
     output: src/storage
     rust:
       resource_name_heuristic: true
-      include_bidi_streaming_methods: false
-      include_server_streaming_methods: false
       modules:
         - module_path: crate::generated::gapic_control::model
           name_overrides: .google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_buckets=CloudStorageBucketsOneOf,.google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_locations=CloudStorageLocationsOneOf

--- a/src/storage/src/generated/gapic/model.rs
+++ b/src/storage/src/generated/gapic/model.rs
@@ -1961,6 +1961,8 @@ impl wkt::message::Message for RestoreObjectRequest {
 }
 
 /// Request message for [ReadObject][google.storage.v2.Storage.ReadObject].
+///
+/// [google.storage.v2.Storage.ReadObject]: crate::client::StorageControl::read_object
 #[derive(Clone, Default, PartialEq)]
 #[non_exhaustive]
 pub struct ReadObjectRequest {


### PR DESCRIPTION
There is one small diff in the ReadObject documentation. The previous link was broken and the new one is as well.

This is part of a cleanup to enable streaming rpcs globally (skipping these will then be configured via the usual skipped_ids and included_ids).