### PR TITLE
cleanup(pubsub): forwards lease shutdown actions on drain

### DIFF
--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -146,10 +146,8 @@ async fn shutdown<L>(mut state: LeaseState<L>, mut ack_rx: UnboundedReceiver<Act
 where
     L: Leaser + Clone + Send + 'static,
 {
-    while let Ok(r) = ack_rx.try_recv() {
-        if let Action::Ack(ack_id) = r {
-            state.process(Action::Ack(ack_id));
-        }
+    while let Ok(a) = ack_rx.try_recv() {
+        state.process(a);
     }
     state.shutdown().await;
 }


### PR DESCRIPTION
Related to #6675 

Note that (1) we do not support waiting for exactly once acks when configured to `NackImmediately` #5109 and (2) all known messages are nacked, so it is not like we are dropping nacks.

This PR just refactors the code to forward exactly once acks to the lease state (which will then drop them).