### PR TITLE
refactor(bigquery): send via stream entry

### DIFF
--- a/src/bigquery/src/write.rs
+++ b/src/bigquery/src/write.rs
@@ -24,9 +24,9 @@ pub(super) mod append_response;
 pub(super) mod builder;
 pub(super) mod client;
 pub(super) mod client_builder;
-#[cfg_attr(not(test), expect(dead_code))]
-mod entry;
 pub(super) mod error;
+
+mod entry;
 #[cfg_attr(not(test), expect(dead_code))]
 mod pool;
 mod proto_schema;

--- a/src/bigquery/src/write/builder/append.rs
+++ b/src/bigquery/src/write/builder/append.rs
@@ -14,23 +14,31 @@
 
 use super::super::append_future::AppendFuture;
 use super::super::append_response::to_result;
-use super::super::error::AppendError;
+use super::super::entry::StreamEntry;
 use super::super::runner::WriteRequest;
 use crate::Error;
 use crate::model::AppendRowsRequest;
 use gaxi::prost::{FromProto, ToProto};
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 use tokio::sync::{mpsc, oneshot};
 
 /// A request builder for appending rows on the default stream.
 #[derive(Clone, Debug)]
 pub struct Append {
-    req_tx: mpsc::UnboundedSender<WriteRequest>,
+    entry: StreamEntry,
     pub(crate) req: AppendRowsRequest,
 }
 
 impl Append {
     pub(crate) fn new(req_tx: mpsc::UnboundedSender<WriteRequest>, req: AppendRowsRequest) -> Self {
-        Self { req_tx, req }
+        let entry = StreamEntry {
+            id: 0,
+            req_tx,
+            outstanding_requests: Arc::new(AtomicU64::new(0)),
+            outstanding_bytes: Arc::new(AtomicU64::new(0)),
+        };
+        Self { entry, req }
     }
 
     /// Append rows to the stream.
@@ -58,14 +66,9 @@ impl Append {
     pub fn send(self) -> AppendFuture {
         let (tx, rx) = oneshot::channel();
         tokio::spawn(async move {
-            let (resp_tx, resp_rx) = oneshot::channel();
             let res = async move {
                 let req = self.req.to_proto().map_err(Error::deser)?;
-                let write = WriteRequest { req, resp_tx };
-                let _ = self.req_tx.send(write);
-                let resp = resp_rx
-                    .await
-                    .map_err(|_| AppendError::UnexpectedEndOfStream)??;
+                let resp = self.entry.send(req).await?;
                 let resp = resp.cnv().map_err(Error::ser)?;
                 to_result(resp)
             }
@@ -79,6 +82,7 @@ impl Append {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::AppendError;
     use crate::google::cloud::bigquery::storage::v1;
     use crate::google::cloud::bigquery::storage::v1::append_rows_response::{
         AppendResult, Response,

--- a/src/bigquery/src/write/entry.rs
+++ b/src/bigquery/src/write/entry.rs
@@ -47,11 +47,9 @@ impl StreamEntry {
             .send(write)
             .map_err(|_| AppendError::UnexpectedEndOfStream)?;
 
-        match resp_rx.await {
-            Ok(Ok(resp)) => Ok(resp),
-            Ok(Err(err)) => Err(err),
-            Err(_) => Err(AppendError::UnexpectedEndOfStream),
-        }
+        resp_rx
+            .await
+            .map_err(|_| AppendError::UnexpectedEndOfStream)?
     }
 }
 

--- a/src/bigquery/src/write/entry.rs
+++ b/src/bigquery/src/write/entry.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::error::{AppendError, AppendResult};
 use super::runner::WriteRequest;
+use crate::google::cloud::bigquery::storage::v1::{AppendRowsRequest, AppendRowsResponse};
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 /// An entry in the stream pool serviced by a `Runner`.
 #[derive(Clone, Debug)]
@@ -31,4 +33,101 @@ pub(crate) struct StreamEntry {
 
     /// The total outstanding bytes on this stream.
     pub(crate) outstanding_bytes: Arc<AtomicU64>,
+}
+
+impl StreamEntry {
+    /// Send a write to the stream task and process the result
+    pub(crate) async fn send(&self, req: AppendRowsRequest) -> AppendResult<AppendRowsResponse> {
+        // TODO(#6122) - track load on the stream entry
+
+        let (resp_tx, resp_rx) = oneshot::channel();
+        let write = WriteRequest { req, resp_tx };
+
+        self.req_tx
+            .send(write)
+            .map_err(|_| AppendError::UnexpectedEndOfStream)?;
+
+        match resp_rx.await {
+            Ok(Ok(resp)) => Ok(resp),
+            Ok(Err(err)) => Err(err),
+            Err(_) => Err(AppendError::UnexpectedEndOfStream),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Error;
+    use crate::error::AppendError;
+    use crate::write::test::*;
+
+    #[tokio::test]
+    async fn success() -> anyhow::Result<()> {
+        let (req_tx, mut req_rx) = mpsc::unbounded_channel();
+        let entry = StreamEntry {
+            id: 0,
+            req_tx,
+            outstanding_requests: Arc::new(AtomicU64::new(0)),
+            outstanding_bytes: Arc::new(AtomicU64::new(0)),
+        };
+        let handle = tokio::spawn(async move { entry.send(test_request(1)).await });
+
+        // Receive and verify the request
+        let write = req_rx.recv().await.expect("should receive request");
+        assert_eq!(write.req.write_stream, write_stream());
+
+        // Provide a successful response
+        write
+            .resp_tx
+            .send(Ok(test_response(1)))
+            .expect("sending on channel always succeeds");
+
+        let resp = handle.await??;
+        assert_eq!(resp, test_response(1));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stream_closed() -> anyhow::Result<()> {
+        let (req_tx, req_rx) = mpsc::unbounded_channel();
+        let entry = StreamEntry {
+            id: 0,
+            req_tx,
+            outstanding_requests: Arc::new(AtomicU64::new(0)),
+            outstanding_bytes: Arc::new(AtomicU64::new(0)),
+        };
+        let handle = tokio::spawn(async move { entry.send(test_request(1)).await });
+
+        // Simulate a stream closure
+        drop(req_rx);
+
+        let err = handle.await?.expect_err("should return an error");
+        assert!(matches!(err, AppendError::UnexpectedEndOfStream));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rpc_error() -> anyhow::Result<()> {
+        let (req_tx, mut req_rx) = mpsc::unbounded_channel();
+        let entry = StreamEntry {
+            id: 0,
+            req_tx,
+            outstanding_requests: Arc::new(AtomicU64::new(0)),
+            outstanding_bytes: Arc::new(AtomicU64::new(0)),
+        };
+        let handle = tokio::spawn(async move { entry.send(test_request(1)).await });
+
+        // Simulate a stream ending in a known error
+        let write = req_rx.recv().await.expect("should receive request");
+        let append_err: AppendError = Error::io("fail").into();
+        write
+            .resp_tx
+            .send(Err(append_err))
+            .expect("sending on channel always succeeds");
+
+        let err = handle.await?.expect_err("should return an error");
+        assert!(matches!(err, AppendError::Rpc { source: _ }));
+        Ok(())
+    }
 }


### PR DESCRIPTION
This PR introduces a helper on a `StreamEntry` to send a request. And it refactors the `Append` builder to call into this helper.

This gets us one step closer to hooking up a writer with a stream pool.

Note that we already have test coverage in `append.rs`, but I feel better duplicating the tests so they also live in `entry.rs`.

Part of the work for #5831 