### PR TITLE
refactor(bigquery): split append builder

### DIFF
--- a/src/bigquery/src/lib.rs
+++ b/src/bigquery/src/lib.rs
@@ -154,7 +154,7 @@ pub mod builder {
     }
     /// Request and client builders for the [Write][crate::client::Write] client.
     pub mod write {
-        pub use crate::write::append_builder::{Append, AppendWithOffset};
+        pub use crate::write::builder::{Append, AppendWithOffset};
         pub use crate::write::client_builder::ClientBuilder;
     }
 }

--- a/src/bigquery/src/write/arrow/buffered.rs
+++ b/src/bigquery/src/write/arrow/buffered.rs
@@ -15,7 +15,7 @@
 use super::base::BaseWriter;
 use crate::Result;
 use crate::model::{ArrowRecordBatch, ArrowSchema, FinalizeWriteStreamResponse, FlushRowsResponse};
-use crate::write::append_builder::AppendWithOffset;
+use crate::write::builder::AppendWithOffset;
 use crate::write::transport::Transport;
 use std::sync::Arc;
 

--- a/src/bigquery/src/write/arrow/committed.rs
+++ b/src/bigquery/src/write/arrow/committed.rs
@@ -15,7 +15,7 @@
 use super::base::BaseWriter;
 use crate::Result;
 use crate::model::{ArrowRecordBatch, ArrowSchema, FinalizeWriteStreamResponse};
-use crate::write::append_builder::AppendWithOffset;
+use crate::write::builder::AppendWithOffset;
 use crate::write::transport::Transport;
 use std::sync::Arc;
 

--- a/src/bigquery/src/write/arrow/default.rs
+++ b/src/bigquery/src/write/arrow/default.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::super::append_builder::Append;
+use super::super::builder::Append;
 use super::super::runner::Runner;
 use super::super::transport::Transport;
 use crate::model::append_rows_request::ArrowData;

--- a/src/bigquery/src/write/arrow/pending.rs
+++ b/src/bigquery/src/write/arrow/pending.rs
@@ -17,7 +17,7 @@ use crate::Result;
 use crate::model::{
     ArrowRecordBatch, ArrowSchema, BatchCommitWriteStreamsResponse, FinalizeWriteStreamResponse,
 };
-use crate::write::append_builder::AppendWithOffset;
+use crate::write::builder::AppendWithOffset;
 use crate::write::transport::Transport;
 use std::sync::Arc;
 

--- a/src/bigquery/src/write/builder.rs
+++ b/src/bigquery/src/write/builder.rs
@@ -12,31 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Types to write data in [Arrow] format
-///
-/// [arrow]: https://arrow.apache.org/
-pub mod arrow;
+mod append;
+mod append_with_offset;
 
-pub use append_future::AppendFuture;
-
-pub(super) mod append_future;
-pub(super) mod append_response;
-pub(super) mod builder;
-pub(super) mod client;
-pub(super) mod client_builder;
-pub(super) mod error;
-#[cfg_attr(not(test), expect(dead_code))]
-mod pool;
-mod proto_schema;
-mod runner;
-mod stream;
-mod transport;
-
-// TODO(#4832) - remove handwritten code.
-mod status;
-
-#[allow(dead_code)]
-pub(crate) mod generated;
-
-#[cfg(test)]
-mod test;
+pub use append::Append;
+pub use append_with_offset::AppendWithOffset;

--- a/src/bigquery/src/write/builder/append.rs
+++ b/src/bigquery/src/write/builder/append.rs
@@ -1,0 +1,185 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::append_future::AppendFuture;
+use super::super::append_response::to_result;
+use super::super::error::AppendError;
+use super::super::runner::WriteRequest;
+use crate::Error;
+use crate::model::AppendRowsRequest;
+use gaxi::prost::{FromProto, ToProto};
+use tokio::sync::{mpsc, oneshot};
+
+/// A request builder for appending rows on the default stream.
+#[derive(Clone, Debug)]
+pub struct Append {
+    req_tx: mpsc::UnboundedSender<WriteRequest>,
+    pub(crate) req: AppendRowsRequest,
+}
+
+impl Append {
+    pub(crate) fn new(req_tx: mpsc::UnboundedSender<WriteRequest>, req: AppendRowsRequest) -> Self {
+        Self { req_tx, req }
+    }
+
+    /// Append rows to the stream.
+    ///
+    /// Applications are encouraged to queue up requests and await their
+    /// responses independently.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use google_cloud_bigquery::write::arrow::DefaultWriter;
+    /// # async fn sample(writer: DefaultWriter) -> anyhow::Result<()> {
+    /// let f1 = writer.append(rows()).send();
+    /// let f2 = writer.append(rows()).send();
+    ///
+    /// let resp1 = f1.await?;
+    /// let resp2 = f2.await?;
+    /// # Ok(()) }
+    ///
+    /// use google_cloud_bigquery::model::ArrowRecordBatch;
+    /// fn rows() -> ArrowRecordBatch {
+    ///   todo!("Define your rows...")
+    /// }
+    /// ```
+    pub fn send(self) -> AppendFuture {
+        let (tx, rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let (resp_tx, resp_rx) = oneshot::channel();
+            let res = async move {
+                let req = self.req.to_proto().map_err(Error::deser)?;
+                let write = WriteRequest { req, resp_tx };
+                let _ = self.req_tx.send(write);
+                let resp = resp_rx
+                    .await
+                    .map_err(|_| AppendError::UnexpectedEndOfStream)??;
+                let resp = resp.cnv().map_err(Error::ser)?;
+                to_result(resp)
+            }
+            .await;
+            let _ = tx.send(res);
+        });
+        AppendFuture::new(rx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::google::cloud::bigquery::storage::v1;
+    use crate::google::cloud::bigquery::storage::v1::append_rows_response::{
+        AppendResult, Response,
+    };
+    use crate::model::TableSchema;
+    use crate::write::test::*;
+
+    #[tokio::test]
+    async fn success() -> anyhow::Result<()> {
+        let (req_tx, mut req_rx) = mpsc::unbounded_channel();
+        let req = AppendRowsRequest::new().set_write_stream(write_stream());
+
+        let builder = Append::new(req_tx, req);
+        let handle = tokio::spawn(async move { builder.send().await });
+
+        // Receive and verify the request
+        let write = req_rx.recv().await.expect("should receive request");
+        assert_eq!(write.req.write_stream, write_stream());
+
+        // Provide a successful response
+        let resp = v1::AppendRowsResponse {
+            response: Some(Response::AppendResult(AppendResult::default())),
+            write_stream: write_stream(),
+            updated_schema: Some(v1::TableSchema::default()),
+            ..Default::default()
+        };
+        write
+            .resp_tx
+            .send(Ok(resp))
+            .expect("sending on channel always succeeds");
+
+        let resp = handle.await??;
+        assert_eq!(resp.offset, None);
+        assert_eq!(resp.updated_schema, Some(TableSchema::default()));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stream_closed() -> anyhow::Result<()> {
+        let (req_tx, req_rx) = mpsc::unbounded_channel();
+        let req = AppendRowsRequest::new().set_write_stream(write_stream());
+
+        let builder = Append::new(req_tx, req);
+        let handle = tokio::spawn(async move { builder.send().await });
+
+        // Simulate a stream closure
+        drop(req_rx);
+
+        let err = handle.await?.expect_err("should return an error");
+        assert!(matches!(err, AppendError::UnexpectedEndOfStream));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rpc_error() -> anyhow::Result<()> {
+        let (req_tx, mut req_rx) = mpsc::unbounded_channel();
+        let req = AppendRowsRequest::new().set_write_stream(write_stream());
+
+        let builder = Append::new(req_tx, req);
+        let handle = tokio::spawn(async move { builder.send().await });
+
+        // Simulate a stream ending in a known error
+        let write = req_rx.recv().await.expect("should receive request");
+        let append_err: AppendError = Error::io("fail").into();
+        write
+            .resp_tx
+            .send(Err(append_err))
+            .expect("sending on channel always succeeds");
+
+        let err = handle.await?.expect_err("should return an error");
+        assert!(matches!(err, AppendError::Rpc { source: _ }));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn row_errors() -> anyhow::Result<()> {
+        let (req_tx, mut req_rx) = mpsc::unbounded_channel();
+        let req = AppendRowsRequest::new().set_write_stream(write_stream());
+
+        let builder = Append::new(req_tx, req);
+        let handle = tokio::spawn(async move { builder.send().await });
+
+        let write = req_rx.recv().await.expect("should receive request");
+
+        let row_error = v1::RowError {
+            index: 42,
+            code: v1::row_error::RowErrorCode::FieldsError as i32,
+            message: "fail".to_string(),
+        };
+        let resp = v1::AppendRowsResponse {
+            row_errors: vec![row_error],
+            write_stream: write_stream(),
+            ..Default::default()
+        };
+        write
+            .resp_tx
+            .send(Ok(resp))
+            .expect("sending on channel always succeeds");
+
+        let err = handle.await?.expect_err("should return an error");
+        assert!(matches!(err, AppendError::RowErrors(_)));
+        Ok(())
+    }
+}

--- a/src/bigquery/src/write/builder/append_with_offset.rs
+++ b/src/bigquery/src/write/builder/append_with_offset.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::append_future::AppendFuture;
-use super::append_response::to_result;
-use super::error::AppendError;
-use super::runner::WriteRequest;
+use super::super::append_future::AppendFuture;
+use super::super::append_response::to_result;
+use super::super::error::AppendError;
+use super::super::runner::WriteRequest;
 use crate::Error;
 use crate::model::AppendRowsRequest;
 use gaxi::prost::{FromProto, ToProto};
@@ -109,61 +109,6 @@ impl AppendWithOffset {
     }
 }
 
-/// A request builder for appending rows on the default stream.
-#[derive(Clone, Debug)]
-pub struct Append {
-    req_tx: mpsc::UnboundedSender<WriteRequest>,
-    pub(crate) req: AppendRowsRequest,
-}
-
-impl Append {
-    pub(crate) fn new(req_tx: mpsc::UnboundedSender<WriteRequest>, req: AppendRowsRequest) -> Self {
-        Self { req_tx, req }
-    }
-
-    /// Append rows to the stream.
-    ///
-    /// Applications are encouraged to queue up requests and await their
-    /// responses independently.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use google_cloud_bigquery::write::arrow::DefaultWriter;
-    /// # async fn sample(writer: DefaultWriter) -> anyhow::Result<()> {
-    /// let f1 = writer.append(rows()).send();
-    /// let f2 = writer.append(rows()).send();
-    ///
-    /// let resp1 = f1.await?;
-    /// let resp2 = f2.await?;
-    /// # Ok(()) }
-    ///
-    /// use google_cloud_bigquery::model::ArrowRecordBatch;
-    /// fn rows() -> ArrowRecordBatch {
-    ///   todo!("Define your rows...")
-    /// }
-    /// ```
-    pub fn send(self) -> AppendFuture {
-        let (tx, rx) = oneshot::channel();
-        tokio::spawn(async move {
-            let (resp_tx, resp_rx) = oneshot::channel();
-            let res = async move {
-                let req = self.req.to_proto().map_err(Error::deser)?;
-                let write = WriteRequest { req, resp_tx };
-                let _ = self.req_tx.send(write);
-                let resp = resp_rx
-                    .await
-                    .map_err(|_| AppendError::UnexpectedEndOfStream)??;
-                let resp = resp.cnv().map_err(Error::ser)?;
-                to_result(resp)
-            }
-            .await;
-            let _ = tx.send(res);
-        });
-        AppendFuture::new(rx)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -171,107 +116,10 @@ mod tests {
     use crate::google::cloud::bigquery::storage::v1::append_rows_response::{
         AppendResult, Response,
     };
-    use crate::model::TableSchema;
+    use crate::write::test::*;
 
     #[tokio::test]
     async fn success() -> anyhow::Result<()> {
-        let (req_tx, mut req_rx) = mpsc::unbounded_channel();
-        let req = AppendRowsRequest::new().set_write_stream(write_stream());
-
-        let builder = Append::new(req_tx, req);
-        let handle = tokio::spawn(async move { builder.send().await });
-
-        // Receive and verify the request
-        let write = req_rx.recv().await.expect("should receive request");
-        assert_eq!(write.req.write_stream, write_stream());
-
-        // Provide a successful response
-        let resp = v1::AppendRowsResponse {
-            response: Some(Response::AppendResult(AppendResult::default())),
-            write_stream: write_stream(),
-            updated_schema: Some(v1::TableSchema::default()),
-            ..Default::default()
-        };
-        write
-            .resp_tx
-            .send(Ok(resp))
-            .expect("sending on channel always succeeds");
-
-        let resp = handle.await??;
-        assert_eq!(resp.offset, None);
-        assert_eq!(resp.updated_schema, Some(TableSchema::default()));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn stream_closed() -> anyhow::Result<()> {
-        let (req_tx, req_rx) = mpsc::unbounded_channel();
-        let req = AppendRowsRequest::new().set_write_stream(write_stream());
-
-        let builder = Append::new(req_tx, req);
-        let handle = tokio::spawn(async move { builder.send().await });
-
-        // Simulate a stream closure
-        drop(req_rx);
-
-        let err = handle.await?.expect_err("should return an error");
-        assert!(matches!(err, AppendError::UnexpectedEndOfStream));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn rpc_error() -> anyhow::Result<()> {
-        let (req_tx, mut req_rx) = mpsc::unbounded_channel();
-        let req = AppendRowsRequest::new().set_write_stream(write_stream());
-
-        let builder = Append::new(req_tx, req);
-        let handle = tokio::spawn(async move { builder.send().await });
-
-        // Simulate a stream ending in a known error
-        let write = req_rx.recv().await.expect("should receive request");
-        let append_err: AppendError = Error::io("fail").into();
-        write
-            .resp_tx
-            .send(Err(append_err))
-            .expect("sending on channel always succeeds");
-
-        let err = handle.await?.expect_err("should return an error");
-        assert!(matches!(err, AppendError::Rpc { source: _ }));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn row_errors() -> anyhow::Result<()> {
-        let (req_tx, mut req_rx) = mpsc::unbounded_channel();
-        let req = AppendRowsRequest::new().set_write_stream(write_stream());
-
-        let builder = Append::new(req_tx, req);
-        let handle = tokio::spawn(async move { builder.send().await });
-
-        let write = req_rx.recv().await.expect("should receive request");
-
-        let row_error = v1::RowError {
-            index: 42,
-            code: v1::row_error::RowErrorCode::FieldsError as i32,
-            message: "fail".to_string(),
-        };
-        let resp = v1::AppendRowsResponse {
-            row_errors: vec![row_error],
-            write_stream: write_stream(),
-            ..Default::default()
-        };
-        write
-            .resp_tx
-            .send(Ok(resp))
-            .expect("sending on channel always succeeds");
-
-        let err = handle.await?.expect_err("should return an error");
-        assert!(matches!(err, AppendError::RowErrors(_)));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn offset_success() -> anyhow::Result<()> {
         let (req_tx, mut req_rx) = mpsc::unbounded_channel();
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
@@ -299,7 +147,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn offset_stream_closed() -> anyhow::Result<()> {
+    async fn stream_closed() -> anyhow::Result<()> {
         let (req_tx, req_rx) = mpsc::unbounded_channel();
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
@@ -314,7 +162,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn offset_rpc_error() -> anyhow::Result<()> {
+    async fn rpc_error() -> anyhow::Result<()> {
         let (req_tx, mut req_rx) = mpsc::unbounded_channel();
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
@@ -335,7 +183,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn offset_row_errors() -> anyhow::Result<()> {
+    async fn row_errors() -> anyhow::Result<()> {
         let (req_tx, mut req_rx) = mpsc::unbounded_channel();
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
@@ -386,9 +234,5 @@ mod tests {
         }
         write_handle.await?;
         Ok(())
-    }
-
-    fn write_stream() -> String {
-        "projects/p/datasets/d/tables/t/streams/_default".to_string()
     }
 }


### PR DESCRIPTION
There were two types defined in here. While similar, I think it is nicer if they are defined in separate files.