### PR TITLE
cleanup(bigquery): centralize test helpers

### DIFF
--- a/src/bigquery/src/write.rs
+++ b/src/bigquery/src/write.rs
@@ -37,3 +37,6 @@ mod status;
 
 #[allow(dead_code)]
 pub(crate) mod generated;
+
+#[cfg(test)]
+mod test;

--- a/src/bigquery/src/write/arrow/buffered.rs
+++ b/src/bigquery/src/write/arrow/buffered.rs
@@ -66,17 +66,16 @@ impl BufferedWriter {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::runner::tests::*;
-    use super::super::super::transport::tests::*;
     use super::*;
     use crate::error::AppendError;
+    use crate::write::test::*;
     use bigquery_grpc_mock::{MockBigQueryWrite, start};
     use gaxi::grpc::tonic::Response as TonicResponse;
     use tokio::sync::mpsc;
 
     #[tokio::test]
     async fn request_fields() -> anyhow::Result<()> {
-        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
+        let transport = Arc::new(test_transport("http://ignored:1").await?);
         let writer = BufferedWriter::new(transport, write_stream(), schema());
         assert_eq!(writer.write_stream(), write_stream());
 
@@ -183,14 +182,6 @@ mod tests {
         assert_eq!(flush2.offset, 2);
 
         Ok(())
-    }
-
-    fn write_stream() -> String {
-        "projects/p/datasets/d/tables/t/streams/s".to_string()
-    }
-
-    fn schema() -> ArrowSchema {
-        ArrowSchema::new().set_serialized_schema("test")
     }
 
     fn rows(id: i64) -> ArrowRecordBatch {

--- a/src/bigquery/src/write/arrow/committed.rs
+++ b/src/bigquery/src/write/arrow/committed.rs
@@ -55,17 +55,16 @@ impl CommittedWriter {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::runner::tests::*;
-    use super::super::super::transport::tests::*;
     use super::*;
     use crate::error::AppendError;
+    use crate::write::test::*;
     use bigquery_grpc_mock::{MockBigQueryWrite, start};
     use gaxi::grpc::tonic::Response as TonicResponse;
     use tokio::sync::mpsc;
 
     #[tokio::test]
     async fn request_fields() -> anyhow::Result<()> {
-        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
+        let transport = Arc::new(test_transport("http://ignored:1").await?);
         let writer = CommittedWriter::new(transport, write_stream(), schema());
         assert_eq!(writer.write_stream(), write_stream());
 
@@ -128,14 +127,6 @@ mod tests {
         writer.finalize().await?;
 
         Ok(())
-    }
-
-    fn write_stream() -> String {
-        "projects/p/datasets/d/tables/t/streams/s".to_string()
-    }
-
-    fn schema() -> ArrowSchema {
-        ArrowSchema::new().set_serialized_schema("test")
     }
 
     fn rows(id: i64) -> ArrowRecordBatch {

--- a/src/bigquery/src/write/arrow/default.rs
+++ b/src/bigquery/src/write/arrow/default.rs
@@ -56,17 +56,16 @@ impl DefaultWriter {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::runner::tests::*;
-    use super::super::super::transport::tests::*;
     use super::*;
     use crate::error::AppendError;
+    use crate::write::test::*;
     use bigquery_grpc_mock::{MockBigQueryWrite, start};
     use gaxi::grpc::tonic::Response as TonicResponse;
     use tokio::sync::mpsc;
 
     #[tokio::test]
     async fn request_fields() -> anyhow::Result<()> {
-        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
+        let transport = Arc::new(test_transport("http://ignored:1").await?);
         let writer = DefaultWriter::new(transport, write_stream(), schema());
 
         let b = writer.append(rows(1));
@@ -117,14 +116,6 @@ mod tests {
         assert!(matches!(err, AppendError::UnexpectedEndOfStream));
 
         Ok(())
-    }
-
-    fn write_stream() -> String {
-        "projects/p/datasets/d/tables/t/streams/_default".to_string()
-    }
-
-    fn schema() -> ArrowSchema {
-        ArrowSchema::new().set_serialized_schema("test")
     }
 
     fn rows(id: i64) -> ArrowRecordBatch {

--- a/src/bigquery/src/write/arrow/pending.rs
+++ b/src/bigquery/src/write/arrow/pending.rs
@@ -77,16 +77,15 @@ impl PendingWriter {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::runner::tests::*;
-    use super::super::super::transport::tests::*;
     use super::*;
+    use crate::write::test::*;
     use bigquery_grpc_mock::{MockBigQueryWrite, start};
     use gaxi::grpc::tonic::Response as TonicResponse;
     use tokio::sync::mpsc;
 
     #[tokio::test]
     async fn request_fields() -> anyhow::Result<()> {
-        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
+        let transport = Arc::new(test_transport("http://ignored:1").await?);
         let writer = PendingWriter::new(transport, write_stream(), schema());
         assert_eq!(writer.write_stream(), write_stream());
 
@@ -133,14 +132,6 @@ mod tests {
         writer.commit().await?;
 
         Ok(())
-    }
-
-    fn write_stream() -> String {
-        "projects/p/datasets/d/tables/t/streams/s".to_string()
-    }
-
-    fn schema() -> ArrowSchema {
-        ArrowSchema::new().set_serialized_schema("test")
     }
 
     fn rows(id: i64) -> ArrowRecordBatch {

--- a/src/bigquery/src/write/arrow/writer_builder.rs
+++ b/src/bigquery/src/write/arrow/writer_builder.rs
@@ -268,8 +268,8 @@ fn validate_stream(stream: &str) -> crate::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::transport::tests::test_transport;
     use super::*;
+    use crate::write::test::*;
     use bigquery_grpc_mock::google::cloud::bigquery::storage::v1::WriteStream as MockWriteStream;
     use bigquery_grpc_mock::{MockBigQueryWrite, start};
     use test_case::test_case;
@@ -290,14 +290,13 @@ mod tests {
         });
         let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
         let transport = Arc::new(test_transport(endpoint).await?);
-        let schema = ArrowSchema::new().set_serialized_schema("test");
-        let builder = WriterBuilder::new(transport, schema.clone());
+        let builder = WriterBuilder::new(transport, schema());
         let writer = builder.pending("projects/p/datasets/d/tables/t").await?;
         assert_eq!(
             writer.inner.write_stream,
             "projects/p/datasets/d/tables/t/streams/s"
         );
-        assert_eq!(writer.inner.schema, schema);
+        assert_eq!(writer.inner.schema, schema());
         Ok(())
     }
 
@@ -306,9 +305,8 @@ mod tests {
     #[test_case("projects/p/datasets/d/tables/")]
     #[tokio::test]
     async fn pending_bad_table_format(table: &str) -> anyhow::Result<()> {
-        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
-        let schema = ArrowSchema::new().set_serialized_schema("test");
-        let builder = WriterBuilder::new(transport, schema.clone());
+        let transport = Arc::new(test_transport("http://ignored:1").await?);
+        let builder = WriterBuilder::new(transport, schema());
         let err = builder
             .pending(table)
             .await
@@ -332,14 +330,13 @@ mod tests {
         });
         let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
         let transport = Arc::new(test_transport(endpoint).await?);
-        let schema = ArrowSchema::new().set_serialized_schema("test");
-        let builder = WriterBuilder::new(transport, schema.clone());
+        let builder = WriterBuilder::new(transport, schema());
         let writer = builder.committed("projects/p/datasets/d/tables/t").await?;
         assert_eq!(
             writer.inner.write_stream,
             "projects/p/datasets/d/tables/t/streams/s"
         );
-        assert_eq!(writer.inner.schema, schema);
+        assert_eq!(writer.inner.schema, schema());
         Ok(())
     }
 
@@ -348,9 +345,8 @@ mod tests {
     #[test_case("projects/p/datasets/d/tables/")]
     #[tokio::test]
     async fn committed_bad_table_format(table: &str) -> anyhow::Result<()> {
-        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
-        let schema = ArrowSchema::new().set_serialized_schema("test");
-        let builder = WriterBuilder::new(transport, schema.clone());
+        let transport = Arc::new(test_transport("http://ignored:1").await?);
+        let builder = WriterBuilder::new(transport, schema());
         let err = builder
             .committed(table)
             .await
@@ -361,15 +357,14 @@ mod tests {
 
     #[tokio::test]
     async fn default() -> anyhow::Result<()> {
-        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
-        let schema = ArrowSchema::new().set_serialized_schema("test");
-        let builder = WriterBuilder::new(transport, schema.clone());
+        let transport = Arc::new(test_transport("http://ignored:1").await?);
+        let builder = WriterBuilder::new(transport, schema());
         let writer = builder.default("projects/p/datasets/d/tables/t")?;
         assert_eq!(
             writer.write_stream,
             "projects/p/datasets/d/tables/t/streams/_default"
         );
-        assert_eq!(writer.schema, schema);
+        assert_eq!(writer.schema, schema());
         Ok(())
     }
 
@@ -381,9 +376,8 @@ mod tests {
     #[test_case("projects/p/datasets/d/tables/t/streams/_default")]
     #[tokio::test]
     async fn bad_table_format(table: &str) -> anyhow::Result<()> {
-        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
-        let schema = ArrowSchema::new().set_serialized_schema("test");
-        let builder = WriterBuilder::new(transport, schema.clone());
+        let transport = Arc::new(test_transport("http://ignored:1").await?);
+        let builder = WriterBuilder::new(transport, schema());
         let err = builder
             .default(table)
             .expect_err("should fail locally on bad format");
@@ -405,14 +399,13 @@ mod tests {
         });
         let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
         let transport = Arc::new(test_transport(endpoint).await?);
-        let schema = ArrowSchema::new().set_serialized_schema("test");
-        let builder = WriterBuilder::new(transport, schema.clone());
+        let builder = WriterBuilder::new(transport, schema());
         let writer = builder.buffered("projects/p/datasets/d/tables/t").await?;
         assert_eq!(
             writer.inner.write_stream,
             "projects/p/datasets/d/tables/t/streams/s"
         );
-        assert_eq!(writer.inner.schema, schema);
+        assert_eq!(writer.inner.schema, schema());
         Ok(())
     }
 
@@ -421,9 +414,8 @@ mod tests {
     #[test_case("projects/p/datasets/d/tables/")]
     #[tokio::test]
     async fn buffered_bad_table_format(table: &str) -> anyhow::Result<()> {
-        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
-        let schema = ArrowSchema::new().set_serialized_schema("test");
-        let builder = WriterBuilder::new(transport, schema.clone());
+        let transport = Arc::new(test_transport("http://ignored:1").await?);
+        let builder = WriterBuilder::new(transport, schema());
         let err = builder
             .buffered(table)
             .await
@@ -451,8 +443,7 @@ mod tests {
     #[tokio::test]
     async fn attach_committed_success() -> anyhow::Result<()> {
         let (transport, _server) = attach_mock(Type::Committed).await?;
-        let schema = ArrowSchema::new().set_serialized_schema("test");
-        let builder = WriterBuilder::new(transport, schema.clone());
+        let builder = WriterBuilder::new(transport, schema());
         let writer: CommittedWriter = builder
             .attach("projects/p/datasets/d/tables/t/streams/s")
             .await?;
@@ -460,15 +451,14 @@ mod tests {
             writer.inner.write_stream,
             "projects/p/datasets/d/tables/t/streams/s"
         );
-        assert_eq!(writer.inner.schema, schema);
+        assert_eq!(writer.inner.schema, schema());
         Ok(())
     }
 
     #[tokio::test]
     async fn attach_pending_success() -> anyhow::Result<()> {
         let (transport, _server) = attach_mock(Type::Pending).await?;
-        let schema = ArrowSchema::new().set_serialized_schema("test");
-        let builder = WriterBuilder::new(transport, schema.clone());
+        let builder = WriterBuilder::new(transport, schema());
         let writer: PendingWriter = builder
             .attach("projects/p/datasets/d/tables/t/streams/s")
             .await?;
@@ -476,15 +466,14 @@ mod tests {
             writer.inner.write_stream,
             "projects/p/datasets/d/tables/t/streams/s"
         );
-        assert_eq!(writer.inner.schema, schema);
+        assert_eq!(writer.inner.schema, schema());
         Ok(())
     }
 
     #[tokio::test]
     async fn attach_buffered_success() -> anyhow::Result<()> {
         let (transport, _server) = attach_mock(Type::Buffered).await?;
-        let schema = ArrowSchema::new().set_serialized_schema("test");
-        let builder = WriterBuilder::new(transport, schema.clone());
+        let builder = WriterBuilder::new(transport, schema());
         let writer: BufferedWriter = builder
             .attach("projects/p/datasets/d/tables/t/streams/s")
             .await?;
@@ -492,7 +481,7 @@ mod tests {
             writer.inner.write_stream,
             "projects/p/datasets/d/tables/t/streams/s"
         );
-        assert_eq!(writer.inner.schema, schema);
+        assert_eq!(writer.inner.schema, schema());
         Ok(())
     }
 
@@ -502,9 +491,8 @@ mod tests {
     #[test_case("projects/p/datasets/d/tables/t/streams/")]
     #[tokio::test]
     async fn attach_bad_stream_format(stream: &str) -> anyhow::Result<()> {
-        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
-        let schema = ArrowSchema::new().set_serialized_schema("test");
-        let builder = WriterBuilder::new(transport, schema.clone());
+        let transport = Arc::new(test_transport("http://ignored:1").await?);
+        let builder = WriterBuilder::new(transport, schema());
         let err = builder
             .attach::<CommittedWriter, _>(stream)
             .await
@@ -516,8 +504,7 @@ mod tests {
     #[tokio::test]
     async fn attach_stream_type_mismatch() -> anyhow::Result<()> {
         let (transport, _server) = attach_mock(Type::Buffered).await?;
-        let schema = ArrowSchema::new().set_serialized_schema("test");
-        let builder = WriterBuilder::new(transport, schema.clone());
+        let builder = WriterBuilder::new(transport, schema());
         let err = builder
             .attach::<CommittedWriter, _>("projects/p/datasets/d/tables/t/streams/s")
             .await

--- a/src/bigquery/src/write/pool.rs
+++ b/src/bigquery/src/write/pool.rs
@@ -147,10 +147,9 @@ impl StreamPool {
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
-    use super::super::runner::tests::*;
-    use super::super::transport::tests::*;
+mod tests {
     use super::*;
+    use crate::write::test::*;
     use bigquery_grpc_mock::{MockBigQueryWrite, start};
     use gaxi::grpc::tonic::Response as TonicResponse;
     use test_case::test_case;

--- a/src/bigquery/src/write/runner.rs
+++ b/src/bigquery/src/write/runner.rs
@@ -144,12 +144,9 @@ fn process_gax_response(
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
-    use super::super::transport::tests::*;
+mod tests {
     use super::*;
-    use crate::google::cloud::bigquery::storage::v1::append_rows_response::{
-        AppendResult, Response,
-    };
+    use crate::write::test::*;
     use bigquery_grpc_mock::{MockBigQueryWrite, start};
     use gaxi::grpc::tonic::Response as TonicResponse;
     use google_cloud_gax::error::rpc::Code;
@@ -470,23 +467,5 @@ pub(crate) mod tests {
         handle.await?;
 
         Ok(())
-    }
-
-    pub(crate) fn test_request(index: i64) -> AppendRowsRequest {
-        AppendRowsRequest {
-            write_stream: "projects/p/datasets/d/tables/t/streams/s".to_string(),
-            offset: Some(index),
-            ..Default::default()
-        }
-    }
-
-    pub(crate) fn test_response(index: i64) -> AppendRowsResponse {
-        AppendRowsResponse {
-            response: Some(Response::AppendResult(AppendResult {
-                offset: Some(index),
-            })),
-            write_stream: "projects/p/datasets/d/tables/t/streams/s".to_string(),
-            ..Default::default()
-        }
     }
 }

--- a/src/bigquery/src/write/stream.rs
+++ b/src/bigquery/src/write/stream.rs
@@ -52,11 +52,11 @@ async fn open_stream(inner: Arc<Transport>, initial_req: AppendRowsRequest) -> R
 
 #[cfg(test)]
 mod tests {
-    use super::super::transport::tests::*;
     use super::*;
     use crate::google::cloud::bigquery::storage::v1::append_rows_response::{
         AppendResult, Response,
     };
+    use crate::write::test::*;
     use bigquery_grpc_mock::{MockBigQueryWrite, start};
     use gaxi::grpc::tonic::{Response as TonicResponse, Status as TonicStatus};
     use google_cloud_gax::error::rpc::Code;

--- a/src/bigquery/src/write/test.rs
+++ b/src/bigquery/src/write/test.rs
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test helpers for the `Write` client internals
+
+use super::transport::Transport;
+use crate::google::cloud::bigquery::storage::v1::append_rows_response::{AppendResult, Response};
+use crate::google::cloud::bigquery::storage::v1::{AppendRowsRequest, AppendRowsResponse};
+use crate::model::ArrowSchema;
+use bigquery_grpc_mock::google::cloud::bigquery::storage::v1;
+use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+
+pub(super) fn write_stream() -> String {
+    "projects/p/datasets/d/tables/t/streams/s".to_string()
+}
+
+pub(super) fn schema() -> ArrowSchema {
+    ArrowSchema::new().set_serialized_schema("test")
+}
+
+pub(super) async fn test_transport<T: Into<String>>(endpoint: T) -> anyhow::Result<Transport> {
+    let mut config = gaxi::options::ClientConfig::default();
+    config.cred = Some(Anonymous::new().build());
+    config.endpoint = Some(endpoint.into());
+    Ok(Transport::new(config).await?)
+}
+
+// Both crates have their own copies of the protos. We can just serialize
+// then deserialize to convert between the two, as performance is not a
+// concern for these unit tests.
+pub(super) fn convert(pb: &AppendRowsResponse) -> v1::AppendRowsResponse {
+    use prost::Message;
+    let v = pb.encode_to_vec();
+    v1::AppendRowsResponse::decode(v.as_slice()).expect("encoding is always valid.")
+}
+
+pub(super) fn test_request(index: i64) -> AppendRowsRequest {
+    AppendRowsRequest {
+        write_stream: "projects/p/datasets/d/tables/t/streams/s".to_string(),
+        offset: Some(index),
+        ..Default::default()
+    }
+}
+
+pub(super) fn test_response(index: i64) -> AppendRowsResponse {
+    AppendRowsResponse {
+        response: Some(Response::AppendResult(AppendResult {
+            offset: Some(index),
+        })),
+        write_stream: "projects/p/datasets/d/tables/t/streams/s".to_string(),
+        ..Default::default()
+    }
+}

--- a/src/bigquery/src/write/transport.rs
+++ b/src/bigquery/src/write/transport.rs
@@ -68,30 +68,13 @@ impl Transport {
 }
 
 #[cfg(test)]
-pub(super) mod tests {
+mod tests {
     use super::*;
     use crate::google::cloud::bigquery::storage::v1::append_rows_response::{
         AppendResult, Response,
     };
-    use bigquery_grpc_mock::google::cloud::bigquery::storage::v1;
+    use crate::write::test::*;
     use bigquery_grpc_mock::{MockBigQueryWrite, start};
-    use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
-
-    pub(crate) async fn test_transport<T: Into<String>>(endpoint: T) -> anyhow::Result<Transport> {
-        let mut config = gaxi::options::ClientConfig::default();
-        config.cred = Some(Anonymous::new().build());
-        config.endpoint = Some(endpoint.into());
-        Ok(Transport::new(config).await?)
-    }
-
-    // Both crates have their own copies of the protos. We can just serialize
-    // then deserialize to convert between the two, as performance is not a
-    // concern for these unit tests.
-    pub(crate) fn convert(pb: &AppendRowsResponse) -> v1::AppendRowsResponse {
-        use prost::Message;
-        let v = pb.encode_to_vec();
-        v1::AppendRowsResponse::decode(v.as_slice()).expect("encoding is always valid.")
-    }
 
     #[tokio::test]
     async fn append_rows() -> anyhow::Result<()> {


### PR DESCRIPTION
We have a bunch of test helpers defined at wherever I first needed them. Move them all to a centralized `mod test`, so they are easier to find.