### PR TITLE
ci: pin tinyvec to avoid 1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9974,8 +9974,7 @@ dependencies = [
 [[package]]
 name = "tinyvec"
 version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+source = "git+https://github.com/Lokathor/tinyvec?tag=v1.12.0#347ddc6463159eec38d3758a8881a22f44d50373"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -623,3 +623,9 @@ unexpected_cfgs = { level = "deny", check-cfg = [
 
 [workspace.metadata.cargo-machete]
 ignored = ["h2", "lazy_static", "pin-project", "rustc_version"]
+
+[patch.crates-io]
+# TODO(#6656) - unpin `tinyvec`
+# `tinyvec` is an indirect dependency. We need to avoid 1.13.0 because of:
+# https://github.com/Lokathor/tinyvec/issues/225
+tinyvec = { git = "https://github.com/Lokathor/tinyvec", tag = "v1.12.0" }


### PR DESCRIPTION
For #6656 