### PR TITLE
cleanup(spanner): generate streaming methods

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1487,8 +1487,6 @@ libraries:
     copyright_year: "2026"
     output: src/spanner
     rust:
-      include_bidi_streaming_methods: false
-      include_server_streaming_methods: false
       modules:
         - module_path: crate::generated::gapic_dataplane::model
           output: src/spanner/src/generated/convert/spanner

--- a/src/spanner/src/generated/gapic_dataplane/builder.rs
+++ b/src/spanner/src/generated/gapic_dataplane/builder.rs
@@ -570,6 +570,219 @@ pub mod spanner {
         }
     }
 
+    /// The request builder for [Spanner::execute_streaming_sql][crate::client::Spanner::execute_streaming_sql] calls.
+    #[derive(Clone, Debug)]
+    pub(crate) struct ExecuteStreamingSql(RequestBuilder<crate::model::ExecuteSqlRequest>);
+
+    impl ExecuteStreamingSql {
+        pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::Spanner>) -> Self {
+            Self(RequestBuilder::new(stub))
+        }
+
+        /// Sets the full request, replacing any prior values.
+        pub fn with_request<V: Into<crate::model::ExecuteSqlRequest>>(mut self, v: V) -> Self {
+            self.0.request = v.into();
+            self
+        }
+
+        /// Sets all the options, replacing any prior values.
+        pub fn with_options<V: Into<crate::RequestOptions>>(mut self, v: V) -> Self {
+            self.0.options = v.into();
+            self
+        }
+
+        /// Initiates the server stream.
+        pub async fn send(
+            self,
+        ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::PartialResultSet>>
+        {
+            (*self.0.stub)
+                .execute_streaming_sql(self.0.request, self.0.options)
+                .await
+        }
+
+        /// Sets the value of [session][crate::model::ExecuteSqlRequest::session].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_session<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.session = v.into();
+            self
+        }
+
+        /// Sets the value of [transaction][crate::model::ExecuteSqlRequest::transaction].
+        pub fn set_transaction<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<crate::model::TransactionSelector>,
+        {
+            self.0.request.transaction = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [transaction][crate::model::ExecuteSqlRequest::transaction].
+        pub fn set_or_clear_transaction<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<crate::model::TransactionSelector>,
+        {
+            self.0.request.transaction = v.map(|x| x.into());
+            self
+        }
+
+        /// Sets the value of [sql][crate::model::ExecuteSqlRequest::sql].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_sql<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.sql = v.into();
+            self
+        }
+
+        /// Sets the value of [params][crate::model::ExecuteSqlRequest::params].
+        pub fn set_params<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<wkt::Struct>,
+        {
+            self.0.request.params = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [params][crate::model::ExecuteSqlRequest::params].
+        pub fn set_or_clear_params<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<wkt::Struct>,
+        {
+            self.0.request.params = v.map(|x| x.into());
+            self
+        }
+
+        /// Sets the value of [param_types][crate::model::ExecuteSqlRequest::param_types].
+        pub fn set_param_types<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<crate::model::Type>,
+        {
+            self.0.request.param_types = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [resume_token][crate::model::ExecuteSqlRequest::resume_token].
+        pub fn set_resume_token<T: Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+            self.0.request.resume_token = v.into();
+            self
+        }
+
+        /// Sets the value of [query_mode][crate::model::ExecuteSqlRequest::query_mode].
+        pub fn set_query_mode<T: Into<crate::model::execute_sql_request::QueryMode>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.query_mode = v.into();
+            self
+        }
+
+        /// Sets the value of [partition_token][crate::model::ExecuteSqlRequest::partition_token].
+        pub fn set_partition_token<T: Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+            self.0.request.partition_token = v.into();
+            self
+        }
+
+        /// Sets the value of [seqno][crate::model::ExecuteSqlRequest::seqno].
+        pub fn set_seqno<T: Into<i64>>(mut self, v: T) -> Self {
+            self.0.request.seqno = v.into();
+            self
+        }
+
+        /// Sets the value of [query_options][crate::model::ExecuteSqlRequest::query_options].
+        pub fn set_query_options<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<crate::model::execute_sql_request::QueryOptions>,
+        {
+            self.0.request.query_options = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [query_options][crate::model::ExecuteSqlRequest::query_options].
+        pub fn set_or_clear_query_options<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<crate::model::execute_sql_request::QueryOptions>,
+        {
+            self.0.request.query_options = v.map(|x| x.into());
+            self
+        }
+
+        /// Sets the value of [request_options][crate::model::ExecuteSqlRequest::request_options].
+        pub fn set_request_options<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<crate::model::RequestOptions>,
+        {
+            self.0.request.request_options = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [request_options][crate::model::ExecuteSqlRequest::request_options].
+        pub fn set_or_clear_request_options<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<crate::model::RequestOptions>,
+        {
+            self.0.request.request_options = v.map(|x| x.into());
+            self
+        }
+
+        /// Sets the value of [directed_read_options][crate::model::ExecuteSqlRequest::directed_read_options].
+        pub fn set_directed_read_options<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<crate::model::DirectedReadOptions>,
+        {
+            self.0.request.directed_read_options = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [directed_read_options][crate::model::ExecuteSqlRequest::directed_read_options].
+        pub fn set_or_clear_directed_read_options<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<crate::model::DirectedReadOptions>,
+        {
+            self.0.request.directed_read_options = v.map(|x| x.into());
+            self
+        }
+
+        /// Sets the value of [data_boost_enabled][crate::model::ExecuteSqlRequest::data_boost_enabled].
+        pub fn set_data_boost_enabled<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.data_boost_enabled = v.into();
+            self
+        }
+
+        /// Sets the value of [last_statement][crate::model::ExecuteSqlRequest::last_statement].
+        pub fn set_last_statement<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.last_statement = v.into();
+            self
+        }
+
+        /// Sets the value of [routing_hint][crate::model::ExecuteSqlRequest::routing_hint].
+        pub fn set_routing_hint<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<crate::model::RoutingHint>,
+        {
+            self.0.request.routing_hint = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [routing_hint][crate::model::ExecuteSqlRequest::routing_hint].
+        pub fn set_or_clear_routing_hint<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<crate::model::RoutingHint>,
+        {
+            self.0.request.routing_hint = v.map(|x| x.into());
+            self
+        }
+    }
+
+    #[doc(hidden)]
+    impl crate::RequestBuilder for ExecuteStreamingSql {
+        fn request_options(&mut self) -> &mut crate::RequestOptions {
+            &mut self.0.options
+        }
+    }
+
     /// The request builder for [Spanner::execute_batch_dml][crate::client::Spanner::execute_batch_dml] calls.
     #[derive(Clone, Debug)]
     pub(crate) struct ExecuteBatchDml(RequestBuilder<crate::model::ExecuteBatchDmlRequest>);
@@ -882,6 +1095,213 @@ pub mod spanner {
 
     #[doc(hidden)]
     impl crate::RequestBuilder for Read {
+        fn request_options(&mut self) -> &mut crate::RequestOptions {
+            &mut self.0.options
+        }
+    }
+
+    /// The request builder for [Spanner::streaming_read][crate::client::Spanner::streaming_read] calls.
+    #[derive(Clone, Debug)]
+    pub(crate) struct StreamingRead(RequestBuilder<crate::model::ReadRequest>);
+
+    impl StreamingRead {
+        pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::Spanner>) -> Self {
+            Self(RequestBuilder::new(stub))
+        }
+
+        /// Sets the full request, replacing any prior values.
+        pub fn with_request<V: Into<crate::model::ReadRequest>>(mut self, v: V) -> Self {
+            self.0.request = v.into();
+            self
+        }
+
+        /// Sets all the options, replacing any prior values.
+        pub fn with_options<V: Into<crate::RequestOptions>>(mut self, v: V) -> Self {
+            self.0.options = v.into();
+            self
+        }
+
+        /// Initiates the server stream.
+        pub async fn send(
+            self,
+        ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::PartialResultSet>>
+        {
+            (*self.0.stub)
+                .streaming_read(self.0.request, self.0.options)
+                .await
+        }
+
+        /// Sets the value of [session][crate::model::ReadRequest::session].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_session<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.session = v.into();
+            self
+        }
+
+        /// Sets the value of [transaction][crate::model::ReadRequest::transaction].
+        pub fn set_transaction<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<crate::model::TransactionSelector>,
+        {
+            self.0.request.transaction = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [transaction][crate::model::ReadRequest::transaction].
+        pub fn set_or_clear_transaction<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<crate::model::TransactionSelector>,
+        {
+            self.0.request.transaction = v.map(|x| x.into());
+            self
+        }
+
+        /// Sets the value of [table][crate::model::ReadRequest::table].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_table<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.table = v.into();
+            self
+        }
+
+        /// Sets the value of [index][crate::model::ReadRequest::index].
+        pub fn set_index<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.index = v.into();
+            self
+        }
+
+        /// Sets the value of [columns][crate::model::ReadRequest::columns].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_columns<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.columns = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [key_set][crate::model::ReadRequest::key_set].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_key_set<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<crate::model::KeySet>,
+        {
+            self.0.request.key_set = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [key_set][crate::model::ReadRequest::key_set].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_or_clear_key_set<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<crate::model::KeySet>,
+        {
+            self.0.request.key_set = v.map(|x| x.into());
+            self
+        }
+
+        /// Sets the value of [limit][crate::model::ReadRequest::limit].
+        pub fn set_limit<T: Into<i64>>(mut self, v: T) -> Self {
+            self.0.request.limit = v.into();
+            self
+        }
+
+        /// Sets the value of [resume_token][crate::model::ReadRequest::resume_token].
+        pub fn set_resume_token<T: Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+            self.0.request.resume_token = v.into();
+            self
+        }
+
+        /// Sets the value of [partition_token][crate::model::ReadRequest::partition_token].
+        pub fn set_partition_token<T: Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+            self.0.request.partition_token = v.into();
+            self
+        }
+
+        /// Sets the value of [request_options][crate::model::ReadRequest::request_options].
+        pub fn set_request_options<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<crate::model::RequestOptions>,
+        {
+            self.0.request.request_options = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [request_options][crate::model::ReadRequest::request_options].
+        pub fn set_or_clear_request_options<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<crate::model::RequestOptions>,
+        {
+            self.0.request.request_options = v.map(|x| x.into());
+            self
+        }
+
+        /// Sets the value of [directed_read_options][crate::model::ReadRequest::directed_read_options].
+        pub fn set_directed_read_options<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<crate::model::DirectedReadOptions>,
+        {
+            self.0.request.directed_read_options = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [directed_read_options][crate::model::ReadRequest::directed_read_options].
+        pub fn set_or_clear_directed_read_options<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<crate::model::DirectedReadOptions>,
+        {
+            self.0.request.directed_read_options = v.map(|x| x.into());
+            self
+        }
+
+        /// Sets the value of [data_boost_enabled][crate::model::ReadRequest::data_boost_enabled].
+        pub fn set_data_boost_enabled<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.data_boost_enabled = v.into();
+            self
+        }
+
+        /// Sets the value of [order_by][crate::model::ReadRequest::order_by].
+        pub fn set_order_by<T: Into<crate::model::read_request::OrderBy>>(mut self, v: T) -> Self {
+            self.0.request.order_by = v.into();
+            self
+        }
+
+        /// Sets the value of [lock_hint][crate::model::ReadRequest::lock_hint].
+        pub fn set_lock_hint<T: Into<crate::model::read_request::LockHint>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.lock_hint = v.into();
+            self
+        }
+
+        /// Sets the value of [routing_hint][crate::model::ReadRequest::routing_hint].
+        pub fn set_routing_hint<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<crate::model::RoutingHint>,
+        {
+            self.0.request.routing_hint = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [routing_hint][crate::model::ReadRequest::routing_hint].
+        pub fn set_or_clear_routing_hint<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<crate::model::RoutingHint>,
+        {
+            self.0.request.routing_hint = v.map(|x| x.into());
+            self
+        }
+    }
+
+    #[doc(hidden)]
+    impl crate::RequestBuilder for StreamingRead {
         fn request_options(&mut self) -> &mut crate::RequestOptions {
             &mut self.0.options
         }
@@ -1476,6 +1896,152 @@ pub mod spanner {
 
     #[doc(hidden)]
     impl crate::RequestBuilder for PartitionRead {
+        fn request_options(&mut self) -> &mut crate::RequestOptions {
+            &mut self.0.options
+        }
+    }
+
+    /// The request builder for [Spanner::batch_write][crate::client::Spanner::batch_write] calls.
+    #[derive(Clone, Debug)]
+    pub(crate) struct BatchWrite(RequestBuilder<crate::model::BatchWriteRequest>);
+
+    impl BatchWrite {
+        pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::Spanner>) -> Self {
+            Self(RequestBuilder::new(stub))
+        }
+
+        /// Sets the full request, replacing any prior values.
+        pub fn with_request<V: Into<crate::model::BatchWriteRequest>>(mut self, v: V) -> Self {
+            self.0.request = v.into();
+            self
+        }
+
+        /// Sets all the options, replacing any prior values.
+        pub fn with_options<V: Into<crate::RequestOptions>>(mut self, v: V) -> Self {
+            self.0.options = v.into();
+            self
+        }
+
+        /// Initiates the server stream.
+        pub async fn send(
+            self,
+        ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::BatchWriteResponse>>
+        {
+            (*self.0.stub)
+                .batch_write(self.0.request, self.0.options)
+                .await
+        }
+
+        /// Sets the value of [session][crate::model::BatchWriteRequest::session].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_session<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.session = v.into();
+            self
+        }
+
+        /// Sets the value of [request_options][crate::model::BatchWriteRequest::request_options].
+        pub fn set_request_options<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<crate::model::RequestOptions>,
+        {
+            self.0.request.request_options = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [request_options][crate::model::BatchWriteRequest::request_options].
+        pub fn set_or_clear_request_options<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<crate::model::RequestOptions>,
+        {
+            self.0.request.request_options = v.map(|x| x.into());
+            self
+        }
+
+        /// Sets the value of [mutation_groups][crate::model::BatchWriteRequest::mutation_groups].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_mutation_groups<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::batch_write_request::MutationGroup>,
+        {
+            use std::iter::Iterator;
+            self.0.request.mutation_groups = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [exclude_txn_from_change_streams][crate::model::BatchWriteRequest::exclude_txn_from_change_streams].
+        pub fn set_exclude_txn_from_change_streams<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.exclude_txn_from_change_streams = v.into();
+            self
+        }
+    }
+
+    #[doc(hidden)]
+    impl crate::RequestBuilder for BatchWrite {
+        fn request_options(&mut self) -> &mut crate::RequestOptions {
+            &mut self.0.options
+        }
+    }
+
+    /// The request builder for [Spanner::fetch_cache_update][crate::client::Spanner::fetch_cache_update] calls.
+    #[derive(Clone, Debug)]
+    pub(crate) struct FetchCacheUpdate(RequestBuilder<crate::model::FetchCacheUpdateRequest>);
+
+    impl FetchCacheUpdate {
+        pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::Spanner>) -> Self {
+            Self(RequestBuilder::new(stub))
+        }
+
+        /// Sets the full request, replacing any prior values.
+        pub fn with_request<V: Into<crate::model::FetchCacheUpdateRequest>>(
+            mut self,
+            v: V,
+        ) -> Self {
+            self.0.request = v.into();
+            self
+        }
+
+        /// Sets all the options, replacing any prior values.
+        pub fn with_options<V: Into<crate::RequestOptions>>(mut self, v: V) -> Self {
+            self.0.options = v.into();
+            self
+        }
+
+        /// Initiates the server stream.
+        pub async fn send(
+            self,
+        ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::CacheUpdate>>
+        {
+            (*self.0.stub)
+                .fetch_cache_update(self.0.request, self.0.options)
+                .await
+        }
+
+        /// Sets the value of [database][crate::model::FetchCacheUpdateRequest::database].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_database<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.database = v.into();
+            self
+        }
+
+        /// Sets the value of [max_recipe_count][crate::model::FetchCacheUpdateRequest::max_recipe_count].
+        pub fn set_max_recipe_count<T: Into<i32>>(mut self, v: T) -> Self {
+            self.0.request.max_recipe_count = v.into();
+            self
+        }
+
+        /// Sets the value of [max_range_count][crate::model::FetchCacheUpdateRequest::max_range_count].
+        pub fn set_max_range_count<T: Into<i32>>(mut self, v: T) -> Self {
+            self.0.request.max_range_count = v.into();
+            self
+        }
+    }
+
+    #[doc(hidden)]
+    impl crate::RequestBuilder for FetchCacheUpdate {
         fn request_options(&mut self) -> &mut crate::RequestOptions {
             &mut self.0.options
         }

--- a/src/spanner/src/generated/gapic_dataplane/client.rs
+++ b/src/spanner/src/generated/gapic_dataplane/client.rs
@@ -133,9 +133,24 @@ impl Spanner {
     /// The query string can be SQL or [Graph Query Language
     /// (GQL)](https://cloud.google.com/spanner/docs/reference/standard-sql/graph-intro).
     ///
+    /// [google.spanner.v1.Spanner.ExecuteStreamingSql]: crate::client::Spanner::execute_streaming_sql
     /// [google.spanner.v1.Transaction]: crate::model::Transaction
     pub(crate) fn execute_sql(&self) -> super::builder::spanner::ExecuteSql {
         super::builder::spanner::ExecuteSql::new(self.inner.clone())
+    }
+
+    /// Like [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], except returns the
+    /// result set as a stream. Unlike
+    /// [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], there is no limit on
+    /// the size of the returned result set. However, no individual row in the
+    /// result set can exceed 100 MiB, and no column value can exceed 10 MiB.
+    ///
+    /// The query string can be SQL or [Graph Query Language
+    /// (GQL)](https://cloud.google.com/spanner/docs/reference/standard-sql/graph-intro).
+    ///
+    /// [google.spanner.v1.Spanner.ExecuteSql]: crate::client::Spanner::execute_sql
+    pub(crate) fn execute_streaming_sql(&self) -> super::builder::spanner::ExecuteStreamingSql {
+        super::builder::spanner::ExecuteStreamingSql::new(self.inner.clone())
     }
 
     /// Executes a batch of SQL DML statements. This method allows many statements
@@ -173,9 +188,21 @@ impl Spanner {
     /// [StreamingRead][google.spanner.v1.Spanner.StreamingRead] instead.
     ///
     /// [google.spanner.v1.Spanner.ExecuteSql]: crate::client::Spanner::execute_sql
+    /// [google.spanner.v1.Spanner.StreamingRead]: crate::client::Spanner::streaming_read
     /// [google.spanner.v1.Transaction]: crate::model::Transaction
     pub(crate) fn read(&self) -> super::builder::spanner::Read {
         super::builder::spanner::Read::new(self.inner.clone())
+    }
+
+    /// Like [Read][google.spanner.v1.Spanner.Read], except returns the result set
+    /// as a stream. Unlike [Read][google.spanner.v1.Spanner.Read], there is no
+    /// limit on the size of the returned result set. However, no individual row in
+    /// the result set can exceed 100 MiB, and no column value can exceed
+    /// 10 MiB.
+    ///
+    /// [google.spanner.v1.Spanner.Read]: crate::client::Spanner::read
+    pub(crate) fn streaming_read(&self) -> super::builder::spanner::StreamingRead {
+        super::builder::spanner::StreamingRead::new(self.inner.clone())
     }
 
     /// Begins a new transaction. This step can often be skipped:
@@ -237,6 +264,8 @@ impl Spanner {
     /// is deleted, is idle for too long, begins a new transaction, or becomes too
     /// old. When any of these happen, it isn't possible to resume the query, and
     /// the whole operation must be restarted from the beginning.
+    ///
+    /// [google.spanner.v1.Spanner.ExecuteStreamingSql]: crate::client::Spanner::execute_streaming_sql
     pub(crate) fn partition_query(&self) -> super::builder::spanner::PartitionQuery {
         super::builder::spanner::PartitionQuery::new(self.inner.clone())
     }
@@ -255,7 +284,41 @@ impl Spanner {
     /// is deleted, is idle for too long, begins a new transaction, or becomes too
     /// old. When any of these happen, it isn't possible to resume the read, and
     /// the whole operation must be restarted from the beginning.
+    ///
+    /// [google.spanner.v1.Spanner.StreamingRead]: crate::client::Spanner::streaming_read
     pub(crate) fn partition_read(&self) -> super::builder::spanner::PartitionRead {
         super::builder::spanner::PartitionRead::new(self.inner.clone())
+    }
+
+    /// Batches the supplied mutation groups in a collection of efficient
+    /// transactions. All mutations in a group are committed atomically. However,
+    /// mutations across groups can be committed non-atomically in an unspecified
+    /// order and thus, they must be independent of each other. Partial failure is
+    /// possible, that is, some groups might have been committed successfully,
+    /// while some might have failed. The results of individual batches are
+    /// streamed into the response as the batches are applied.
+    ///
+    /// `BatchWrite` requests are not replay protected, meaning that each mutation
+    /// group can be applied more than once. Replays of non-idempotent mutations
+    /// can have undesirable effects. For example, replays of an insert mutation
+    /// can produce an already exists error or if you use generated or commit
+    /// timestamp-based keys, it can result in additional rows being added to the
+    /// mutation's table. We recommend structuring your mutation groups to be
+    /// idempotent to avoid this issue.
+    pub(crate) fn batch_write(&self) -> super::builder::spanner::BatchWrite {
+        super::builder::spanner::BatchWrite::new(self.inner.clone())
+    }
+
+    /// Retrieves a cache update for a given database.
+    ///
+    /// This RPC can be used to warm up the client cache by fetching key recipes
+    /// and server information for a given database. It is recommended to call
+    /// this RPC at the beginning of the client's lifecycle, prior to any other
+    /// data plane operations.
+    ///
+    /// The cache update is returned as a stream because the response can be too
+    /// large to fit into a single `CacheUpdate` message.
+    pub(crate) fn fetch_cache_update(&self) -> super::builder::spanner::FetchCacheUpdate {
+        super::builder::spanner::FetchCacheUpdate::new(self.inner.clone())
     }
 }

--- a/src/spanner/src/generated/gapic_dataplane/model.rs
+++ b/src/spanner/src/generated/gapic_dataplane/model.rs
@@ -6743,6 +6743,7 @@ pub mod directed_read_options {
 /// [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql].
 ///
 /// [google.spanner.v1.Spanner.ExecuteSql]: crate::client::Spanner::execute_sql
+/// [google.spanner.v1.Spanner.ExecuteStreamingSql]: crate::client::Spanner::execute_streaming_sql
 #[derive(Clone, Default, PartialEq)]
 #[non_exhaustive]
 pub struct ExecuteSqlRequest {
@@ -7728,6 +7729,8 @@ pub struct PartitionQueryRequest {
     /// [`ExecuteStreamingSql`][google.spanner.v1.Spanner.ExecuteStreamingSql] with
     /// a `PartitionedDml` transaction for large, partition-friendly DML
     /// operations.
+    ///
+    /// [google.spanner.v1.Spanner.ExecuteStreamingSql]: crate::client::Spanner::execute_streaming_sql
     pub sql: std::string::String,
 
     /// Optional. Parameter names and values that bind to placeholders in the SQL
@@ -8102,6 +8105,7 @@ impl wkt::message::Message for PartitionResponse {
 /// [StreamingRead][google.spanner.v1.Spanner.StreamingRead].
 ///
 /// [google.spanner.v1.Spanner.Read]: crate::client::Spanner::read
+/// [google.spanner.v1.Spanner.StreamingRead]: crate::client::Spanner::streaming_read
 #[derive(Clone, Default, PartialEq)]
 #[non_exhaustive]
 pub struct ReadRequest {
@@ -9138,6 +9142,8 @@ impl wkt::message::Message for RollbackRequest {
 }
 
 /// The request for [BatchWrite][google.spanner.v1.Spanner.BatchWrite].
+///
+/// [google.spanner.v1.Spanner.BatchWrite]: crate::client::Spanner::batch_write
 #[derive(Clone, Default, PartialEq)]
 #[non_exhaustive]
 pub struct BatchWriteRequest {
@@ -9342,6 +9348,8 @@ impl wkt::message::Message for BatchWriteResponse {
 
 /// The request for
 /// [FetchCacheUpdate][google.spanner.v1.Spanner.FetchCacheUpdate].
+///
+/// [google.spanner.v1.Spanner.FetchCacheUpdate]: crate::client::Spanner::fetch_cache_update
 #[derive(Clone, Default, PartialEq)]
 #[non_exhaustive]
 pub struct FetchCacheUpdateRequest {

--- a/src/spanner/src/generated/gapic_dataplane/stub.rs
+++ b/src/spanner/src/generated/gapic_dataplane/stub.rs
@@ -99,6 +99,19 @@ pub trait Spanner: std::fmt::Debug + Send + Sync {
         gaxi::unimplemented::unimplemented_stub()
     }
 
+    /// Implements [super::client::Spanner::execute_streaming_sql].
+    fn execute_streaming_sql(
+        &self,
+        _req: crate::model::ExecuteSqlRequest,
+        _options: crate::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<
+            google_cloud_gax::streaming::ResponseStream<crate::model::PartialResultSet>,
+        >,
+    > + Send {
+        gaxi::unimplemented::unimplemented_server_streaming_stub()
+    }
+
     /// Implements [super::client::Spanner::execute_batch_dml].
     fn execute_batch_dml(
         &self,
@@ -118,6 +131,19 @@ pub trait Spanner: std::fmt::Debug + Send + Sync {
     ) -> impl std::future::Future<Output = crate::Result<crate::Response<crate::model::ResultSet>>> + Send
     {
         gaxi::unimplemented::unimplemented_stub()
+    }
+
+    /// Implements [super::client::Spanner::streaming_read].
+    fn streaming_read(
+        &self,
+        _req: crate::model::ReadRequest,
+        _options: crate::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<
+            google_cloud_gax::streaming::ResponseStream<crate::model::PartialResultSet>,
+        >,
+    > + Send {
+        gaxi::unimplemented::unimplemented_server_streaming_stub()
     }
 
     /// Implements [super::client::Spanner::begin_transaction].
@@ -170,5 +196,31 @@ pub trait Spanner: std::fmt::Debug + Send + Sync {
         Output = crate::Result<crate::Response<crate::model::PartitionResponse>>,
     > + Send {
         gaxi::unimplemented::unimplemented_stub()
+    }
+
+    /// Implements [super::client::Spanner::batch_write].
+    fn batch_write(
+        &self,
+        _req: crate::model::BatchWriteRequest,
+        _options: crate::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<
+            google_cloud_gax::streaming::ResponseStream<crate::model::BatchWriteResponse>,
+        >,
+    > + Send {
+        gaxi::unimplemented::unimplemented_server_streaming_stub()
+    }
+
+    /// Implements [super::client::Spanner::fetch_cache_update].
+    fn fetch_cache_update(
+        &self,
+        _req: crate::model::FetchCacheUpdateRequest,
+        _options: crate::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<
+            google_cloud_gax::streaming::ResponseStream<crate::model::CacheUpdate>,
+        >,
+    > + Send {
+        gaxi::unimplemented::unimplemented_server_streaming_stub()
     }
 }

--- a/src/spanner/src/generated/gapic_dataplane/stub/dynamic.rs
+++ b/src/spanner/src/generated/gapic_dataplane/stub/dynamic.rs
@@ -53,6 +53,12 @@ pub trait Spanner: std::fmt::Debug + Send + Sync {
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<crate::model::ResultSet>>;
 
+    async fn execute_streaming_sql(
+        &self,
+        req: crate::model::ExecuteSqlRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<google_cloud_gax::streaming::ResponseStream<crate::model::PartialResultSet>>;
+
     async fn execute_batch_dml(
         &self,
         req: crate::model::ExecuteBatchDmlRequest,
@@ -64,6 +70,12 @@ pub trait Spanner: std::fmt::Debug + Send + Sync {
         req: crate::model::ReadRequest,
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<crate::model::ResultSet>>;
+
+    async fn streaming_read(
+        &self,
+        req: crate::model::ReadRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<google_cloud_gax::streaming::ResponseStream<crate::model::PartialResultSet>>;
 
     async fn begin_transaction(
         &self,
@@ -94,6 +106,18 @@ pub trait Spanner: std::fmt::Debug + Send + Sync {
         req: crate::model::PartitionReadRequest,
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<crate::model::PartitionResponse>>;
+
+    async fn batch_write(
+        &self,
+        req: crate::model::BatchWriteRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<google_cloud_gax::streaming::ResponseStream<crate::model::BatchWriteResponse>>;
+
+    async fn fetch_cache_update(
+        &self,
+        req: crate::model::FetchCacheUpdateRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<google_cloud_gax::streaming::ResponseStream<crate::model::CacheUpdate>>;
 }
 
 /// All implementations of [super::Spanner] also implement [Spanner].
@@ -154,6 +178,16 @@ impl<T: super::Spanner> Spanner for T {
     }
 
     /// Forwards the call to the implementation provided by `T`.
+    async fn execute_streaming_sql(
+        &self,
+        req: crate::model::ExecuteSqlRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<google_cloud_gax::streaming::ResponseStream<crate::model::PartialResultSet>>
+    {
+        T::execute_streaming_sql(self, req, options).await
+    }
+
+    /// Forwards the call to the implementation provided by `T`.
     async fn execute_batch_dml(
         &self,
         req: crate::model::ExecuteBatchDmlRequest,
@@ -169,6 +203,16 @@ impl<T: super::Spanner> Spanner for T {
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<crate::model::ResultSet>> {
         T::read(self, req, options).await
+    }
+
+    /// Forwards the call to the implementation provided by `T`.
+    async fn streaming_read(
+        &self,
+        req: crate::model::ReadRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<google_cloud_gax::streaming::ResponseStream<crate::model::PartialResultSet>>
+    {
+        T::streaming_read(self, req, options).await
     }
 
     /// Forwards the call to the implementation provided by `T`.
@@ -214,5 +258,24 @@ impl<T: super::Spanner> Spanner for T {
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<crate::model::PartitionResponse>> {
         T::partition_read(self, req, options).await
+    }
+
+    /// Forwards the call to the implementation provided by `T`.
+    async fn batch_write(
+        &self,
+        req: crate::model::BatchWriteRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<google_cloud_gax::streaming::ResponseStream<crate::model::BatchWriteResponse>>
+    {
+        T::batch_write(self, req, options).await
+    }
+
+    /// Forwards the call to the implementation provided by `T`.
+    async fn fetch_cache_update(
+        &self,
+        req: crate::model::FetchCacheUpdateRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<google_cloud_gax::streaming::ResponseStream<crate::model::CacheUpdate>> {
+        T::fetch_cache_update(self, req, options).await
     }
 }

--- a/src/spanner/src/generated/gapic_dataplane/tracing.rs
+++ b/src/spanner/src/generated/gapic_dataplane/tracing.rs
@@ -22,6 +22,7 @@ where
     T: super::stub::Spanner + std::fmt::Debug + Send + Sync,
 {
     inner: T,
+    #[allow(dead_code)]
     duration: gaxi::observability::DurationMetric,
 }
 
@@ -125,6 +126,14 @@ where
         pending.await
     }
 
+    async fn execute_streaming_sql(
+        &self,
+        req: crate::model::ExecuteSqlRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::PartialResultSet>> {
+        self.inner.execute_streaming_sql(req, options).await
+    }
+
     #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn execute_batch_dml(
         &self,
@@ -151,6 +160,14 @@ where
             method: "client::Spanner::read",
             self.inner.read(req, options));
         pending.await
+    }
+
+    async fn streaming_read(
+        &self,
+        req: crate::model::ReadRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::PartialResultSet>> {
+        self.inner.streaming_read(req, options).await
     }
 
     #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
@@ -221,6 +238,22 @@ where
             method: "client::Spanner::partition_read",
             self.inner.partition_read(req, options));
         pending.await
+    }
+
+    async fn batch_write(
+        &self,
+        req: crate::model::BatchWriteRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::BatchWriteResponse>> {
+        self.inner.batch_write(req, options).await
+    }
+
+    async fn fetch_cache_update(
+        &self,
+        req: crate::model::FetchCacheUpdateRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::CacheUpdate>> {
+        self.inner.fetch_cache_update(req, options).await
     }
 }
 

--- a/src/spanner/src/generated/gapic_dataplane/transport.rs
+++ b/src/spanner/src/generated/gapic_dataplane/transport.rs
@@ -399,6 +399,46 @@ impl super::stub::Spanner for Spanner {
             .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::ResultSet>)
     }
 
+    async fn execute_streaming_sql(
+        &self,
+        req: crate::model::ExecuteSqlRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::PartialResultSet>> {
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "google.spanner.v1.Spanner",
+                "ExecuteStreamingSql",
+            ));
+            e
+        };
+        let path =
+            http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/ExecuteStreamingSql");
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.session)
+            .map(|s| s.as_str())
+            .map(|v| format!("session={v}"))]
+        .into_iter()
+        .flatten()
+        .fold(String::new(), |b, p| b + "&" + &p);
+
+        self.inner
+            .execute_server_streaming::<
+                crate::model::ExecuteSqlRequest,
+                crate::model::PartialResultSet,
+                crate::google::spanner::v1::ExecuteSqlRequest,
+                crate::google::spanner::v1::PartialResultSet,
+            >(
+                extensions,
+                path,
+                req,
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+    }
+
     async fn execute_batch_dml(
         &self,
         req: crate::model::ExecuteBatchDmlRequest,
@@ -509,6 +549,45 @@ impl super::stub::Spanner for Spanner {
             )
             .await
             .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::ResultSet>)
+    }
+
+    async fn streaming_read(
+        &self,
+        req: crate::model::ReadRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::PartialResultSet>> {
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "google.spanner.v1.Spanner",
+                "StreamingRead",
+            ));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/StreamingRead");
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.session)
+            .map(|s| s.as_str())
+            .map(|v| format!("session={v}"))]
+        .into_iter()
+        .flatten()
+        .fold(String::new(), |b, p| b + "&" + &p);
+
+        self.inner
+            .execute_server_streaming::<
+                crate::model::ReadRequest,
+                crate::model::PartialResultSet,
+                crate::google::spanner::v1::ReadRequest,
+                crate::google::spanner::v1::PartialResultSet,
+            >(
+                extensions,
+                path,
+                req,
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
     }
 
     async fn begin_transaction(
@@ -790,5 +869,84 @@ impl super::stub::Spanner for Spanner {
             )
             .await
             .and_then(gaxi::grpc::to_gax_response::<TR, crate::model::PartitionResponse>)
+    }
+
+    async fn batch_write(
+        &self,
+        req: crate::model::BatchWriteRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::BatchWriteResponse>> {
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "google.spanner.v1.Spanner",
+                "BatchWrite",
+            ));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/BatchWrite");
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.session)
+            .map(|s| s.as_str())
+            .map(|v| format!("session={v}"))]
+        .into_iter()
+        .flatten()
+        .fold(String::new(), |b, p| b + "&" + &p);
+
+        self.inner
+            .execute_server_streaming::<
+                crate::model::BatchWriteRequest,
+                crate::model::BatchWriteResponse,
+                crate::google::spanner::v1::BatchWriteRequest,
+                crate::google::spanner::v1::BatchWriteResponse,
+            >(
+                extensions,
+                path,
+                req,
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+    }
+
+    async fn fetch_cache_update(
+        &self,
+        req: crate::model::FetchCacheUpdateRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseStream<crate::model::CacheUpdate>> {
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "google.spanner.v1.Spanner",
+                "FetchCacheUpdate",
+            ));
+            e
+        };
+        let path =
+            http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/FetchCacheUpdate");
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.database)
+            .map(|s| s.as_str())
+            .map(|v| format!("database={v}"))]
+        .into_iter()
+        .flatten()
+        .fold(String::new(), |b, p| b + "&" + &p);
+
+        self.inner
+            .execute_server_streaming::<
+                crate::model::FetchCacheUpdateRequest,
+                crate::model::CacheUpdate,
+                crate::google::spanner::v1::FetchCacheUpdateRequest,
+                crate::google::spanner::v1::CacheUpdate,
+            >(
+                extensions,
+                path,
+                req,
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
     }
 }


### PR DESCRIPTION
This change removes the gate for streaming methods on spanner. I intend to remove the include_*_streaming_methods configuration.

An alternative if you do not want to include these methods in your crate is to add them to skipped_ids.

          skipped_ids: 
          - .google.spanner.v1.Spanner.ExecuteStreamingSql
          - .google.spanner.v1.Spanner.StreamingRead
          - .google.spanner.v1.Spanner.BatchWrite
          - .google.spanner.v1.Spanner.FetchCacheUpdate

