### PR TITLE
refactor(bigquery): default writer holds stream entry

### DIFF
--- a/src/bigquery/src/write/arrow/default.rs
+++ b/src/bigquery/src/write/arrow/default.rs
@@ -13,19 +13,20 @@
 // limitations under the License.
 
 use super::super::builder::Append;
+use super::super::entry::StreamEntry;
 use super::super::runner::Runner;
 use super::super::transport::Transport;
 use crate::model::append_rows_request::ArrowData;
 use crate::model::{AppendRowsRequest, ArrowRecordBatch, ArrowSchema};
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 
 /// A writer for the [default stream]
 ///
 /// [default stream]: https://docs.cloud.google.com/bigquery/docs/write-api#default_stream
 #[derive(Debug)]
 pub struct DefaultWriter {
-    // TODO(#5744) - support multiplexed connections
-    runner: Runner,
+    entry: Arc<StreamEntry>,
     pub(crate) write_stream: String,
     pub(crate) schema: ArrowSchema,
 }
@@ -33,8 +34,14 @@ pub struct DefaultWriter {
 impl DefaultWriter {
     pub(crate) fn new(inner: Arc<Transport>, write_stream: String, schema: ArrowSchema) -> Self {
         let runner = Runner::new(inner);
+        let entry = Arc::new(StreamEntry {
+            id: 0,
+            req_tx: runner.req_tx,
+            outstanding_requests: Arc::new(AtomicU64::new(0)),
+            outstanding_bytes: Arc::new(AtomicU64::new(0)),
+        });
         Self {
-            runner,
+            entry,
             write_stream,
             schema,
         }
@@ -50,7 +57,7 @@ impl DefaultWriter {
                     .set_writer_schema(self.schema.clone())
                     .set_rows(rows),
             );
-        Append::new(self.runner.req_tx.clone(), req)
+        Append::new(self.entry.clone(), req)
     }
 }
 

--- a/src/bigquery/src/write/builder/append.rs
+++ b/src/bigquery/src/write/builder/append.rs
@@ -15,29 +15,21 @@
 use super::super::append_future::AppendFuture;
 use super::super::append_response::to_result;
 use super::super::entry::StreamEntry;
-use super::super::runner::WriteRequest;
 use crate::Error;
 use crate::model::AppendRowsRequest;
 use gaxi::prost::{FromProto, ToProto};
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::oneshot;
 
 /// A request builder for appending rows on the default stream.
 #[derive(Clone, Debug)]
 pub struct Append {
-    entry: StreamEntry,
+    entry: Arc<StreamEntry>,
     pub(crate) req: AppendRowsRequest,
 }
 
 impl Append {
-    pub(crate) fn new(req_tx: mpsc::UnboundedSender<WriteRequest>, req: AppendRowsRequest) -> Self {
-        let entry = StreamEntry {
-            id: 0,
-            req_tx,
-            outstanding_requests: Arc::new(AtomicU64::new(0)),
-            outstanding_bytes: Arc::new(AtomicU64::new(0)),
-        };
+    pub(crate) fn new(entry: Arc<StreamEntry>, req: AppendRowsRequest) -> Self {
         Self { entry, req }
     }
 
@@ -89,13 +81,15 @@ mod tests {
     };
     use crate::model::TableSchema;
     use crate::write::test::*;
+    use tokio::sync::mpsc;
 
     #[tokio::test]
     async fn success() -> anyhow::Result<()> {
         let (req_tx, mut req_rx) = mpsc::unbounded_channel();
+        let entry = test_entry(req_tx);
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
-        let builder = Append::new(req_tx, req);
+        let builder = Append::new(entry, req);
         let handle = tokio::spawn(async move { builder.send().await });
 
         // Receive and verify the request
@@ -123,9 +117,10 @@ mod tests {
     #[tokio::test]
     async fn stream_closed() -> anyhow::Result<()> {
         let (req_tx, req_rx) = mpsc::unbounded_channel();
+        let entry = test_entry(req_tx);
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
-        let builder = Append::new(req_tx, req);
+        let builder = Append::new(entry, req);
         let handle = tokio::spawn(async move { builder.send().await });
 
         // Simulate a stream closure
@@ -139,9 +134,10 @@ mod tests {
     #[tokio::test]
     async fn rpc_error() -> anyhow::Result<()> {
         let (req_tx, mut req_rx) = mpsc::unbounded_channel();
+        let entry = test_entry(req_tx);
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
-        let builder = Append::new(req_tx, req);
+        let builder = Append::new(entry, req);
         let handle = tokio::spawn(async move { builder.send().await });
 
         // Simulate a stream ending in a known error
@@ -160,9 +156,10 @@ mod tests {
     #[tokio::test]
     async fn row_errors() -> anyhow::Result<()> {
         let (req_tx, mut req_rx) = mpsc::unbounded_channel();
+        let entry = test_entry(req_tx);
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
-        let builder = Append::new(req_tx, req);
+        let builder = Append::new(entry, req);
         let handle = tokio::spawn(async move { builder.send().await });
 
         let write = req_rx.recv().await.expect("should receive request");

--- a/src/bigquery/src/write/test.rs
+++ b/src/bigquery/src/write/test.rs
@@ -14,12 +14,17 @@
 
 //! Test helpers for the `Write` client internals
 
+use super::entry::StreamEntry;
+use super::runner::WriteRequest;
 use super::transport::Transport;
 use crate::google::cloud::bigquery::storage::v1::append_rows_response::{AppendResult, Response};
 use crate::google::cloud::bigquery::storage::v1::{AppendRowsRequest, AppendRowsResponse};
 use crate::model::ArrowSchema;
 use bigquery_grpc_mock::google::cloud::bigquery::storage::v1;
 use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use tokio::sync::mpsc;
 
 pub(super) fn write_stream() -> String {
     "projects/p/datasets/d/tables/t/streams/s".to_string()
@@ -61,4 +66,14 @@ pub(super) fn test_response(index: i64) -> AppendRowsResponse {
         write_stream: "projects/p/datasets/d/tables/t/streams/s".to_string(),
         ..Default::default()
     }
+}
+
+// Return a stream entry that sends requests on the provided channel.
+pub(super) fn test_entry(req_tx: mpsc::UnboundedSender<WriteRequest>) -> Arc<StreamEntry> {
+    Arc::new(StreamEntry {
+        id: 0,
+        req_tx,
+        outstanding_requests: Arc::new(AtomicU64::new(0)),
+        outstanding_bytes: Arc::new(AtomicU64::new(0)),
+    })
 }


### PR DESCRIPTION
Continue the refactor. Now the default writer holds a stream entry and passes it along to the append builders.

Eventually this gets hooked up to a stream pool.

In response to: https://github.com/googleapis/google-cloud-rust/pull/6739#discussion_r3960213617

Towards #5831 