### PR TITLE
chore: update librarian version to v0.42.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.40.1-0.20260904230940-45d06df00775
+version: v0.42.0
 repo: googleapis/google-cloud-rust
 sources:
   conformance:


### PR DESCRIPTION
Update librarian version to v0.42.0.
### Included Librarian Updates
- googleapis/librarian#7524: chore(main): release 0.42.0
- googleapis/librarian#7473: chore(main): release 0.41.0
