### PR TITLE
ci: use e2-highmem-16 for large worker pool

### DIFF
--- a/.gcb/builds/resources/main.tf
+++ b/.gcb/builds/resources/main.tf
@@ -98,7 +98,7 @@ resource "google_cloudbuild_worker_pool" "large-pool" {
   location = "us-central1"
   worker_config {
     disk_size_gb   = 256
-    machine_type   = "e2-standard-32"
+    machine_type   = "e2-highmem-16"
     no_external_ip = false
   }
 }


### PR DESCRIPTION
Update the private worker pool `rust-sdk-pool-large` to use `e2-highmem-16` instances instead of `e2-standard-32`. This maintains the 128 GB memory capacity while naturally scaling down Cargo parallelism, providing 8 GB RAM per core to avoid Out of Memory (OOM) failures on large crates like `google-cloud-compute-v1`.