### PR TITLE
chore(spanner): implement transaction affinity resolution, R/W counting, and CAS conflict handling in channel pool

### DIFF
--- a/src/spanner/src/channel_pool/affinity.rs
+++ b/src/spanner/src/channel_pool/affinity.rs
@@ -17,6 +17,9 @@
 //! Provides caller-owned handles to pin multi-statement transactions to the same physical
 //! channel and support both hard affinity (Read/Write transactions) and soft affinity (Read-Only transactions).
 
+use crate::channel_pool::entry::{ChannelLease, RwTransactionAffinityGuard};
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Caller-owned handle managing channel affinity across multi-statement transactions.
@@ -24,6 +27,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 pub(crate) struct TransactionAffinity {
     entry_id: AtomicU64,
     kind: AffinityKind,
+    rw_guard: Mutex<Option<RwTransactionAffinityGuard>>,
 }
 
 impl Default for TransactionAffinity {
@@ -34,15 +38,11 @@ impl Default for TransactionAffinity {
 
 impl TransactionAffinity {
     /// Creates a new, unpinned `TransactionAffinity` handle for Read/Write transactions (hard stickiness).
-    pub(crate) fn new() -> Self {
-        Self::new_read_write()
-    }
-
-    /// Creates a new, unpinned `TransactionAffinity` handle for Read/Write transactions (hard stickiness).
     pub(crate) fn new_read_write() -> Self {
         Self {
             entry_id: AtomicU64::new(0),
             kind: AffinityKind::ReadWrite,
+            rw_guard: Mutex::new(None),
         }
     }
 
@@ -51,7 +51,18 @@ impl TransactionAffinity {
         Self {
             entry_id: AtomicU64::new(0),
             kind: AffinityKind::ReadOnly,
+            rw_guard: Mutex::new(None),
         }
+    }
+
+    /// Returns the provided affinity handle, or creates a new default `ReadOnly` affinity if `None`.
+    pub(crate) fn default_read_only(existing: Option<Arc<Self>>) -> Arc<Self> {
+        existing.unwrap_or_else(|| Arc::new(Self::new_read_only()))
+    }
+
+    /// Returns the provided affinity handle, or creates a new default `ReadWrite` affinity if `None`.
+    pub(crate) fn default_read_write(existing: Option<Arc<Self>>) -> Arc<Self> {
+        existing.unwrap_or_else(|| Arc::new(Self::new_read_write()))
     }
 
     /// Returns `true` if this handle requires hard stickiness (Read/Write transactions).
@@ -59,21 +70,10 @@ impl TransactionAffinity {
         self.kind == AffinityKind::ReadWrite
     }
 
-    /// Returns `true` if this handle uses soft stickiness (Read-Only transactions).
-    pub(crate) fn is_read_only(&self) -> bool {
-        self.kind == AffinityKind::ReadOnly
-    }
-
     /// Returns the pinned monotonic channel entry ID, or `None` if unpinned.
     pub(crate) fn pinned_entry_id(&self) -> Option<u64> {
         let id = self.entry_id.load(Ordering::Acquire);
         (id != 0).then_some(id)
-    }
-
-    /// Sets the pinned channel entry ID.
-    pub(crate) fn set_entry_id(&self, entry_id: u64) {
-        debug_assert_ne!(entry_id, 0, "entry_id must be non-zero");
-        self.entry_id.store(entry_id, Ordering::Release);
     }
 
     /// Atomically sets the pinned channel entry ID if matching `current`.
@@ -86,9 +86,21 @@ impl TransactionAffinity {
             .map(|_| ())
     }
 
-    /// Clears the pinned channel entry ID, making this handle unpinned.
-    pub(crate) fn reset(&self) {
-        self.entry_id.store(0, Ordering::Release);
+    /// Ensures that an `RwTransactionAffinityGuard` is attached for the leased channel entry.
+    ///
+    /// If an existing guard already protects `lease.entry_id()`, this is a no-op that avoids
+    /// allocating a new guard or mutating active transaction atomic counters.
+    pub(crate) fn ensure_rw_guard(&self, lease: &ChannelLease) {
+        let mut slot = self
+            .rw_guard
+            .lock()
+            .expect("affinity rw_guard lock poisoned");
+        if let Some(existing) = slot.as_ref()
+            && existing.entry_id() == lease.entry_id()
+        {
+            return;
+        }
+        *slot = Some(lease.rw_affinity_guard());
     }
 }
 
@@ -105,14 +117,67 @@ pub(crate) enum AffinityKind {
 }
 
 #[cfg(test)]
+impl TransactionAffinity {
+    pub(crate) fn set_entry_id(&self, entry_id: u64) {
+        debug_assert_ne!(entry_id, 0, "entry_id must be non-zero");
+        self.entry_id.store(entry_id, Ordering::Release);
+    }
+
+    pub(crate) fn set_pinned_entry_id_for_test(&self, id: u64) {
+        self.entry_id.store(id, Ordering::Release);
+    }
+
+    pub(crate) fn is_read_only(&self) -> bool {
+        self.kind == AffinityKind::ReadOnly
+    }
+
+    pub(crate) fn reset(&self) {
+        self.entry_id.store(0, Ordering::Release);
+        let mut slot = self
+            .rw_guard
+            .lock()
+            .expect("affinity rw_guard lock poisoned");
+        *slot = None;
+    }
+
+    pub(crate) fn has_rw_guard(&self) -> bool {
+        self.rw_guard
+            .lock()
+            .expect("affinity rw_guard lock poisoned")
+            .is_some()
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
+    use crate::channel_pool::entry::{ActiveRpcGuard, ChannelEntry};
+    use crate::client::Channel;
+    use crate::generated::gapic_dataplane::stub::Spanner as SpannerStub;
     use std::fmt::Debug;
+    use std::time::Duration;
+
+    #[derive(Debug)]
+    struct DummyStub;
+    impl SpannerStub for DummyStub {}
 
     #[test]
     fn traits() {
         static_assertions::assert_impl_all!(TransactionAffinity: Debug, Send, Sync);
         static_assertions::assert_impl_all!(AffinityKind: Clone, Copy, Debug, PartialEq, Eq, Send, Sync);
+    }
+
+    impl TransactionAffinity {
+        fn attach_rw_guard(&self, guard: RwTransactionAffinityGuard) {
+            let mut slot = self
+                .rw_guard
+                .lock()
+                .expect("affinity rw_guard lock poisoned");
+            match slot.as_ref() {
+                Some(existing) if existing.entry_id() == guard.entry_id() => {}
+                _ => *slot = Some(guard),
+            }
+        }
     }
 
     #[test]
@@ -126,11 +191,6 @@ mod tests {
         assert!(
             default_affinity.is_read_write(),
             "Default affinity must be ReadWrite"
-        );
-        let new_affinity = TransactionAffinity::new();
-        assert!(
-            new_affinity.is_read_write(),
-            "TransactionAffinity::new must be ReadWrite"
         );
 
         let affinity = TransactionAffinity::new_read_write();
@@ -193,5 +253,142 @@ mod tests {
             !read_only_affinity.is_read_write(),
             "ReadOnly affinity is not ReadWrite"
         );
+    }
+
+    #[test]
+    fn transaction_affinity_defaults() {
+        let default_read_only = TransactionAffinity::default_read_only(None);
+        assert!(
+            default_read_only.is_read_only(),
+            "default_read_only(None) must return ReadOnly affinity"
+        );
+
+        let custom_read_only = Arc::new(TransactionAffinity::new_read_only());
+        let passed_read_only =
+            TransactionAffinity::default_read_only(Some(Arc::clone(&custom_read_only)));
+        assert!(
+            Arc::ptr_eq(&custom_read_only, &passed_read_only),
+            "default_read_only(Some(handle)) must return existing handle without recreating"
+        );
+
+        let default_read_write = TransactionAffinity::default_read_write(None);
+        assert!(
+            default_read_write.is_read_write(),
+            "default_read_write(None) must return ReadWrite affinity"
+        );
+
+        let custom_read_write = Arc::new(TransactionAffinity::new_read_write());
+        let passed_read_write =
+            TransactionAffinity::default_read_write(Some(Arc::clone(&custom_read_write)));
+        assert!(
+            Arc::ptr_eq(&custom_read_write, &passed_read_write),
+            "default_read_write(Some(handle)) must return existing handle without recreating"
+        );
+    }
+
+    #[test]
+    fn attach_rw_guard_repinning_replaces_old_guard() {
+        let channel1 = Channel::new_for_test(DummyStub);
+        let channel2 = Channel::new_for_test(DummyStub);
+        let entry1 = Arc::new(ChannelEntry::new(1, 10, channel1));
+        let entry2 = Arc::new(ChannelEntry::new(2, 20, channel2));
+
+        assert_eq!(
+            entry1.active_rw_count(),
+            0,
+            "entry1 initial active_rw_count must be 0"
+        );
+        assert_eq!(
+            entry2.active_rw_count(),
+            0,
+            "entry2 initial active_rw_count must be 0"
+        );
+
+        let affinity = TransactionAffinity::new_read_write();
+        assert!(
+            !affinity.has_rw_guard(),
+            "affinity must not have rw guard initially"
+        );
+
+        // First attach for entry 1
+        affinity.attach_rw_guard(RwTransactionAffinityGuard::new(Arc::clone(&entry1)));
+        assert!(affinity.has_rw_guard(), "guard must be attached");
+        assert_eq!(
+            entry1.active_rw_count(),
+            1,
+            "entry1 active_rw_count must be 1"
+        );
+        assert_eq!(
+            entry2.active_rw_count(),
+            0,
+            "entry2 active_rw_count must be 0"
+        );
+
+        // Duplicate attach for entry 1 (same entry id) must not increment count
+        affinity.attach_rw_guard(RwTransactionAffinityGuard::new(Arc::clone(&entry1)));
+        assert_eq!(
+            entry1.active_rw_count(),
+            1,
+            "duplicate attach for entry1 must keep active_rw_count at 1"
+        );
+
+        // Repinning attach for entry 2: old guard on entry 1 is dropped and replaced with guard on entry 2
+        affinity.attach_rw_guard(RwTransactionAffinityGuard::new(Arc::clone(&entry2)));
+        assert_eq!(
+            entry1.active_rw_count(),
+            0,
+            "entry1 active_rw_count must drop to 0 after repinning"
+        );
+        assert_eq!(
+            entry2.active_rw_count(),
+            1,
+            "entry2 active_rw_count must be 1 after repinning"
+        );
+
+        // Reset drops any attached guard
+        affinity.reset();
+        assert!(
+            !affinity.has_rw_guard(),
+            "has_rw_guard must be false after reset"
+        );
+        assert_eq!(
+            entry2.active_rw_count(),
+            0,
+            "entry2 active_rw_count must drop to 0 after reset"
+        );
+    }
+
+    #[test]
+    fn ensure_rw_guard_attaches_and_is_noop_on_same_entry() {
+        let channel1 = Channel::new_for_test(DummyStub);
+        let channel2 = Channel::new_for_test(DummyStub);
+        let entry1 = Arc::new(ChannelEntry::new(1, 1, channel1));
+        let entry2 = Arc::new(ChannelEntry::new(2, 2, channel2));
+
+        let affinity = TransactionAffinity::new_read_write();
+        let lease1 = ChannelLease::new(ActiveRpcGuard::new(
+            Arc::clone(&entry1),
+            0,
+            Duration::ZERO,
+            0,
+        ));
+        affinity.ensure_rw_guard(&lease1);
+        assert!(affinity.has_rw_guard(), "guard must be attached");
+        assert_eq!(entry1.active_rw_count(), 1, "entry1 count must be 1");
+
+        // Calling ensure_rw_guard again for the same entry does not increment count
+        affinity.ensure_rw_guard(&lease1);
+        assert_eq!(entry1.active_rw_count(), 1, "entry1 count must remain 1");
+
+        // Calling ensure_rw_guard with lease2 repins and drops old guard
+        let lease2 = ChannelLease::new(ActiveRpcGuard::new(
+            Arc::clone(&entry2),
+            0,
+            Duration::ZERO,
+            0,
+        ));
+        affinity.ensure_rw_guard(&lease2);
+        assert_eq!(entry1.active_rw_count(), 0, "entry1 count must drop to 0");
+        assert_eq!(entry2.active_rw_count(), 1, "entry2 count must be 1");
     }
 }

--- a/src/spanner/src/channel_pool/entry.rs
+++ b/src/spanner/src/channel_pool/entry.rs
@@ -16,6 +16,7 @@
 
 use crate::client::Channel;
 use google_cloud_gax::error::rpc::Code;
+use std::ops::Deref;
 use std::result::Result;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, AtomicU32, AtomicU64, Ordering};
@@ -40,8 +41,6 @@ pub(crate) enum ChannelState {
 pub(crate) struct ChannelEntry {
     /// Monotonically increasing unique internal ID for transaction affinity pinning.
     pub(crate) id: u64,
-    /// Logical 1-based channel slot (1..=max_channels) passed to `x-goog-spanner-request-id`.
-    pub(crate) logical_channel_id: usize,
     /// Physical gRPC channel instance.
     pub(crate) channel: Channel,
     /// Count of active RPCs currently executing over the wire.
@@ -76,7 +75,6 @@ impl ChannelEntry {
         channel.channel_id = logical_channel_id;
         Self {
             id,
-            logical_channel_id,
             channel,
             in_flight_rpcs: AtomicU32::new(0),
             active_rw_transactions: AtomicU32::new(0),
@@ -85,6 +83,11 @@ impl ChannelEntry {
             created_at,
             last_activity_nanos: AtomicU64::new(0),
         }
+    }
+
+    /// Logical 1-based channel slot (1..=max_channels) passed to `x-goog-spanner-request-id`.
+    pub(crate) fn logical_channel_id(&self) -> usize {
+        self.channel.channel_id
     }
 
     pub(crate) fn decode_penalty_state(packed: u64) -> (u32, u64) {
@@ -104,11 +107,6 @@ impl ChannelEntry {
         let elapsed = u64::try_from(self.created_at.elapsed().as_nanos()).unwrap_or(u64::MAX);
         self.last_activity_nanos
             .fetch_max(elapsed, Ordering::Relaxed);
-    }
-
-    /// Returns the raw activity timestamp in nanoseconds from `created_at` for warmth comparisons.
-    pub(crate) fn last_activity_nanos(&self) -> u64 {
-        self.last_activity_nanos.load(Ordering::Relaxed)
     }
 
     /// Returns the current number of in-flight RPCs on this channel.
@@ -286,6 +284,11 @@ impl RwTransactionAffinityGuard {
         entry.active_rw_transactions.fetch_add(1, Ordering::Relaxed);
         Self { entry }
     }
+
+    /// Returns the monotonic entry ID of the guarded channel entry.
+    pub(crate) fn entry_id(&self) -> u64 {
+        self.entry.id
+    }
 }
 
 impl Drop for RwTransactionAffinityGuard {
@@ -317,14 +320,23 @@ impl ChannelLease {
         Self { guard }
     }
 
+    /// Consumes the lease, returning the underlying active RPC guard.
+    pub(crate) fn into_guard(self) -> ActiveRpcGuard {
+        self.guard
+    }
+
+    /// Records the result of an RPC call and applies an error penalty if a qualifying error occurred.
+    pub(crate) fn record_result<T, E>(
+        &self,
+        result: &Result<T, E>,
+        extract_code: impl Fn(&E) -> Option<Code>,
+    ) {
+        self.guard.record_result(result, extract_code);
+    }
+
     /// Returns a reference to the physical `Channel`.
     pub(crate) fn channel(&self) -> &Channel {
         &self.guard.entry.channel
-    }
-
-    /// Returns the logical 1-based channel slot (1..=max_channels) for request ID tagging.
-    pub(crate) fn logical_channel_id(&self) -> usize {
-        self.guard.entry.logical_channel_id
     }
 
     /// Returns the unique monotonic internal entry ID.
@@ -335,6 +347,16 @@ impl ChannelLease {
     /// Creates an RAII guard that pins this channel entry for an active Read/Write transaction.
     pub(crate) fn rw_affinity_guard(&self) -> RwTransactionAffinityGuard {
         RwTransactionAffinityGuard::new(Arc::clone(&self.guard.entry))
+    }
+}
+
+/// Enables `ChannelLease` to dereference transparently to the underlying `Channel`,
+/// allowing callers to pass `&lease` anywhere a `&Channel` is required.
+impl Deref for ChannelLease {
+    type Target = Channel;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard.entry.channel
     }
 }
 
@@ -545,7 +567,8 @@ mod tests {
 
         assert_eq!(entry.id, 10, "id must match constructor arg");
         assert_eq!(
-            entry.logical_channel_id, 2,
+            entry.logical_channel_id(),
+            2,
             "logical_channel_id must match constructor arg"
         );
         assert!(entry.is_active(), "New channel entry must start Active");
@@ -599,11 +622,11 @@ mod tests {
         );
 
         // Activity timestamps
-        let initial_activity = entry.last_activity_nanos();
+        let initial_activity = entry.last_activity_nanos.load(Ordering::Relaxed);
         assert_eq!(initial_activity, 0, "Initial last_activity_nanos must be 0");
 
         entry.touch_activity();
-        let updated_activity = entry.last_activity_nanos();
+        let updated_activity = entry.last_activity_nanos.load(Ordering::Relaxed);
         assert!(
             updated_activity > 0,
             "touch_activity() must set last_activity_nanos > 0"
@@ -680,14 +703,19 @@ mod tests {
             "entry_id() must return entry's internal id 42"
         );
         assert_eq!(
-            lease.logical_channel_id(),
+            lease.channel().channel_id,
             3,
-            "logical_channel_id() must return entry's logical id 3"
+            "channel.channel_id must match entry's logical id 3"
         );
         let _channel = lease.channel();
 
         // rw_affinity_guard helper creates an RAII guard incrementing active_rw_transactions
         let rw_guard = lease.rw_affinity_guard();
+        assert_eq!(
+            rw_guard.entry_id(),
+            42,
+            "rw_affinity_guard() must report matching entry_id"
+        );
         assert_eq!(
             entry.active_rw_count(),
             1,
@@ -698,6 +726,65 @@ mod tests {
             entry.active_rw_count(),
             0,
             "dropping RwTransactionAffinityGuard must decrement active_rw_transactions"
+        );
+    }
+
+    #[test]
+    fn channel_lease_into_guard() {
+        let channel = create_mock_channel();
+        let entry = Arc::new(ChannelEntry::new(42, 3, channel));
+
+        assert_eq!(entry.in_flight(), 0, "initial in-flight count must be 0");
+        let guard = ActiveRpcGuard::new(Arc::clone(&entry), 0, Duration::ZERO, 0);
+        let lease = ChannelLease::new(guard);
+        assert_eq!(
+            entry.in_flight(),
+            1,
+            "creating guard must increment in-flight count"
+        );
+
+        let guard = lease.into_guard();
+        assert_eq!(
+            entry.in_flight(),
+            1,
+            "into_guard must preserve in-flight count"
+        );
+
+        drop(guard);
+        assert_eq!(
+            entry.in_flight(),
+            0,
+            "dropping ActiveRpcGuard must decrement in-flight count"
+        );
+    }
+
+    #[test]
+    fn channel_lease_record_result_and_deref() {
+        let channel = create_mock_channel();
+        let entry = Arc::new(ChannelEntry::new(42, 3, channel));
+        let guard = ActiveRpcGuard::new(Arc::clone(&entry), 5, Duration::from_secs(10), 10);
+        let lease = ChannelLease::new(guard);
+
+        // Verify Deref to Channel
+        assert_eq!(
+            lease.channel_id, 3,
+            "Deref must allow accessing underlying channel fields"
+        );
+
+        let ok_result: Result<&str, Status> = Ok("success");
+        lease.record_result(&ok_result, |status| Some(status.code));
+        assert_eq!(
+            entry.current_penalty(),
+            0,
+            "record_result on Ok must not add penalty load"
+        );
+
+        let err_result: Result<&str, Status> = Err(Status::default().set_code(Code::Unavailable));
+        lease.record_result(&err_result, |status| Some(status.code));
+        assert_eq!(
+            entry.current_penalty(),
+            5,
+            "record_result on qualifying error must add penalty load"
         );
     }
 }

--- a/src/spanner/src/channel_pool/mod.rs
+++ b/src/spanner/src/channel_pool/mod.rs
@@ -28,9 +28,14 @@ pub(crate) mod entry;
 pub(crate) mod pool;
 pub(crate) mod scaler;
 
+#[allow(unused_imports)]
 pub(crate) use affinity::TransactionAffinity;
-pub(crate) use config::{
-    ChannelPoolConfig, ChannelSelectionStrategy, DynamicChannelPoolConfig, StaticChannelPoolConfig,
-};
-pub(crate) use entry::{ActiveRpcGuard, ChannelEntry, ChannelLease, RwTransactionAffinityGuard};
+#[allow(unused_imports)]
+#[cfg(test)]
+pub(crate) use config::DynamicChannelPoolConfig;
+#[allow(unused_imports)]
+pub(crate) use config::{ChannelPoolConfig, StaticChannelPoolConfig};
+#[allow(unused_imports)]
+pub(crate) use entry::ChannelLease;
+#[allow(unused_imports)]
 pub(crate) use pool::ChannelPool;

--- a/src/spanner/src/channel_pool/pool.rs
+++ b/src/spanner/src/channel_pool/pool.rs
@@ -26,14 +26,13 @@ use crate::channel_pool::scaler::{scale_down_monitor_loop, scale_up_worker_loop}
 use crate::client::Channel;
 use crate::routing::power_of_two_selector::PowerOfTwoSelector;
 use gaxi::options::ClientConfig;
+use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::sync::atomic::{AtomicU64, AtomicUsize};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 use tokio::spawn;
 use tokio::sync::Notify;
-use tokio::sync::watch::{
-    Receiver as WatchReceiver, Sender as WatchSender, channel as watch_channel,
-};
+use tokio::sync::watch::{Sender as WatchSender, channel as watch_channel};
 
 /// Unified channel pool managing gRPC channels for the Spanner client.
 ///
@@ -41,6 +40,17 @@ use tokio::sync::watch::{
 #[derive(Clone)]
 pub(crate) struct ChannelPool {
     pub(crate) inner: Arc<ChannelPoolInner>,
+}
+
+impl Debug for ChannelPool {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
+        formatter
+            .debug_struct("ChannelPool")
+            .field("config", &self.inner.config)
+            .field("active_channels", &self.active_channel_count())
+            .field("draining_channels", &self.draining_channel_count())
+            .finish()
+    }
 }
 
 impl ChannelPool {
@@ -181,19 +191,21 @@ impl ChannelPool {
                 .iter()
                 .find(|entry| entry.id == id && entry.is_active())
             {
-                return Some(self.make_lease(Arc::clone(entry)));
+                let lease = self.make_lease(Arc::clone(entry));
+                if affinity.is_read_write() {
+                    affinity.ensure_rw_guard(&lease);
+                }
+                return Some(lease);
             }
 
             // 2. Draining-path: Only Read/Write transactions (hard stickiness) preserve draining affinity.
             // Read-Only transactions (soft stickiness) bypass draining channels and pick a fresh active channel.
-            if affinity.is_read_write() {
-                let draining_guard = self.inner.draining_entries.read().expect("lock poisoned");
-                if let Some(entry) = draining_guard
-                    .iter()
-                    .find(|entry| entry.id == id && !entry.is_closed())
-                {
-                    return Some(self.make_lease(Arc::clone(entry)));
-                }
+            if affinity.is_read_write()
+                && let Some(entry) = self.find_draining_entry(id)
+            {
+                let lease = self.make_lease(entry);
+                affinity.ensure_rw_guard(&lease);
+                return Some(lease);
             }
         }
 
@@ -203,27 +215,82 @@ impl ChannelPool {
 
         // Atomically attempt to pin this channel. If another concurrent thread pinned first,
         // use the winning channel to ensure all concurrent statements route to the same SpanFE.
-        match affinity.compare_and_set_entry_id(expected_id, lease.entry_id()) {
-            Ok(()) => Some(lease),
-            Err(winner_id) => {
-                if let Some(winner_entry) = active_guard
-                    .iter()
-                    .find(|entry| entry.id == winner_id && entry.is_active())
-                {
-                    return Some(self.make_lease(Arc::clone(winner_entry)));
-                }
-                if affinity.is_read_write() {
-                    let draining_guard = self.inner.draining_entries.read().expect("lock poisoned");
-                    if let Some(entry) = draining_guard
-                        .iter()
-                        .find(|entry| entry.id == winner_id && !entry.is_closed())
-                    {
-                        return Some(self.make_lease(Arc::clone(entry)));
-                    }
-                }
-                Some(lease)
+        let final_lease = match affinity.compare_and_set_entry_id(expected_id, lease.entry_id()) {
+            Ok(()) => lease,
+            Err(winner_id) => self.resolve_cas_conflict(affinity, lease, &active_guard, winner_id),
+        };
+
+        if affinity.is_read_write() {
+            affinity.ensure_rw_guard(&final_lease);
+        }
+
+        Some(final_lease)
+    }
+
+    /// Resolves a compare-and-swap (CAS) conflict when two or more concurrent tasks attempt to
+    /// pin or re-pin channel affinity for the same transaction simultaneously.
+    ///
+    /// # Background and Motivation
+    ///
+    /// When concurrent tasks execute statements within an unpinned transaction, each task independently
+    /// selects an active channel candidate from the pool and attempts to atomically record its choice
+    /// via CAS on the shared [`TransactionAffinity`] handle. The first task to succeed wins and establishes
+    /// the transaction's channel pin.
+    ///
+    /// Any losing task arrives here with the winning channel ID (`winner_id`). To guarantee that all
+    /// statements within the transaction route to the same Spanner frontend (SpanFE) server (preserving
+    /// in-memory lock state and avoiding transaction aborted errors), the losing task discards its
+    /// independently selected lease and adopts the winning channel.
+    ///
+    /// # Handling Stale or Closed Winner Channels
+    ///
+    /// If the winning channel is no longer active in `active_candidates`:
+    /// 1. **Read/Write transactions (hard stickiness)**: Checks if the winning channel transitioned to
+    ///    `Draining`. If so, hard affinity requires following that channel to avoid aborting in-flight work.
+    /// 2. **Unusable winner**: If the winner is closed (or is draining for Read-Only transactions which use
+    ///    soft stickiness), it cannot be used. In this case, this task attempts to re-pin affinity to its
+    ///    own active `lease` via CAS.
+    /// 3. **Retry on contention**: If re-pinning encounters another concurrent CAS race, the loop retries
+    ///    with the new winning entry ID.
+    pub(crate) fn resolve_cas_conflict(
+        &self,
+        affinity: &TransactionAffinity,
+        lease: ChannelLease,
+        active_candidates: &[Arc<ChannelEntry>],
+        mut winner_id: u64,
+    ) -> ChannelLease {
+        loop {
+            // 1. If the winning channel is still active in the candidate set, adopt it.
+            if let Some(winner_entry) = active_candidates
+                .iter()
+                .find(|entry| entry.id == winner_id && entry.is_active())
+            {
+                return self.make_lease(Arc::clone(winner_entry));
+            }
+
+            // 2. Read/Write transactions preserve draining channels under hard stickiness.
+            if affinity.is_read_write()
+                && let Some(entry) = self.find_draining_entry(winner_id)
+            {
+                return self.make_lease(entry);
+            }
+
+            // 3. The winner channel is unusable (closed, or draining for Read-Only soft stickiness).
+            // Attempt to re-pin affinity to our active lease.
+            match affinity.compare_and_set_entry_id(winner_id, lease.entry_id()) {
+                Ok(()) => return lease,
+                Err(new_winner_id) => winner_id = new_winner_id,
             }
         }
+    }
+
+    /// Finds a channel entry in the draining pool by ID, if present and still draining.
+    fn find_draining_entry(&self, entry_id: u64) -> Option<Arc<ChannelEntry>> {
+        let draining_guard = self.inner.draining_entries.read().expect("lock poisoned");
+        draining_guard
+            .iter()
+            .find(|entry| entry.id == entry_id && entry.is_draining())
+            .cloned()
     }
 
     fn pick_from_slice(&self, candidates: &[Arc<ChannelEntry>]) -> Option<ChannelLease> {
@@ -257,21 +324,6 @@ impl ChannelPool {
         self.inner.scale_up_notify.notify_one();
     }
 
-    /// Clears the cached prime session name.
-    pub(crate) fn clear_prime_session(&self) {
-        let mut prime = self.inner.prime_session.write().expect("lock poisoned");
-        *prime = None;
-    }
-
-    /// Checks if a valid multiplexed session name is currently registered.
-    pub(crate) fn has_prime_session(&self) -> bool {
-        self.inner
-            .prime_session
-            .read()
-            .expect("lock poisoned")
-            .is_some()
-    }
-
     /// Returns the total number of active channels in the pool.
     pub(crate) fn active_channel_count(&self) -> usize {
         self.inner
@@ -290,10 +342,20 @@ impl ChannelPool {
             .len()
     }
 
-    /// Returns the total count of in-flight RPCs across all active channels.
-    pub(crate) fn total_in_flight_rpcs(&self) -> u32 {
+    /// Returns a clone of the first active channel in the pool, if present.
+    ///
+    /// # Warning
+    ///
+    /// This method is intended strictly for internal metadata setup (e.g. configuring
+    /// fallback gateway connection endpoints during client initialization).
+    ///
+    /// **Never** use this method for routing or executing queries or RPCs. Doing so would
+    /// bypass load balancing and cause traffic to herd onto the first channel.
+    /// Use [`ChannelPool::pick_channel`] for P2C load-balanced channel selection, or
+    /// [`ChannelPool::resolve_affinity`] for operations requiring transaction affinity.
+    pub(crate) fn default_channel(&self) -> Option<Channel> {
         let active_guard = self.inner.active_entries.read().expect("lock poisoned");
-        active_guard.iter().map(|entry| entry.in_flight()).sum()
+        active_guard.first().map(|entry| entry.channel.clone())
     }
 }
 
@@ -305,6 +367,8 @@ pub(crate) struct ChannelPoolInner {
     pub(crate) draining_entries: RwLock<Vec<Arc<ChannelEntry>>>,
     pub(crate) next_entry_id: AtomicU64,
     pub(crate) scale_up_notify: Arc<Notify>,
+    #[allow(dead_code)]
+    // Retained for RAII drop signaling; read in scaler unit tests via subscribe()
     pub(crate) shutdown_sender: WatchSender<()>,
     pub(crate) last_scale_up_time: Mutex<Option<Instant>>,
     pub(crate) consecutive_low_load_checks: AtomicUsize,
@@ -345,6 +409,29 @@ impl ChannelPoolInner {
 }
 
 #[cfg(test)]
+impl ChannelPool {
+    pub(crate) fn config(&self) -> &ChannelPoolConfig {
+        &self.inner.config
+    }
+
+    pub(crate) fn has_prime_session(&self) -> bool {
+        self.inner
+            .prime_session
+            .read()
+            .expect("lock poisoned")
+            .is_some()
+    }
+
+    pub(crate) fn active_entries(&self) -> Vec<Arc<ChannelEntry>> {
+        self.inner
+            .active_entries
+            .read()
+            .expect("lock poisoned")
+            .clone()
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::Response;
@@ -380,8 +467,19 @@ mod tests {
 
     #[test]
     fn traits() {
-        static_assertions::assert_impl_all!(ChannelPool: Clone, Send, Sync);
+        static_assertions::assert_impl_all!(ChannelPool: Clone, Debug, Send, Sync);
         static_assertions::assert_impl_all!(ChannelPoolInner: Send, Sync);
+    }
+
+    impl ChannelPool {
+        fn total_in_flight_rpcs(&self) -> u32 {
+            let active_guard = self.inner.active_entries.read().expect("lock poisoned");
+            active_guard.iter().map(|entry| entry.in_flight()).sum()
+        }
+
+        fn clear_prime_session(&self) {
+            *self.inner.prime_session.write().expect("lock poisoned") = None;
+        }
     }
 
     #[test]
@@ -400,7 +498,7 @@ mod tests {
 
         let lease1 = pool.pick_channel().expect("channel pick should succeed");
         assert!(
-            (1..=3).contains(&lease1.logical_channel_id()),
+            (1..=3).contains(&lease1.channel_id),
             "logical channel ID must be in range 1..=3"
         );
 
@@ -504,7 +602,9 @@ mod tests {
 
         // Read/Write transaction requires hard stickiness
         let affinity = TransactionAffinity::new_read_write();
-        affinity.set_entry_id(2); // Pinned to channel 2 (which is draining)
+        affinity
+            .compare_and_set_entry_id(0, 2)
+            .expect("pin affinity"); // Pinned to channel 2 (which is draining)
 
         let lease = pool
             .resolve_affinity(&affinity)
@@ -513,6 +613,27 @@ mod tests {
             lease.entry_id(),
             2,
             "Must preserve affinity to draining channel for Read/Write transactions"
+        );
+        assert_eq!(
+            channel_2.active_rw_count(),
+            1,
+            "Draining channel must have active_rw_count = 1 while Read/Write affinity holds guard"
+        );
+        assert!(
+            affinity.has_rw_guard(),
+            "Read/Write affinity must hold rw_guard"
+        );
+
+        // Reset clears the guard and decrements the active_rw_count
+        affinity.reset();
+        assert_eq!(
+            channel_2.active_rw_count(),
+            0,
+            "active_rw_count must decrement to 0 after affinity is reset"
+        );
+        assert!(
+            !affinity.has_rw_guard(),
+            "affinity must not hold rw_guard after reset"
         );
     }
 
@@ -533,9 +654,10 @@ mod tests {
         *pool.inner.active_entries.write().expect("lock") = vec![Arc::clone(&channel_1)];
         *pool.inner.draining_entries.write().expect("lock") = vec![Arc::clone(&channel_2)];
 
-        // Read-Only transaction uses soft stickiness
+        // Simulate a Read-Only transaction that was previously pinned to channel 2,
+        // which has now transitioned to Draining during a scale-down event.
         let read_only_affinity = TransactionAffinity::new_read_only();
-        read_only_affinity.set_entry_id(2); // Was pinned to channel 2 (now draining)
+        read_only_affinity.set_pinned_entry_id_for_test(2);
 
         let lease = pool
             .resolve_affinity(&read_only_affinity)
@@ -623,7 +745,7 @@ mod tests {
         pool.clear_prime_session();
         assert!(
             !pool.has_prime_session(),
-            "Prime session must be None after clear_prime_session"
+            "Prime session must be None after clearing"
         );
     }
 
@@ -749,9 +871,10 @@ mod tests {
         *pool.inner.active_entries.write().expect("lock") = vec![Arc::clone(&channel_1)];
         *pool.inner.draining_entries.write().expect("lock") = vec![Arc::clone(&channel_2)];
 
-        // 1. ReadWrite affinity pinned to a Closed draining channel -> must fallback to active channel
+        // 1. Simulate a Read/Write transaction previously pinned to channel 2,
+        // which has now transitioned to Closed after an idle timeout.
         let rw_affinity = TransactionAffinity::new_read_write();
-        rw_affinity.set_entry_id(2); // Channel 2 is closed
+        rw_affinity.set_pinned_entry_id_for_test(2);
         let lease = pool
             .resolve_affinity(&rw_affinity)
             .expect("must fallback to active channel when draining channel is closed");
@@ -762,9 +885,9 @@ mod tests {
             "Affinity pin must be updated to active channel 1"
         );
 
-        // 2. Affinity pinned to a non-existent channel ID -> must fallback to active channel
+        // 2. Simulate affinity pinned to a stale / non-existent channel ID -> must fallback to active channel
         let non_existent_affinity = TransactionAffinity::new_read_write();
-        non_existent_affinity.set_entry_id(999);
+        non_existent_affinity.set_pinned_entry_id_for_test(999);
         let lease_fallback = pool
             .resolve_affinity(&non_existent_affinity)
             .expect("must fallback to active channel for unknown channel ID");
@@ -777,6 +900,170 @@ mod tests {
             non_existent_affinity.pinned_entry_id(),
             Some(1),
             "affinity pin must update to active channel 1"
+        );
+    }
+
+    #[test]
+    fn resolve_cas_conflict_winner_in_active_candidates() {
+        let client_config = ClientConfig::default();
+        let channel_1 = Arc::new(ChannelEntry::new(1, 1, create_mock_channel()));
+        let channel_2 = Arc::new(ChannelEntry::new(2, 2, create_mock_channel()));
+
+        let pool = ChannelPool::new_static(
+            vec![create_mock_channel(), create_mock_channel()],
+            StaticChannelPoolConfig { num_channels: 2 },
+            client_config,
+        );
+        let active = vec![Arc::clone(&channel_1), Arc::clone(&channel_2)];
+        *pool.inner.active_entries.write().expect("lock") = active.clone();
+
+        let affinity = TransactionAffinity::new_read_write();
+        let my_lease = pool.make_lease(Arc::clone(&channel_1));
+
+        let resolved_lease = pool.resolve_cas_conflict(&affinity, my_lease, &active, 2);
+        assert_eq!(
+            resolved_lease.entry_id(),
+            2,
+            "Resolved lease must match winner channel entry ID 2"
+        );
+    }
+
+    #[test]
+    fn resolve_cas_conflict_read_write_winner_in_draining_entries() {
+        let client_config = ClientConfig::default();
+        let channel_1 = Arc::new(ChannelEntry::new(1, 1, create_mock_channel()));
+        let channel_2 = Arc::new(ChannelEntry::new(2, 2, create_mock_channel()));
+        channel_2.set_state(ChannelState::Draining);
+
+        let pool = ChannelPool::new_static(
+            vec![create_mock_channel()],
+            StaticChannelPoolConfig { num_channels: 1 },
+            client_config,
+        );
+        let active = vec![Arc::clone(&channel_1)];
+        *pool.inner.active_entries.write().expect("lock") = active.clone();
+        *pool.inner.draining_entries.write().expect("lock") = vec![Arc::clone(&channel_2)];
+
+        let affinity = TransactionAffinity::new_read_write();
+        let my_lease = pool.make_lease(Arc::clone(&channel_1));
+
+        let resolved_lease = pool.resolve_cas_conflict(&affinity, my_lease, &active, 2);
+        assert_eq!(
+            resolved_lease.entry_id(),
+            2,
+            "ReadWrite affinity must return lease for draining winner channel 2"
+        );
+    }
+
+    #[test]
+    fn resolve_cas_conflict_read_write_winner_closed_or_unknown() {
+        let client_config = ClientConfig::default();
+        let channel_1 = Arc::new(ChannelEntry::new(1, 1, create_mock_channel()));
+        let channel_2 = Arc::new(ChannelEntry::new(2, 2, create_mock_channel()));
+        channel_2.set_state(ChannelState::Closed);
+
+        let pool = ChannelPool::new_static(
+            vec![create_mock_channel()],
+            StaticChannelPoolConfig { num_channels: 1 },
+            client_config,
+        );
+        let active = vec![Arc::clone(&channel_1)];
+        *pool.inner.active_entries.write().expect("lock") = active.clone();
+        *pool.inner.draining_entries.write().expect("lock") = vec![Arc::clone(&channel_2)];
+
+        let affinity = TransactionAffinity::new_read_write();
+        affinity
+            .compare_and_set_entry_id(0, 2)
+            .expect("pin affinity to 2");
+
+        let my_lease = pool.make_lease(Arc::clone(&channel_1));
+
+        let resolved_lease = pool.resolve_cas_conflict(&affinity, my_lease, &active, 2);
+        assert_eq!(
+            resolved_lease.entry_id(),
+            1,
+            "Must fallback to active lease 1 when winner channel is closed"
+        );
+        assert_eq!(
+            affinity.pinned_entry_id(),
+            Some(1),
+            "Affinity must be re-pinned to active channel 1"
+        );
+    }
+
+    #[test]
+    fn resolve_cas_conflict_read_only_winner_not_active() {
+        let client_config = ClientConfig::default();
+        let channel_1 = Arc::new(ChannelEntry::new(1, 1, create_mock_channel()));
+        let channel_2 = Arc::new(ChannelEntry::new(2, 2, create_mock_channel()));
+        channel_2.set_state(ChannelState::Draining);
+
+        let pool = ChannelPool::new_static(
+            vec![create_mock_channel()],
+            StaticChannelPoolConfig { num_channels: 1 },
+            client_config,
+        );
+        let active = vec![Arc::clone(&channel_1)];
+        *pool.inner.active_entries.write().expect("lock") = active.clone();
+        *pool.inner.draining_entries.write().expect("lock") = vec![Arc::clone(&channel_2)];
+
+        let affinity = TransactionAffinity::new_read_only();
+        affinity
+            .compare_and_set_entry_id(0, 2)
+            .expect("pin affinity to 2");
+
+        let my_lease = pool.make_lease(Arc::clone(&channel_1));
+
+        let resolved_lease = pool.resolve_cas_conflict(&affinity, my_lease, &active, 2);
+        assert_eq!(
+            resolved_lease.entry_id(),
+            1,
+            "ReadOnly affinity must fallback to active lease 1 when winner is not active"
+        );
+        assert_eq!(
+            affinity.pinned_entry_id(),
+            Some(1),
+            "Affinity must be re-pinned to active channel 1"
+        );
+    }
+
+    #[test]
+    fn resolve_cas_conflict_cas_failure_loops_and_resolves_with_new_winner() {
+        let client_config = ClientConfig::default();
+        let channel_1 = Arc::new(ChannelEntry::new(1, 1, create_mock_channel()));
+        let channel_2 = Arc::new(ChannelEntry::new(2, 2, create_mock_channel()));
+        channel_2.set_state(ChannelState::Closed);
+        let channel_3 = Arc::new(ChannelEntry::new(3, 3, create_mock_channel()));
+
+        let pool = ChannelPool::new_static(
+            vec![create_mock_channel(), create_mock_channel()],
+            StaticChannelPoolConfig { num_channels: 2 },
+            client_config,
+        );
+        let active = vec![Arc::clone(&channel_1), Arc::clone(&channel_3)];
+        *pool.inner.active_entries.write().expect("lock") = active.clone();
+        *pool.inner.draining_entries.write().expect("lock") = vec![Arc::clone(&channel_2)];
+
+        let affinity = TransactionAffinity::new_read_write();
+        // Another thread already updated affinity from 2 to 3
+        affinity
+            .compare_and_set_entry_id(0, 3)
+            .expect("pin affinity to 3");
+
+        let my_lease = pool.make_lease(Arc::clone(&channel_1));
+
+        // When this thread tries to resolve conflict with winner_id 2 (which is closed),
+        // CAS to re-pin to 1 fails because affinity is 3. The method must loop and resolve with 3!
+        let resolved_lease = pool.resolve_cas_conflict(&affinity, my_lease, &active, 2);
+        assert_eq!(
+            resolved_lease.entry_id(),
+            3,
+            "Must loop and adopt winning channel 3 when CAS fails during re-pinning"
+        );
+        assert_eq!(
+            affinity.pinned_entry_id(),
+            Some(3),
+            "Affinity must remain pinned to channel 3"
         );
     }
 
@@ -835,5 +1122,149 @@ mod tests {
             "Dynamic pool guard must accumulate configured error penalty step of 7"
         );
         drop(dynamic_guard);
+    }
+
+    #[test]
+    fn channel_pool_helpers() {
+        let channels = vec![
+            create_mock_channel(),
+            create_mock_channel(),
+            create_mock_channel(),
+        ];
+        let pool = ChannelPool::new_static(
+            channels,
+            StaticChannelPoolConfig { num_channels: 3 },
+            ClientConfig::default(),
+        );
+
+        assert_eq!(
+            pool.active_channel_count(),
+            3,
+            "active_channel_count must match 3"
+        );
+        assert!(
+            pool.default_channel().is_some(),
+            "default_channel must return the first channel"
+        );
+        assert!(
+            matches!(pool.config(), ChannelPoolConfig::Static(_)),
+            "pool.config() must return configured static pool config"
+        );
+        assert_eq!(
+            pool.active_entries().len(),
+            3,
+            "pool.active_entries() must return active channel entries"
+        );
+
+        let empty_pool = ChannelPool::new_static(
+            Vec::new(),
+            StaticChannelPoolConfig { num_channels: 0 },
+            ClientConfig::default(),
+        );
+        assert!(
+            empty_pool.default_channel().is_none(),
+            "default_channel must return None on empty pool"
+        );
+    }
+
+    #[test]
+    fn channel_pool_debug_formatting() {
+        let channels = vec![create_mock_channel(), create_mock_channel()];
+        let pool = ChannelPool::new_static(
+            channels,
+            StaticChannelPoolConfig { num_channels: 2 },
+            ClientConfig::default(),
+        );
+
+        let debug_output = format!("{pool:?}");
+        assert!(
+            debug_output.contains("ChannelPool"),
+            "debug output should contain struct name: {debug_output}"
+        );
+        assert!(
+            debug_output.contains("active_channels: 2"),
+            "debug output should contain active channel count: {debug_output}"
+        );
+        assert!(
+            debug_output.contains("draining_channels: 0"),
+            "debug output should contain draining channel count: {debug_output}"
+        );
+        assert!(
+            debug_output.contains("Static"),
+            "debug output should contain config details: {debug_output}"
+        );
+    }
+
+    #[test]
+    fn affinity_resolution_read_only_happy_path() {
+        let client_config = ClientConfig::default();
+        let channels = vec![create_mock_channel(), create_mock_channel()];
+        let pool = ChannelPool::new_static(
+            channels,
+            StaticChannelPoolConfig { num_channels: 2 },
+            client_config,
+        );
+
+        let affinity = TransactionAffinity::new_read_only();
+        let lease1 = pool
+            .resolve_affinity(&affinity)
+            .expect("unpinned read-only resolve succeeds");
+        assert_eq!(
+            affinity.pinned_entry_id(),
+            Some(lease1.entry_id()),
+            "read-only affinity must pin to first lease"
+        );
+        assert!(
+            !affinity.has_rw_guard(),
+            "read-only affinity must not hold rw_guard"
+        );
+
+        let lease2 = pool
+            .resolve_affinity(&affinity)
+            .expect("pinned read-only resolve succeeds");
+        assert_eq!(
+            lease2.entry_id(),
+            lease1.entry_id(),
+            "read-only affinity must reuse pinned channel on fast path"
+        );
+        assert!(
+            !affinity.has_rw_guard(),
+            "read-only affinity must not hold rw_guard on fast path"
+        );
+    }
+
+    #[test]
+    fn resolve_affinity_cas_conflict_resolution() {
+        let client_config = ClientConfig::default();
+        let channel_1 = Arc::new(ChannelEntry::new(1, 1, create_mock_channel()));
+        let channel_2 = Arc::new(ChannelEntry::new(2, 2, create_mock_channel()));
+
+        let pool = ChannelPool::new_static(
+            vec![create_mock_channel(), create_mock_channel()],
+            StaticChannelPoolConfig { num_channels: 2 },
+            client_config,
+        );
+        let active = vec![Arc::clone(&channel_1), Arc::clone(&channel_2)];
+        *pool.inner.active_entries.write().expect("lock") = active;
+
+        let affinity = TransactionAffinity::new_read_write();
+        // Simulate affinity having an unknown stale ID (e.g. 999)
+        affinity.set_pinned_entry_id_for_test(999);
+
+        // Another concurrent thread successfully updates affinity to channel 2
+        affinity
+            .compare_and_set_entry_id(999, 2)
+            .expect("pin affinity to 2");
+
+        // When resolve_affinity attempts compare_and_set_entry_id(999, lease_id),
+        // it encounters CAS Err(2) and triggers resolve_cas_conflict internally
+        let lease = pool
+            .resolve_affinity(&affinity)
+            .expect("must resolve affinity via CAS conflict resolution");
+        assert_eq!(
+            lease.entry_id(),
+            2,
+            "must adopt winning channel 2 on CAS conflict"
+        );
     }
 }

--- a/src/spanner/src/channel_pool/scaler.rs
+++ b/src/spanner/src/channel_pool/scaler.rs
@@ -261,8 +261,8 @@ fn publish_primed_channel(inner: &ChannelPoolInner, channel: Channel, max_channe
 
     // Mark slots occupied by active channels
     for entry in active_write.iter() {
-        if entry.logical_channel_id <= MAX_SUPPORTED_CHANNELS {
-            occupied_slots[entry.logical_channel_id] = true;
+        if entry.logical_channel_id() <= MAX_SUPPORTED_CHANNELS {
+            occupied_slots[entry.logical_channel_id()] = true;
         }
     }
 
@@ -270,8 +270,8 @@ fn publish_primed_channel(inner: &ChannelPoolInner, channel: Channel, max_channe
     {
         let draining_guard = inner.draining_entries.read().expect("lock poisoned");
         for entry in draining_guard.iter() {
-            if !entry.is_closed() && entry.logical_channel_id <= MAX_SUPPORTED_CHANNELS {
-                occupied_slots[entry.logical_channel_id] = true;
+            if !entry.is_closed() && entry.logical_channel_id() <= MAX_SUPPORTED_CHANNELS {
+                occupied_slots[entry.logical_channel_id()] = true;
             }
         }
     }
@@ -962,7 +962,8 @@ mod tests {
                 "Active channel count must be 2 after publishing"
             );
             assert_eq!(
-                active[1].logical_channel_id, 3,
+                active[1].logical_channel_id(),
+                3,
                 "New channel must receive slot 3"
             );
             assert_eq!(active[1].id, 3, "New channel must receive monotonic ID 3");


### PR DESCRIPTION
Implements transaction affinity resolution and concurrency handling for multi-statement transactions inside `ChannelPool`.

Key changes:
- Tracks active Read/Write transactions on channels using RAII guards so channels undergoing scale-down draining are kept alive until in-flight transactions complete.
- Implements affinity resolution supporting hard stickiness (Read/Write transactions follow their pinned channel even when draining) and soft stickiness (Read-Only transactions prefer warmth but cleanly fail over to active channels).
- Handles concurrent CAS races when multiple statements attempt to pin the same transaction at once, ensuring all statements consistently route to the winning channel.