### PR TITLE
ci: limit cargo build jobs to prevent OOM

### DIFF
--- a/.gcb/complex.yaml
+++ b/.gcb/complex.yaml
@@ -22,7 +22,7 @@ options:
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY
   env:
-    - CARGO_BUILD_JOBS=24
+    - CARGO_BUILD_JOBS=16
     - GOOGLE_CLOUD_RUST_TEST_RUNNING_ON_GCB=1
     - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
     - SCCACHE_GCS_BUCKET=${PROJECT_ID}-build-cache

--- a/.gcb/complex.yaml
+++ b/.gcb/complex.yaml
@@ -22,6 +22,7 @@ options:
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY
   env:
+    - CARGO_BUILD_JOBS=24
     - GOOGLE_CLOUD_RUST_TEST_RUNNING_ON_GCB=1
     - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
     - SCCACHE_GCS_BUCKET=${PROJECT_ID}-build-cache

--- a/.gcb/coverage.yaml
+++ b/.gcb/coverage.yaml
@@ -22,7 +22,7 @@ options:
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY
   env:
-    - CARGO_BUILD_JOBS=24
+    - CARGO_BUILD_JOBS=16
     - GOOGLE_CLOUD_RUST_TEST_RUNNING_ON_GCB=1
     - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
     - SCCACHE_GCS_BUCKET=${PROJECT_ID}-build-cache

--- a/.gcb/coverage.yaml
+++ b/.gcb/coverage.yaml
@@ -22,6 +22,7 @@ options:
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY
   env:
+    - CARGO_BUILD_JOBS=24
     - GOOGLE_CLOUD_RUST_TEST_RUNNING_ON_GCB=1
     - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
     - SCCACHE_GCS_BUCKET=${PROJECT_ID}-build-cache

--- a/.gcb/cryptoproviders.yaml
+++ b/.gcb/cryptoproviders.yaml
@@ -17,6 +17,7 @@ options:
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY
   env:
+    - CARGO_BUILD_JOBS=24
     - GOOGLE_CLOUD_RUST_TEST_RUNNING_ON_GCB=1
     - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
     - GOOGLE_CLOUD_RUST_TEST_SERVICE_ACCOUNT=rust-sdk-test@${PROJECT_ID}.iam.gserviceaccount.com

--- a/.gcb/cryptoproviders.yaml
+++ b/.gcb/cryptoproviders.yaml
@@ -17,7 +17,7 @@ options:
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY
   env:
-    - CARGO_BUILD_JOBS=24
+    - CARGO_BUILD_JOBS=16
     - GOOGLE_CLOUD_RUST_TEST_RUNNING_ON_GCB=1
     - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
     - GOOGLE_CLOUD_RUST_TEST_SERVICE_ACCOUNT=rust-sdk-test@${PROJECT_ID}.iam.gserviceaccount.com

--- a/.gcb/format.yaml
+++ b/.gcb/format.yaml
@@ -22,7 +22,7 @@ options:
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY
   env:
-    - CARGO_BUILD_JOBS=24
+    - CARGO_BUILD_JOBS=16
     - GOOGLE_CLOUD_RUST_TEST_RUNNING_ON_GCB=1
     - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
     - SCCACHE_GCS_BUCKET=${PROJECT_ID}-build-cache

--- a/.gcb/format.yaml
+++ b/.gcb/format.yaml
@@ -22,6 +22,7 @@ options:
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY
   env:
+    - CARGO_BUILD_JOBS=24
     - GOOGLE_CLOUD_RUST_TEST_RUNNING_ON_GCB=1
     - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
     - SCCACHE_GCS_BUCKET=${PROJECT_ID}-build-cache

--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -17,6 +17,7 @@ options:
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY
   env:
+    - CARGO_BUILD_JOBS=24
     - GOOGLE_CLOUD_RUST_TEST_RUNNING_ON_GCB=1
     - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
     - GOOGLE_CLOUD_RUST_TEST_SERVICE_ACCOUNT=rust-sdk-test@${PROJECT_ID}.iam.gserviceaccount.com

--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -17,7 +17,7 @@ options:
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY
   env:
-    - CARGO_BUILD_JOBS=24
+    - CARGO_BUILD_JOBS=16
     - GOOGLE_CLOUD_RUST_TEST_RUNNING_ON_GCB=1
     - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
     - GOOGLE_CLOUD_RUST_TEST_SERVICE_ACCOUNT=rust-sdk-test@${PROJECT_ID}.iam.gserviceaccount.com

--- a/.gcb/msrv.yaml
+++ b/.gcb/msrv.yaml
@@ -19,6 +19,7 @@ options:
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY
   env:
+    - CARGO_BUILD_JOBS=24
     - GOOGLE_CLOUD_RUST_TEST_RUNNING_ON_GCB=1
     - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
     - SCCACHE_GCS_BUCKET=${PROJECT_ID}-build-cache

--- a/.gcb/msrv.yaml
+++ b/.gcb/msrv.yaml
@@ -19,7 +19,7 @@ options:
   substitutionOption: 'ALLOW_LOOSE'
   logging: CLOUD_LOGGING_ONLY
   env:
-    - CARGO_BUILD_JOBS=24
+    - CARGO_BUILD_JOBS=16
     - GOOGLE_CLOUD_RUST_TEST_RUNNING_ON_GCB=1
     - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
     - SCCACHE_GCS_BUCKET=${PROJECT_ID}-build-cache


### PR DESCRIPTION
Attempt to fix #6623 

Limit the number of parallel cargo build jobs to 24 across all GCB configurations to prevent Out of Memory errors. 

Our GCB worker pools run on instances which provide 32 vCPUs. By default, cargo utilizes all 32 vCPUs, severely dropping the available memory per `rustc` job (~4GB per job). This might have caused starvation and OOM crashes during heavy macro expansion.

By setting `CARGO_BUILD_JOBS=24`, we throttle cargo compilation to a safer memory limit (allocating ~5.3GB per job) without slowing down too much.