### PR TITLE
chore(spanner): record transaction affinity for streaming RPCs with inline begin

### DIFF
--- a/src/spanner/src/database_client.rs
+++ b/src/spanner/src/database_client.rs
@@ -46,6 +46,7 @@ use crate::routing::latency_registry::LatencyRegistry;
 use crate::routing::location_router::{LocationRouter, RoutingContext};
 use crate::routing::server_connection::ServerConnection;
 use crate::server_streaming::builder::{BatchWrite, ExecuteStreamingSql, StreamingRead};
+use crate::server_streaming::stream::TransactionIdCallback;
 use crate::session_maintainer::ManagedSessionMaintainer;
 use crate::transaction_runner::TransactionRunnerBuilder;
 use crate::write_only_transaction::WriteOnlyTransactionBuilder;
@@ -139,6 +140,7 @@ macro_rules! define_db_streaming_rpc {
             options: RequestOptions,
             channel_hint: usize,
         ) -> $builder_type {
+            let is_read_write_begin = is_read_write_begin(request.transaction.as_ref());
             // Step 1: When location-aware routing is disabled (standard Cloud Spanner),
             // `self.location_routing` is `None` so `$extract_key` is skipped immediately.
             // When enabled (Spanner Omni), extract the operation UID and binary routing key.
@@ -156,7 +158,7 @@ macro_rules! define_db_streaming_rpc {
                 &mut request.routing_hint,
             );
 
-            // Step 4: Select the gRPC channel:
+            // Step 3: Select the gRPC channel:
             // - If location-aware routing resolved a direct node connection (`Some(connection)`), use `connection.channel()`.
             // - Otherwise (location routing disabled, unkeyed query/read, or cold cache), fall back to round-robin
             //   load-balancing across the client's channel pool via `self.spanner.get_channel(channel_hint)`.
@@ -165,7 +167,11 @@ macro_rules! define_db_streaming_rpc {
                 Some(connection) => connection.channel(),
                 None => self.spanner.get_channel(channel_hint),
             };
-            self.spanner.$method(request, options, channel)
+            let callback =
+                self.streaming_transaction_id_callback(is_read_write_begin, connection.as_ref());
+            self.spanner
+                .$method(request, options, channel)
+                .with_transaction_id_callback(callback)
         }
     };
 }
@@ -874,6 +880,22 @@ impl DatabaseClient {
         self.record_transaction_affinity_routing(is_read_write_begin, transaction_id, connection);
     }
 
+    fn streaming_transaction_id_callback(
+        &self,
+        is_read_write_begin: bool,
+        connection: Option<&ServerConnection>,
+    ) -> Option<TransactionIdCallback> {
+        if !is_read_write_begin {
+            return None;
+        }
+        let routing = self.location_routing.as_ref()?;
+        let address = routing.resolved_or_default_address(connection).to_string();
+        let router = Arc::clone(&routing.location_router);
+        Some(TransactionIdCallback::new(move |transaction_id| {
+            router.record_transaction_affinity(transaction_id, &address);
+        }))
+    }
+
     fn pre_route_rollback(
         &self,
         request: &mut RollbackRequest,
@@ -963,14 +985,7 @@ impl DatabaseClient {
         let Some(routing) = &self.location_routing else {
             return;
         };
-        let address = match connection {
-            Some(connection) => connection.address(),
-            None => routing
-                .location_router
-                .connection_cache()
-                .default_connection()
-                .address(),
-        };
+        let address = routing.resolved_or_default_address(connection);
         routing
             .location_router
             .record_transaction_affinity(transaction_id, address);
@@ -1275,6 +1290,22 @@ impl LocationRoutingState {
             key_recipe_cache,
             cache_subscriber,
             endpoint_lifecycle_manager,
+        }
+    }
+
+    /// Returns the target server address from the resolved direct connection, or
+    /// falls back to the default gateway connection address when no direct route exists.
+    pub(crate) fn resolved_or_default_address<'a>(
+        &'a self,
+        connection: Option<&'a ServerConnection>,
+    ) -> &'a str {
+        match connection {
+            Some(connection) => connection.address(),
+            None => self
+                .location_router
+                .connection_cache()
+                .default_connection()
+                .address(),
         }
     }
 }

--- a/src/spanner/src/routing/mock_tests.rs
+++ b/src/spanner/src/routing/mock_tests.rs
@@ -65,7 +65,7 @@ use spanner_grpc_mock::google::rpc::Status;
 use spanner_grpc_mock::google::spanner::v1 as mock_v1;
 use spanner_grpc_mock::google::spanner::v1::spanner_server::SpannerServer;
 use spanner_grpc_mock::start;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -3483,6 +3483,857 @@ async fn unary_execute_batch_dml_with_inline_begin_rw_records_affinity() -> anyh
 }
 
 #[tokio_test_no_panics]
+async fn streaming_execute_sql_with_inline_begin_rw_records_affinity() -> anyhow::Result<()> {
+    let mut mock_gateway = create_base_mock();
+    let gateway_sql_received = Arc::new(AtomicBool::new(false));
+    let gateway_sql_received_clone = Arc::clone(&gateway_sql_received);
+    mock_gateway
+        .expect_execute_streaming_sql()
+        .returning(move |_| {
+            gateway_sql_received_clone.store(true, Ordering::SeqCst);
+            single_row_streaming_response_with_transaction(b"tx-inline-stream-sql-rw")
+        });
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+
+    let execute_sql_request = ExecuteSqlRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_sql("SELECT 1")
+        .set_transaction(
+            TransactionSelector::default()
+                .set_begin(TransactionOptions::default().set_read_write(ReadWrite::default())),
+        );
+
+    let mut stream = database_client
+        .execute_streaming_sql(execute_sql_request, RequestOptions::default(), 0)
+        .send()
+        .await?;
+
+    let message = stream.next_message().await;
+    assert!(
+        message.is_some(),
+        "stream should yield at least one message"
+    );
+    let message = message.expect("message must exist")?;
+    assert!(
+        message.metadata.is_some(),
+        "partial result set should contain metadata"
+    );
+
+    assert!(
+        gateway_sql_received.load(Ordering::SeqCst),
+        "execute_streaming_sql with inline begin must be executed"
+    );
+    assert_eq!(
+        router.get_transaction_affinity(b"tx-inline-stream-sql-rw"),
+        Some(Arc::from(gateway_address.as_str())),
+        "inline begin in execute_streaming_sql must record transaction affinity"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn streaming_execute_sql_with_multiple_chunks_records_affinity_and_yields_all_rows()
+-> anyhow::Result<()> {
+    let mut mock_gateway = create_base_mock();
+    let gateway_sql_received = Arc::new(AtomicBool::new(false));
+    let gateway_sql_received_clone = Arc::clone(&gateway_sql_received);
+    mock_gateway
+        .expect_execute_streaming_sql()
+        .returning(move |_| {
+            gateway_sql_received_clone.store(true, Ordering::SeqCst);
+            let (sender, receiver) = mpsc::channel(2);
+            // Chunk 1: metadata with transaction ID, first row, last: false
+            let chunk_1 = mock_v1::PartialResultSet {
+                metadata: Some(mock_v1::ResultSetMetadata {
+                    row_type: Some(mock_v1::StructType {
+                        fields: vec![mock_v1::struct_type::Field {
+                            name: "SingerId".to_string(),
+                            r#type: Some(mock_v1::Type {
+                                code: mock_v1::TypeCode::Int64 as i32,
+                                ..Default::default()
+                            }),
+                        }],
+                    }),
+                    transaction: Some(mock_v1::Transaction {
+                        id: b"tx-multi-chunk-rw".to_vec(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                values: vec![Value {
+                    kind: Some(prost_types::value::Kind::StringValue("1".to_string())),
+                }],
+                last: false,
+                ..Default::default()
+            };
+            sender.try_send(Ok(chunk_1)).expect("send chunk 1");
+
+            // Chunk 2: second row without transaction ID, last: true
+            let chunk_2 = mock_v1::PartialResultSet {
+                values: vec![Value {
+                    kind: Some(prost_types::value::Kind::StringValue("2".to_string())),
+                }],
+                last: true,
+                ..Default::default()
+            };
+            sender.try_send(Ok(chunk_2)).expect("send chunk 2");
+
+            Ok(Response::from(receiver))
+        });
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+
+    let execute_sql_request = ExecuteSqlRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_sql("SELECT SingerId FROM Singers")
+        .set_transaction(
+            TransactionSelector::default()
+                .set_begin(TransactionOptions::default().set_read_write(ReadWrite::default())),
+        );
+
+    let mut stream = database_client
+        .execute_streaming_sql(execute_sql_request, RequestOptions::default(), 0)
+        .send()
+        .await?;
+
+    // First chunk
+    let first_message = stream.next_message().await;
+    assert!(
+        first_message.is_some(),
+        "first chunk should yield a message"
+    );
+    let first_message = first_message.expect("message 1 must exist")?;
+    assert!(
+        first_message.metadata.is_some(),
+        "first chunk must contain metadata"
+    );
+    assert_eq!(
+        router.get_transaction_affinity(b"tx-multi-chunk-rw"),
+        Some(Arc::from(gateway_address.as_str())),
+        "affinity must be recorded on first chunk"
+    );
+
+    // Second chunk
+    let second_message = stream.next_message().await;
+    assert!(
+        second_message.is_some(),
+        "second chunk should yield a message"
+    );
+    let second_message = second_message.expect("message 2 must exist")?;
+    assert!(second_message.last, "second chunk must have last flag set");
+    assert_eq!(
+        router.get_transaction_affinity(b"tx-multi-chunk-rw"),
+        Some(Arc::from(gateway_address.as_str())),
+        "affinity must remain bound after subsequent chunk"
+    );
+
+    // Stream conclusion (EOF)
+    let end = stream.next_message().await;
+    assert!(end.is_none(), "stream should conclude with None on EOF");
+
+    assert!(
+        gateway_sql_received.load(Ordering::SeqCst),
+        "streaming sql must be received by gateway"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn streaming_read_with_inline_begin_rw_records_affinity() -> anyhow::Result<()> {
+    let mut mock_gateway = create_base_mock();
+    let gateway_read_received = Arc::new(AtomicBool::new(false));
+    let gateway_read_received_clone = Arc::clone(&gateway_read_received);
+    mock_gateway.expect_streaming_read().returning(move |_| {
+        gateway_read_received_clone.store(true, Ordering::SeqCst);
+        single_row_streaming_response_with_transaction(b"tx-inline-stream-read-rw")
+    });
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+
+    let read_request = ReadRequest::builder("Singers", vec!["SingerId"])
+        .with_keys(KeySet::all())
+        .build()
+        .into_request()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_transaction(
+            TransactionSelector::default()
+                .set_begin(TransactionOptions::default().set_read_write(ReadWrite::default())),
+        );
+
+    let mut stream = database_client
+        .streaming_read(read_request, RequestOptions::default(), 0)
+        .send()
+        .await?;
+
+    let message = stream.next_message().await;
+    assert!(
+        message.is_some(),
+        "stream should yield at least one message"
+    );
+    let message = message.expect("message must exist")?;
+    assert!(
+        message.metadata.is_some(),
+        "partial result set should contain metadata"
+    );
+
+    assert!(
+        gateway_read_received.load(Ordering::SeqCst),
+        "streaming_read with inline begin must be executed"
+    );
+    assert_eq!(
+        router.get_transaction_affinity(b"tx-inline-stream-read-rw"),
+        Some(Arc::from(gateway_address.as_str())),
+        "inline begin in streaming_read must record transaction affinity"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn streaming_execute_sql_with_inline_begin_ro_does_not_record_affinity() -> anyhow::Result<()>
+{
+    let mut mock_gateway = create_base_mock();
+    let gateway_sql_received = Arc::new(AtomicBool::new(false));
+    let gateway_sql_received_clone = Arc::clone(&gateway_sql_received);
+    mock_gateway
+        .expect_execute_streaming_sql()
+        .returning(move |_| {
+            gateway_sql_received_clone.store(true, Ordering::SeqCst);
+            single_row_streaming_response_with_transaction(b"tx-inline-stream-sql-ro")
+        });
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+
+    let execute_sql_request = ExecuteSqlRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_sql("SELECT 1")
+        .set_transaction(
+            TransactionSelector::default()
+                .set_begin(TransactionOptions::default().set_read_only(ReadOnly::default())),
+        );
+
+    let mut stream = database_client
+        .execute_streaming_sql(execute_sql_request, RequestOptions::default(), 0)
+        .send()
+        .await?;
+
+    let message = stream.next_message().await;
+    assert!(
+        message.is_some(),
+        "stream should yield at least one message"
+    );
+    let message = message.expect("message must exist")?;
+    assert!(
+        message.metadata.is_some(),
+        "partial result set should contain metadata"
+    );
+
+    assert!(
+        gateway_sql_received.load(Ordering::SeqCst),
+        "execute_streaming_sql with read-only inline begin must be executed"
+    );
+    assert_eq!(
+        router.get_transaction_affinity(b"tx-inline-stream-sql-ro"),
+        None,
+        "read-only inline begin must not record transaction affinity"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn streaming_execute_sql_with_error_does_not_record_affinity() -> anyhow::Result<()> {
+    let mut mock_gateway = create_base_mock();
+    let gateway_sql_received = Arc::new(AtomicBool::new(false));
+    let gateway_sql_received_clone = Arc::clone(&gateway_sql_received);
+    mock_gateway
+        .expect_execute_streaming_sql()
+        .returning(move |_| {
+            gateway_sql_received_clone.store(true, Ordering::SeqCst);
+            streaming_error_response(TonicStatus::invalid_argument("table not found"))
+        });
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+
+    let execute_sql_request = ExecuteSqlRequest::default()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_sql("SELECT * FROM NonExistentTable")
+        .set_transaction(
+            TransactionSelector::default()
+                .set_begin(TransactionOptions::default().set_read_write(ReadWrite::default())),
+        );
+
+    let mut stream = database_client
+        .execute_streaming_sql(execute_sql_request, RequestOptions::default(), 0)
+        .send()
+        .await?;
+
+    let message = stream.next_message().await;
+    assert!(message.is_some(), "stream should yield an error message");
+    assert!(
+        message.expect("message must exist").is_err(),
+        "stream message must be an error"
+    );
+
+    assert!(
+        gateway_sql_received.load(Ordering::SeqCst),
+        "execute_streaming_sql must be executed"
+    );
+    assert_eq!(
+        router.affinity_count(),
+        0,
+        "failed streaming execution must not record any affinity"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn read_write_transaction_inline_begin_query_records_affinity_and_routes_commit_to_affinity()
+-> anyhow::Result<()> {
+    let mut mock_gateway = create_base_mock();
+    let gateway_sql_received = Arc::new(AtomicBool::new(false));
+    let gateway_sql_received_clone = Arc::clone(&gateway_sql_received);
+    mock_gateway
+        .expect_execute_streaming_sql()
+        .returning(move |_| {
+            gateway_sql_received_clone.store(true, Ordering::SeqCst);
+            single_row_streaming_response_with_transaction(b"tx-inline-runner-rw")
+        });
+
+    let gateway_commit_received = Arc::new(AtomicBool::new(false));
+    let gateway_commit_received_clone = Arc::clone(&gateway_commit_received);
+    mock_gateway.expect_commit().returning(move |request| {
+        gateway_commit_received_clone.store(true, Ordering::SeqCst);
+        assert_eq!(
+            request.get_ref().transaction,
+            Some(mock_v1::commit_request::Transaction::TransactionId(
+                b"tx-inline-runner-rw".to_vec()
+            )),
+            "commit must carry the transaction ID returned by inline begin"
+        );
+        Ok(Response::new(mock_v1::CommitResponse {
+            commit_timestamp: Some(Timestamp {
+                seconds: 1700000000,
+                nanos: 0,
+            }),
+            ..Default::default()
+        }))
+    });
+
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+
+    let affinity_verified_inside_runner = Arc::new(AtomicBool::new(false));
+    let affinity_verified_inside_runner_clone = Arc::clone(&affinity_verified_inside_runner);
+    let router_clone = Arc::clone(router);
+    let gateway_address_clone = gateway_address.clone();
+
+    let runner = database_client.read_write_transaction().build().await?;
+    runner
+        .run(|transaction: ReadWriteTransaction| {
+            let router_clone = Arc::clone(&router_clone);
+            let gateway_address_clone = gateway_address_clone.clone();
+            let affinity_verified = Arc::clone(&affinity_verified_inside_runner_clone);
+            async move {
+                let mut result_set = transaction.execute_query("SELECT 1").await?;
+                let row = result_set.next().await;
+                assert!(row.is_some(), "result set should yield a row");
+
+                assert_eq!(
+                    router_clone.get_transaction_affinity(b"tx-inline-runner-rw"),
+                    Some(Arc::from(gateway_address_clone.as_str())),
+                    "affinity must be recorded during inline begin execution"
+                );
+                affinity_verified.store(true, Ordering::SeqCst);
+
+                Ok(())
+            }
+        })
+        .await?;
+
+    assert!(
+        gateway_sql_received.load(Ordering::SeqCst),
+        "streaming sql must be received by gateway"
+    );
+    assert!(
+        affinity_verified_inside_runner.load(Ordering::SeqCst),
+        "affinity must be verified inside transaction runner"
+    );
+    assert!(
+        gateway_commit_received.load(Ordering::SeqCst),
+        "commit must be received by gateway"
+    );
+    assert_eq!(
+        router.get_transaction_affinity(b"tx-inline-runner-rw"),
+        None,
+        "commit must clear transaction affinity"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn read_write_transaction_inline_begin_read_records_affinity_and_routes_commit_to_affinity()
+-> anyhow::Result<()> {
+    let mut mock_gateway = create_base_mock();
+    let gateway_read_received = Arc::new(AtomicBool::new(false));
+    let gateway_read_received_clone = Arc::clone(&gateway_read_received);
+    mock_gateway
+        .expect_streaming_read()
+        .returning(move |request| {
+            gateway_read_received_clone.store(true, Ordering::SeqCst);
+            assert!(
+                request.get_ref().transaction.is_some(),
+                "request must contain transaction selector"
+            );
+            single_row_streaming_response_with_transaction(b"tx-inline-runner-read-rw")
+        });
+
+    let gateway_commit_received = Arc::new(AtomicBool::new(false));
+    let gateway_commit_received_clone = Arc::clone(&gateway_commit_received);
+    mock_gateway.expect_commit().returning(move |request| {
+        gateway_commit_received_clone.store(true, Ordering::SeqCst);
+        assert_eq!(
+            request.get_ref().transaction,
+            Some(mock_v1::commit_request::Transaction::TransactionId(
+                b"tx-inline-runner-read-rw".to_vec()
+            )),
+            "commit must route to transaction ID recorded by inline begin read"
+        );
+        Ok(Response::new(mock_v1::CommitResponse {
+            commit_timestamp: Some(Timestamp {
+                seconds: 1700000000,
+                nanos: 0,
+            }),
+            ..Default::default()
+        }))
+    });
+
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+
+    let affinity_verified_inside_runner = Arc::new(AtomicBool::new(false));
+    let affinity_verified = Arc::clone(&affinity_verified_inside_runner);
+    let router_clone = Arc::clone(router);
+    let gateway_address_clone = gateway_address.clone();
+
+    let runner = database_client.read_write_transaction().build().await?;
+    runner
+        .run(|transaction: ReadWriteTransaction| {
+            let affinity_verified = Arc::clone(&affinity_verified);
+            let router_clone = Arc::clone(&router_clone);
+            let gateway_address_clone = gateway_address_clone.clone();
+            async move {
+                let read = ReadRequest::builder("Singers", vec!["SingerId"])
+                    .with_keys(key![100i64])
+                    .build();
+                let mut result_set = transaction.execute_read(read).await?;
+                let row = result_set.next().await;
+                assert!(row.is_some(), "result set should yield a row");
+                let row = row.expect("row must exist")?;
+                assert_eq!(row.raw_values().len(), 1, "row must contain 1 column");
+
+                assert_eq!(
+                    router_clone.get_transaction_affinity(b"tx-inline-runner-read-rw"),
+                    Some(Arc::from(gateway_address_clone.as_str())),
+                    "affinity must be recorded during inline begin read execution"
+                );
+                affinity_verified.store(true, Ordering::SeqCst);
+
+                Ok(())
+            }
+        })
+        .await?;
+
+    assert!(
+        gateway_read_received.load(Ordering::SeqCst),
+        "streaming read must be received by gateway"
+    );
+    assert!(
+        affinity_verified_inside_runner.load(Ordering::SeqCst),
+        "affinity must be verified inside transaction runner"
+    );
+    assert!(
+        gateway_commit_received.load(Ordering::SeqCst),
+        "commit must be received by gateway"
+    );
+    assert_eq!(
+        router.get_transaction_affinity(b"tx-inline-runner-read-rw"),
+        None,
+        "commit must clear transaction affinity"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn read_write_transaction_inline_begin_query_aborted_retries_and_updates_affinity()
+-> anyhow::Result<()> {
+    let mut mock_gateway = create_base_mock();
+    let mut sequence = mockall::Sequence::new();
+
+    // Attempt 1: ExecuteStreamingSql succeeds with tx-attempt-1, but Commit fails with ABORTED
+    mock_gateway
+        .expect_execute_streaming_sql()
+        .times(1)
+        .in_sequence(&mut sequence)
+        .returning(|_| single_row_streaming_response_with_transaction(b"tx-attempt-1"));
+
+    mock_gateway
+        .expect_commit()
+        .times(1)
+        .in_sequence(&mut sequence)
+        .returning(|request| {
+            assert_eq!(
+                request.get_ref().transaction,
+                Some(mock_v1::commit_request::Transaction::TransactionId(
+                    b"tx-attempt-1".to_vec()
+                )),
+                "first commit attempt must carry tx-attempt-1"
+            );
+            Err(TonicStatus::aborted("Transaction concurrency conflict"))
+        });
+
+    // Attempt 2: ExecuteStreamingSql succeeds with tx-attempt-2, and Commit succeeds
+    mock_gateway
+        .expect_execute_streaming_sql()
+        .times(1)
+        .in_sequence(&mut sequence)
+        .returning(|_| single_row_streaming_response_with_transaction(b"tx-attempt-2"));
+
+    let commit_received = Arc::new(AtomicBool::new(false));
+    let commit_received_clone = Arc::clone(&commit_received);
+    mock_gateway
+        .expect_commit()
+        .times(1)
+        .in_sequence(&mut sequence)
+        .returning(move |request| {
+            commit_received_clone.store(true, Ordering::SeqCst);
+            assert_eq!(
+                request.get_ref().transaction,
+                Some(mock_v1::commit_request::Transaction::TransactionId(
+                    b"tx-attempt-2".to_vec()
+                )),
+                "second commit attempt must carry tx-attempt-2"
+            );
+            Ok(Response::new(mock_v1::CommitResponse {
+                commit_timestamp: Some(Timestamp {
+                    seconds: 1700000000,
+                    nanos: 0,
+                }),
+                ..Default::default()
+            }))
+        });
+
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_clone = Arc::clone(&attempts);
+    let router_clone = Arc::clone(router);
+    let gateway_address_clone = gateway_address.clone();
+
+    let runner = database_client.read_write_transaction().build().await?;
+    runner
+        .run(|transaction: ReadWriteTransaction| {
+            let attempts = Arc::clone(&attempts_clone);
+            let router_clone = Arc::clone(&router_clone);
+            let gateway_address_clone = gateway_address_clone.clone();
+            async move {
+                let current_attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                let mut result_set = transaction.execute_query("SELECT 1").await?;
+                let row = result_set.next().await;
+                assert!(
+                    row.is_some(),
+                    "result set should yield a row on each attempt"
+                );
+                let row = row.expect("row must exist")?;
+                assert_eq!(row.raw_values().len(), 1, "row must contain 1 column");
+
+                if current_attempt == 1 {
+                    assert_eq!(
+                        router_clone.get_transaction_affinity(b"tx-attempt-1"),
+                        Some(Arc::from(gateway_address_clone.as_str())),
+                        "first attempt must bind affinity to gateway for tx-attempt-1"
+                    );
+                } else if current_attempt == 2 {
+                    assert_eq!(
+                        router_clone.get_transaction_affinity(b"tx-attempt-2"),
+                        Some(Arc::from(gateway_address_clone.as_str())),
+                        "retried attempt must bind affinity to gateway for tx-attempt-2"
+                    );
+                }
+
+                Ok(())
+            }
+        })
+        .await?;
+
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        2,
+        "transaction should succeed on second attempt"
+    );
+    assert!(
+        commit_received.load(Ordering::SeqCst),
+        "commit must be received for the retried attempt"
+    );
+    assert_eq!(
+        router.get_transaction_affinity(b"tx-attempt-2"),
+        None,
+        "commit must clear affinity for second attempt"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
+async fn streaming_read_with_inline_begin_rw_routed_to_tablet_records_tablet_affinity()
+-> anyhow::Result<()> {
+    let mock_gateway = create_base_mock();
+    let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
+
+    let mut mock_tablet = create_base_mock();
+    let tablet_read_received = Arc::new(AtomicBool::new(false));
+    let tablet_read_received_clone = Arc::clone(&tablet_read_received);
+    mock_tablet
+        .expect_streaming_read()
+        .returning(move |request| {
+            tablet_read_received_clone.store(true, Ordering::SeqCst);
+            let hint = request
+                .get_ref()
+                .routing_hint
+                .as_ref()
+                .expect("routing hint must be present on routed request");
+            assert_eq!(
+                hint.tablet_uid, 5001,
+                "routing hint must target tablet 5001"
+            );
+            single_row_streaming_response_with_transaction(b"tx-inline-tablet-read-rw")
+        });
+    let (tablet_address, _tablet_server) = start("127.0.0.1:0", mock_tablet).await?;
+
+    let spanner = Spanner::builder()
+        .with_endpoint(gateway_address.clone())
+        .with_instance_type(InstanceType::Omni)
+        .with_credentials(Anonymous::new().build())
+        .build()
+        .await?;
+
+    let database_client = spanner
+        .database_client("projects/test-project/instances/test-instance/databases/test-db")
+        .with_location_aware_routing(true)
+        .build()
+        .await?;
+
+    let router = database_client
+        .location_router()
+        .expect("location router must be present");
+
+    let mut cache_update = sample_model_cache_update(5005, 5001, &tablet_address, &tablet_address);
+    cache_update.range = vec![ModelRange {
+        start_key: Bytes::from_static(b""),
+        limit_key: Bytes::from_static(b""),
+        group_uid: 5001,
+        split_id: 5001,
+        generation: Bytes::from_static(b"gen_1"),
+        _unknown_fields: Default::default(),
+    }];
+    database_client.observe_cache_update(Some(cache_update));
+
+    let client_config = database_client
+        .cache_updater()
+        .expect("cache updater present")
+        .client_config();
+    let _ = router
+        .connection_cache()
+        .get(&tablet_address, client_config)
+        .await?;
+
+    let read_request = ReadRequest::builder("Singers", vec!["SingerId"])
+        .with_keys(key![100i64])
+        .build()
+        .into_request()
+        .set_session(
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/session-1",
+        )
+        .set_transaction(
+            TransactionSelector::default()
+                .set_begin(TransactionOptions::default().set_read_write(ReadWrite::default())),
+        );
+
+    let mut stream = database_client
+        .streaming_read(read_request, RequestOptions::default(), 0)
+        .send()
+        .await?;
+
+    let message = stream.next_message().await;
+    assert!(
+        message.is_some(),
+        "stream should yield at least one message"
+    );
+    let message = message.expect("message must exist")?;
+    assert!(
+        message.metadata.is_some(),
+        "partial result set should contain metadata"
+    );
+
+    assert!(
+        tablet_read_received.load(Ordering::SeqCst),
+        "streaming_read with inline begin must be received by tablet"
+    );
+    assert_eq!(
+        router.get_transaction_affinity(b"tx-inline-tablet-read-rw"),
+        Some(Arc::from(tablet_address.as_str())),
+        "inline begin routed to tablet must record affinity to tablet address"
+    );
+
+    Ok(())
+}
+
+#[tokio_test_no_panics]
 async fn unary_partition_read_routes_to_tablet_node() -> anyhow::Result<()> {
     let mock_gateway = create_base_mock();
     let (gateway_address, _gateway_server) = start("127.0.0.1:0", mock_gateway).await?;
@@ -3844,6 +4695,47 @@ fn single_row_streaming_response(
     sender
         .try_send(Ok(partial_result_set))
         .expect("send partial result set");
+    Ok(Response::from(receiver))
+}
+
+fn single_row_streaming_response_with_transaction(
+    transaction_id: &[u8],
+) -> Result<Response<mpsc::Receiver<Result<mock_v1::PartialResultSet, TonicStatus>>>, TonicStatus> {
+    let partial_result_set = mock_v1::PartialResultSet {
+        metadata: Some(mock_v1::ResultSetMetadata {
+            row_type: Some(mock_v1::StructType {
+                fields: vec![mock_v1::struct_type::Field {
+                    name: "SingerId".to_string(),
+                    r#type: Some(mock_v1::Type {
+                        code: mock_v1::TypeCode::Int64 as i32,
+                        ..Default::default()
+                    }),
+                }],
+            }),
+            transaction: Some(mock_v1::Transaction {
+                id: transaction_id.to_vec(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        values: vec![Value {
+            kind: Some(prost_types::value::Kind::StringValue("42".to_string())),
+        }],
+        last: true,
+        ..Default::default()
+    };
+    let (sender, receiver) = mpsc::channel(1);
+    sender
+        .try_send(Ok(partial_result_set))
+        .expect("send partial result set");
+    Ok(Response::from(receiver))
+}
+
+fn streaming_error_response(
+    status: TonicStatus,
+) -> Result<Response<mpsc::Receiver<Result<mock_v1::PartialResultSet, TonicStatus>>>, TonicStatus> {
+    let (sender, receiver) = mpsc::channel(1);
+    sender.try_send(Err(status)).expect("send streaming error");
     Ok(Response::from(receiver))
 }
 

--- a/src/spanner/src/server_streaming/builder.rs
+++ b/src/spanner/src/server_streaming/builder.rs
@@ -23,6 +23,7 @@ use crate::model::ReadRequest;
 use crate::server_streaming::stream::BatchWriteStream;
 use crate::server_streaming::stream::CacheUpdateStream;
 use crate::server_streaming::stream::PartialResultSetStream;
+use crate::server_streaming::stream::TransactionIdCallback;
 use gaxi::grpc::tonic;
 use gaxi::grpc::tonic::Extensions;
 use gaxi::grpc::tonic::GrpcMethod;
@@ -31,11 +32,12 @@ use prost::Message;
 use std::sync::LazyLock;
 
 /// The request builder for [SpannerImpl::execute_streaming_sql][crate::client::SpannerImpl::execute_streaming_sql] calls.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct ExecuteStreamingSql {
     grpc_client: gaxi::grpc::Client,
     request: ExecuteSqlRequest,
     options: RequestOptions,
+    on_first_transaction_id: Option<TransactionIdCallback>,
 }
 
 impl ExecuteStreamingSql {
@@ -44,6 +46,7 @@ impl ExecuteStreamingSql {
             grpc_client,
             request: ExecuteSqlRequest::default(),
             options: RequestOptions::default(),
+            on_first_transaction_id: None,
         }
     }
 
@@ -56,6 +59,15 @@ impl ExecuteStreamingSql {
     /// Sets all the options, replacing any prior values.
     pub(crate) fn with_options<V: Into<RequestOptions>>(mut self, v: V) -> Self {
         self.options = v.into();
+        self
+    }
+
+    /// Attaches a callback to invoke when the first non-empty transaction ID arrives in the stream.
+    pub(crate) fn with_transaction_id_callback<C: Into<Option<TransactionIdCallback>>>(
+        mut self,
+        callback: C,
+    ) -> Self {
+        self.on_first_transaction_id = callback.into();
         self
     }
 
@@ -75,7 +87,8 @@ impl ExecuteStreamingSql {
         .await?;
         let (metadata, stream, _) = response.into_parts();
         let headers = metadata.into_headers();
-        Ok(PartialResultSetStream::new(stream, headers))
+        Ok(PartialResultSetStream::new(stream, headers)
+            .with_transaction_id_callback(self.on_first_transaction_id))
     }
 }
 
@@ -86,11 +99,12 @@ impl RequestBuilder for ExecuteStreamingSql {
 }
 
 /// The request builder for [SpannerImpl::streaming_read][crate::client::SpannerImpl::streaming_read] calls.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct StreamingRead {
     grpc_client: gaxi::grpc::Client,
     request: ReadRequest,
     options: RequestOptions,
+    on_first_transaction_id: Option<TransactionIdCallback>,
 }
 
 impl StreamingRead {
@@ -99,6 +113,7 @@ impl StreamingRead {
             grpc_client,
             request: ReadRequest::default(),
             options: RequestOptions::default(),
+            on_first_transaction_id: None,
         }
     }
 
@@ -111,6 +126,15 @@ impl StreamingRead {
     /// Sets all the options, replacing any prior values.
     pub(crate) fn with_options<V: Into<RequestOptions>>(mut self, v: V) -> Self {
         self.options = v.into();
+        self
+    }
+
+    /// Attaches a callback to invoke when the first non-empty transaction ID arrives in the stream.
+    pub(crate) fn with_transaction_id_callback<C: Into<Option<TransactionIdCallback>>>(
+        mut self,
+        callback: C,
+    ) -> Self {
+        self.on_first_transaction_id = callback.into();
         self
     }
 
@@ -130,7 +154,8 @@ impl StreamingRead {
         .await?;
         let (metadata, stream, _) = response.into_parts();
         let headers = metadata.into_headers();
-        Ok(PartialResultSetStream::new(stream, headers))
+        Ok(PartialResultSetStream::new(stream, headers)
+            .with_transaction_id_callback(self.on_first_transaction_id))
     }
 }
 

--- a/src/spanner/src/server_streaming/stream.rs
+++ b/src/spanner/src/server_streaming/stream.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::Result;
 use crate::google::spanner::v1::BatchWriteResponse;
 use crate::google::spanner::v1::CacheUpdate as ProtoCacheUpdate;
 use crate::google::spanner::v1::PartialResultSet;
@@ -19,6 +20,7 @@ use gaxi::grpc::from_status::to_gax_error;
 use gaxi::grpc::tonic::Streaming;
 use http::HeaderMap;
 use std::any::Any;
+use std::fmt::{Debug, Formatter, Result as FmtResult};
 
 /// Type alias for opaque stream lifetime drop guards.
 pub(crate) type StreamLifetimeGuard = Box<dyn Any + Send + Sync>;
@@ -29,6 +31,7 @@ pub(crate) struct SpannerServerStream<T> {
     pub(crate) inner: Streaming<T>,
     pub(crate) headers: HeaderMap,
     pub(crate) lifetime_guard: Option<StreamLifetimeGuard>,
+    pub(crate) on_first_transaction_id: Option<TransactionIdCallback>,
 }
 
 impl<T> SpannerServerStream<T> {
@@ -37,6 +40,7 @@ impl<T> SpannerServerStream<T> {
             inner,
             headers,
             lifetime_guard: None,
+            on_first_transaction_id: None,
         }
     }
 
@@ -47,24 +51,90 @@ impl<T> SpannerServerStream<T> {
         self
     }
 
+    /// Attaches a callback to invoke when the first non-empty transaction ID arrives in the stream.
+    pub(crate) fn with_transaction_id_callback<C: Into<Option<TransactionIdCallback>>>(
+        mut self,
+        callback: C,
+    ) -> Self {
+        self.on_first_transaction_id = callback.into();
+        self
+    }
+
     /// Returns the initial response headers for the stream.
     pub(crate) fn headers(&self) -> &HeaderMap {
         &self.headers
     }
+}
 
+impl<T: StreamTransactionIdExtractor> SpannerServerStream<T> {
     /// Fetches the next message from the stream.
     ///
     /// Returns `Some(Ok(message))` when a message is successfully received,
     /// `None` when the stream concludes naturally, or `Some(Err(_))` on RPC errors.
     /// Drops the attached lifetime guard on EOF or stream errors to release active in-flight accounting early.
-    pub(crate) async fn next_message(&mut self) -> Option<crate::Result<T>> {
-        match self.inner.message().await.map_err(to_gax_error).transpose() {
-            Some(Ok(message)) => Some(Ok(message)),
+    pub(crate) async fn next_message(&mut self) -> Option<Result<T>> {
+        let message = match self.inner.message().await.map_err(to_gax_error).transpose() {
+            Some(Ok(message)) => message,
             other => {
                 self.lifetime_guard = None;
-                other
+                self.on_first_transaction_id = None;
+                return other;
             }
+        };
+
+        if self.on_first_transaction_id.is_some()
+            && let Some(transaction_id) = message.extract_transaction_id()
+            && let Some(callback) = self.on_first_transaction_id.take()
+        {
+            callback.call(transaction_id);
         }
+
+        Some(Ok(message))
+    }
+}
+
+/// Trait implemented by stream response message types capable of carrying a transaction ID.
+pub(crate) trait StreamTransactionIdExtractor {
+    fn extract_transaction_id(&self) -> Option<&[u8]> {
+        None
+    }
+}
+
+impl StreamTransactionIdExtractor for PartialResultSet {
+    fn extract_transaction_id(&self) -> Option<&[u8]> {
+        self.metadata
+            .as_ref()
+            .and_then(|metadata| metadata.transaction.as_ref())
+            .map(|transaction| transaction.id.as_ref())
+            .filter(|id| !id.is_empty())
+    }
+}
+
+impl StreamTransactionIdExtractor for BatchWriteResponse {}
+
+impl StreamTransactionIdExtractor for ProtoCacheUpdate {}
+
+type TransactionIdCallbackFn = dyn FnOnce(&[u8]) + Send + Sync;
+
+/// Callback invoked when a stream receives its first non-empty transaction ID.
+pub(crate) struct TransactionIdCallback(Box<TransactionIdCallbackFn>);
+
+impl TransactionIdCallback {
+    pub(crate) fn new<F>(callback: F) -> Self
+    where
+        F: FnOnce(&[u8]) + Send + Sync + 'static,
+    {
+        Self(Box::new(callback))
+    }
+
+    pub(crate) fn call(self, transaction_id: &[u8]) {
+        (self.0)(transaction_id);
+    }
+}
+
+impl Debug for TransactionIdCallback {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
+        formatter.write_str("TransactionIdCallback")
     }
 }
 
@@ -79,19 +149,51 @@ pub(crate) type CacheUpdateStream = SpannerServerStream<ProtoCacheUpdate>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::ExecuteSqlRequest;
     use crate::read_only_transaction::tests::{create_session_mock, setup_db_client};
     use gaxi::grpc::tonic::{Response, Status};
     use google_cloud_gax::options::RequestOptions;
     use google_cloud_test_macros::tokio_test_no_panics;
+    use spanner_grpc_mock::google::spanner::v1::{
+        PartialResultSet as MockPartialResultSet, ResultSetMetadata as MockResultSetMetadata,
+        Transaction as MockTransaction,
+    };
     use std::fmt::Debug;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn auto_traits() {
         static_assertions::assert_impl_all!(PartialResultSetStream: Send, Sync, Debug);
         static_assertions::assert_impl_all!(BatchWriteStream: Send, Sync, Debug);
         static_assertions::assert_impl_all!(CacheUpdateStream: Send, Sync, Debug);
+        static_assertions::assert_impl_all!(TransactionIdCallback: Send, Sync, Debug);
+    }
+
+    #[test]
+    fn transaction_id_callback_debug_format() {
+        let callback = TransactionIdCallback::new(|_| {});
+        assert_eq!(
+            format!("{callback:?}"),
+            "TransactionIdCallback",
+            "TransactionIdCallback debug representation must match expected name"
+        );
+    }
+
+    #[test]
+    fn default_extract_transaction_id_is_none() {
+        assert!(
+            BatchWriteResponse::default()
+                .extract_transaction_id()
+                .is_none(),
+            "BatchWriteResponse must return None from default extract_transaction_id"
+        );
+        assert!(
+            ProtoCacheUpdate::default()
+                .extract_transaction_id()
+                .is_none(),
+            "ProtoCacheUpdate must return None from default extract_transaction_id"
+        );
     }
 
     struct TestDropGuard {
@@ -119,7 +221,7 @@ mod tests {
         let (db_client, _server) = setup_db_client(mock).await;
 
         {
-            let request = crate::model::ExecuteSqlRequest::default()
+            let request = ExecuteSqlRequest::default()
                 .set_session(db_client.session_name())
                 .set_sql("SELECT 1");
             let stream = db_client
@@ -156,7 +258,7 @@ mod tests {
 
         let (db_client, _server) = setup_db_client(mock).await;
 
-        let request = crate::model::ExecuteSqlRequest::default()
+        let request = ExecuteSqlRequest::default()
             .set_session(db_client.session_name())
             .set_sql("SELECT 1");
         let mut stream = db_client
@@ -196,7 +298,7 @@ mod tests {
 
         let (db_client, _server) = setup_db_client(mock).await;
 
-        let request = crate::model::ExecuteSqlRequest::default()
+        let request = ExecuteSqlRequest::default()
             .set_session(db_client.session_name())
             .set_sql("SELECT 1");
         let mut stream = db_client
@@ -225,6 +327,161 @@ mod tests {
             dropped.load(Ordering::Relaxed),
             "Guard must be dropped immediately on stream error"
         );
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn transaction_id_callback_invoked_on_first_message() -> anyhow::Result<()> {
+        let invoked_transaction_id = Arc::new(Mutex::new(None));
+        let invoked_transaction_id_clone = Arc::clone(&invoked_transaction_id);
+        let callback = TransactionIdCallback::new(move |transaction_id| {
+            *invoked_transaction_id_clone
+                .lock()
+                .expect("lock callback mutex") = Some(transaction_id.to_vec());
+        });
+
+        let mut mock = create_session_mock();
+        let (sender, receiver) = tokio::sync::mpsc::channel(2);
+        mock.expect_execute_streaming_sql()
+            .return_once(move |_| Ok(Response::from(receiver)));
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let request = ExecuteSqlRequest::default()
+            .set_session(db_client.session_name())
+            .set_sql("SELECT 1");
+        let mut stream = db_client
+            .execute_streaming_sql(request, RequestOptions::default(), 0)
+            .send()
+            .await?
+            .with_transaction_id_callback(callback);
+
+        // Send first chunk with transaction ID
+        let first_chunk = MockPartialResultSet {
+            metadata: Some(MockResultSetMetadata {
+                transaction: Some(MockTransaction {
+                    id: b"stream-unit-tx".to_vec(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        sender
+            .send(Ok(first_chunk))
+            .await
+            .expect("send first chunk");
+
+        // Send second chunk without transaction ID
+        let second_chunk = MockPartialResultSet::default();
+        sender
+            .send(Ok(second_chunk))
+            .await
+            .expect("send second chunk");
+
+        // First message consumes chunk 1 and triggers callback
+        let first_message = stream.next_message().await;
+        assert!(first_message.is_some(), "first message must be received");
+        assert!(
+            first_message.expect("first message").is_ok(),
+            "first message must be ok"
+        );
+        assert_eq!(
+            invoked_transaction_id
+                .lock()
+                .expect("lock invoked transaction ID")
+                .as_deref(),
+            Some(&b"stream-unit-tx"[..]),
+            "callback must be invoked with transaction ID on first message"
+        );
+
+        // Second message consumes chunk 2 and callback is not called again
+        let second_message = stream.next_message().await;
+        assert!(second_message.is_some(), "second message must be received");
+        assert!(
+            second_message.expect("second message").is_ok(),
+            "second message must be ok"
+        );
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn transaction_id_callback_dropped_on_eof_and_error() -> anyhow::Result<()> {
+        struct DropTracker(Arc<AtomicBool>);
+        impl Drop for DropTracker {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Relaxed);
+            }
+        }
+
+        // EOF case
+        {
+            let dropped = Arc::new(AtomicBool::new(false));
+            let tracker = DropTracker(Arc::clone(&dropped));
+            let callback = TransactionIdCallback::new(move |_| {
+                let _ = &tracker;
+            });
+
+            let mut mock = create_session_mock();
+            let (sender, receiver) = tokio::sync::mpsc::channel(1);
+            mock.expect_execute_streaming_sql()
+                .return_once(move |_| Ok(Response::from(receiver)));
+
+            let (db_client, _server) = setup_db_client(mock).await;
+            let request = ExecuteSqlRequest::default()
+                .set_session(db_client.session_name())
+                .set_sql("SELECT 1");
+            let mut stream = db_client
+                .execute_streaming_sql(request, RequestOptions::default(), 0)
+                .send()
+                .await?
+                .with_transaction_id_callback(callback);
+
+            drop(sender); // EOF
+            let message = stream.next_message().await;
+            assert!(message.is_none(), "stream should return None on EOF");
+            assert!(
+                dropped.load(Ordering::Relaxed),
+                "callback must be dropped on stream EOF"
+            );
+        }
+
+        // Error case
+        {
+            let dropped = Arc::new(AtomicBool::new(false));
+            let tracker = DropTracker(Arc::clone(&dropped));
+            let callback = TransactionIdCallback::new(move |_| {
+                let _ = &tracker;
+            });
+
+            let mut mock = create_session_mock();
+            let (sender, receiver) = tokio::sync::mpsc::channel(1);
+            mock.expect_execute_streaming_sql()
+                .return_once(move |_| Ok(Response::from(receiver)));
+
+            let (db_client, _server) = setup_db_client(mock).await;
+            let request = ExecuteSqlRequest::default()
+                .set_session(db_client.session_name())
+                .set_sql("SELECT 1");
+            let mut stream = db_client
+                .execute_streaming_sql(request, RequestOptions::default(), 0)
+                .send()
+                .await?
+                .with_transaction_id_callback(callback);
+
+            sender
+                .send(Err(Status::internal("rpc failed")))
+                .await
+                .expect("send error");
+            let message = stream.next_message().await;
+            assert!(message.is_some(), "stream should return Some on error");
+            assert!(
+                dropped.load(Ordering::Relaxed),
+                "callback must be dropped on stream error"
+            );
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
When executing a streaming query (execute_streaming_sql) or streaming read (streaming_read) with an inline-begin read-write transaction in Spanner Omni, the returned transaction ID was not being captured to establish location-aware routing affinity.

This change:
- Captures the transaction ID from the first stream response chunk and registers node affinity with the location router.
- Introduces a single-use TransactionIdCallback (Box<dyn FnOnce>) attached during stream construction.
- Adds helper logic on DatabaseClient to determine whether affinity recording is required based on the transaction selector and routing mode.
- Expands mock tests covering inline-begin streaming queries, streaming reads, stream errors, and aborted transaction retries.