### PR TITLE
impl(bigquery): add internal proto default writer

### DIFF
--- a/src/bigquery/src/write.rs
+++ b/src/bigquery/src/write.rs
@@ -35,6 +35,7 @@ mod proto_schema;
 mod runner;
 mod stream;
 mod transport;
+mod validate;
 
 // TODO(#4832) - remove handwritten code.
 mod status;

--- a/src/bigquery/src/write.rs
+++ b/src/bigquery/src/write.rs
@@ -16,6 +16,8 @@
 ///
 /// [arrow]: https://arrow.apache.org/
 pub mod arrow;
+#[allow(dead_code)]
+pub(crate) mod proto;
 
 pub use append_future::AppendFuture;
 

--- a/src/bigquery/src/write/arrow/writer_builder.rs
+++ b/src/bigquery/src/write/arrow/writer_builder.rs
@@ -14,14 +14,12 @@
 
 use super::super::generated::gapic_storage::client::BigQueryWrite;
 use super::super::transport::Transport;
+use super::super::validate::{validate_stream, validate_table};
 use super::{BufferedWriter, CommittedWriter, DefaultWriter, PendingWriter, Writer};
+use crate::Result;
 use crate::model::write_stream::Type;
 use crate::model::{ArrowSchema, WriteStream};
 use crate::write::error::{AttachError, AttachResult};
-use crate::{Error, Result};
-use gaxi::path_parameter::{PathMismatchBuilder, try_match};
-use gaxi::routing_parameter::Segment;
-use google_cloud_gax::error::binding::BindingError;
 use std::sync::Arc;
 
 /// A builder to create a stream writer
@@ -213,57 +211,6 @@ impl WriterBuilder {
         }
         Ok(U::build(self.inner, write_stream, self.schema))
     }
-}
-
-fn validate_table(table: &str) -> Result<()> {
-    let segments = &[
-        Segment::Literal("projects/"),
-        Segment::SingleWildcard,
-        Segment::Literal("/datasets/"),
-        Segment::SingleWildcard,
-        Segment::Literal("/tables/"),
-        Segment::SingleWildcard,
-    ];
-    try_match(Some(table), segments)
-        .ok_or_else(|| {
-            let builder = PathMismatchBuilder::default().maybe_add(
-                Some(table),
-                segments,
-                "table",
-                "projects/*/datasets/*/tables/*",
-            );
-            Error::binding(BindingError {
-                paths: vec![builder.build()],
-            })
-        })
-        .map(|_| ())
-}
-
-fn validate_stream(stream: &str) -> crate::Result<()> {
-    let segments = &[
-        Segment::Literal("projects/"),
-        Segment::SingleWildcard,
-        Segment::Literal("/datasets/"),
-        Segment::SingleWildcard,
-        Segment::Literal("/tables/"),
-        Segment::SingleWildcard,
-        Segment::Literal("/streams/"),
-        Segment::SingleWildcard,
-    ];
-    try_match(Some(stream), segments)
-        .ok_or_else(|| {
-            let builder = gaxi::path_parameter::PathMismatchBuilder::default();
-            let builder = builder.maybe_add(
-                Some(stream),
-                segments,
-                "write_stream",
-                "projects/*/datasets/*/tables/*/streams/*",
-            );
-            Error::binding(BindingError {
-                paths: vec![builder.build()],
-            })
-        })
-        .map(|_| ())
 }
 
 #[cfg(test)]

--- a/src/bigquery/src/write/client.rs
+++ b/src/bigquery/src/write/client.rs
@@ -14,9 +14,10 @@
 
 use super::arrow::WriterBuilder as ArrowWriterBuilder;
 use super::client_builder::ClientBuilder;
+use super::proto::WriterBuilder as ProtoWriterBuilder;
 use super::transport::Transport;
 use crate::ClientBuilderResult as BuilderResult;
-use crate::model::ArrowSchema;
+use crate::model::{ArrowSchema, ProtoSchema};
 use std::sync::Arc;
 
 /// A client for BigQuery Storage Write API.
@@ -60,13 +61,18 @@ impl Write {
     pub fn arrow(&self, schema: ArrowSchema) -> ArrowWriterBuilder {
         ArrowWriterBuilder::new(self.inner.clone(), schema)
     }
+
+    #[allow(dead_code)]
+    pub(crate) fn proto(&self, schema: ProtoSchema) -> ProtoWriterBuilder {
+        ProtoWriterBuilder::new(self.inner.clone(), schema)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::super::error::AppendError;
     use super::*;
-    use crate::model::{ArrowRecordBatch, ArrowSchema};
+    use crate::model::{ArrowRecordBatch, ArrowSchema, ProtoRows, ProtoSchema};
     use bigquery_grpc_mock::{MockBigQueryWrite, start};
     use gaxi::grpc::tonic::Status as TonicStatus;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
@@ -87,6 +93,30 @@ mod tests {
             .default("projects/p/datasets/d/tables/t")?;
         let err = writer
             .append(ArrowRecordBatch::new())
+            .send()
+            .await
+            .expect_err("write should fail");
+        assert!(matches!(err, AppendError::Rpc { source: _ }));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn proto() -> anyhow::Result<()> {
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_append_rows()
+            .return_once(|_| Err(TonicStatus::failed_precondition("fail")));
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let client = Write::builder()
+            .with_endpoint(endpoint)
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+        let writer = client
+            .proto(ProtoSchema::new())
+            .default("projects/p/datasets/d/tables/t")?;
+        let err = writer
+            .append(ProtoRows::new())
             .send()
             .await
             .expect_err("write should fail");

--- a/src/bigquery/src/write/proto.rs
+++ b/src/bigquery/src/write/proto.rs
@@ -1,0 +1,19 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod default;
+mod writer_builder;
+
+pub(crate) use default::DefaultWriter;
+pub(crate) use writer_builder::WriterBuilder;

--- a/src/bigquery/src/write/proto/default.rs
+++ b/src/bigquery/src/write/proto/default.rs
@@ -1,0 +1,131 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::builder::Append;
+use super::super::entry::StreamEntry;
+use super::super::runner::Runner;
+use super::super::transport::Transport;
+use crate::model::append_rows_request::ProtoData;
+use crate::model::{AppendRowsRequest, ProtoRows, ProtoSchema};
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+
+/// A writer for the [default stream] using Protobuf as the data format.
+///
+/// [default stream]: https://docs.cloud.google.com/bigquery/docs/write-api#default_stream
+#[derive(Debug)]
+pub struct DefaultWriter {
+    entry: Arc<StreamEntry>,
+    pub(crate) write_stream: String,
+    pub(crate) schema: ProtoSchema,
+}
+
+impl DefaultWriter {
+    pub(crate) fn new(inner: Arc<Transport>, write_stream: String, schema: ProtoSchema) -> Self {
+        let runner = Runner::new(inner);
+        let entry = Arc::new(StreamEntry {
+            id: 0,
+            req_tx: runner.req_tx,
+            outstanding_requests: Arc::new(AtomicU64::new(0)),
+            outstanding_bytes: Arc::new(AtomicU64::new(0)),
+        });
+        Self {
+            entry,
+            write_stream,
+            schema,
+        }
+    }
+
+    /// Append rows to the stream.
+    pub fn append(&self, rows: ProtoRows) -> Append {
+        // TODO(#5744) - send optimization
+        let req = AppendRowsRequest::new()
+            .set_write_stream(&self.write_stream)
+            .set_proto_rows(
+                ProtoData::new()
+                    .set_writer_schema(self.schema.clone())
+                    .set_rows(rows),
+            );
+        Append::new(self.entry.clone(), req)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::AppendError;
+    use crate::write::test::*;
+    use bigquery_grpc_mock::{MockBigQueryWrite, start};
+    use gaxi::grpc::tonic::Response as TonicResponse;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn request_fields() -> anyhow::Result<()> {
+        let transport = Arc::new(test_transport("http://ignored:1").await?);
+        let writer = DefaultWriter::new(transport, write_stream(), proto_schema());
+
+        let b = writer.append(rows(1));
+        assert_eq!(b.req.write_stream, write_stream());
+        let data = b.req.proto_rows().expect("proto rows should be set");
+        let s = data.writer_schema.as_ref().expect("schema should be set");
+        assert_eq!(s.proto_descriptor.as_ref().unwrap().name, "TestMessage");
+        let r = data.rows.as_ref().expect("rows should be set");
+        assert_eq!(r.serialized_rows, vec![bytes::Bytes::from("1")]);
+
+        let b = writer.append(rows(2));
+        assert_eq!(b.req.write_stream, write_stream());
+        let data = b.req.proto_rows().expect("proto rows should be set");
+        let s = data.writer_schema.as_ref().expect("schema should be set");
+        assert_eq!(s.proto_descriptor.as_ref().unwrap().name, "TestMessage");
+        let r = data.rows.as_ref().expect("rows should be set");
+        assert_eq!(r.serialized_rows, vec![bytes::Bytes::from("2")]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn basic_success() -> anyhow::Result<()> {
+        let (response_tx, response_rx) = mpsc::channel(10);
+
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_append_rows()
+            .return_once(|_| Ok(TonicResponse::from(response_rx)));
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let transport = Arc::new(test_transport(endpoint).await?);
+
+        let writer = DefaultWriter::new(transport, write_stream(), proto_schema());
+
+        response_tx.send(Ok(convert(&test_response(1)))).await?;
+        let resp = writer.append(rows(1)).send().await?;
+        assert_eq!(resp.offset, Some(1));
+
+        response_tx.send(Ok(convert(&test_response(2)))).await?;
+        let resp = writer.append(rows(2)).send().await?;
+        assert_eq!(resp.offset, Some(2));
+
+        response_tx.send(Ok(convert(&test_response(3)))).await?;
+        let resp = writer.append(rows(3)).send().await?;
+        assert_eq!(resp.offset, Some(3));
+
+        drop(response_tx);
+        let err = writer.append(rows(4)).send().await.expect_err("channel");
+        assert!(matches!(err, AppendError::UnexpectedEndOfStream));
+
+        Ok(())
+    }
+
+    fn rows(id: i64) -> ProtoRows {
+        ProtoRows::new().set_serialized_rows(vec![bytes::Bytes::from(id.to_string())])
+    }
+}

--- a/src/bigquery/src/write/proto/writer_builder.rs
+++ b/src/bigquery/src/write/proto/writer_builder.rs
@@ -1,0 +1,107 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::super::transport::Transport;
+use super::DefaultWriter;
+use crate::model::ProtoSchema;
+use crate::{Error, Result};
+use gaxi::path_parameter::{PathMismatchBuilder, try_match};
+use gaxi::routing_parameter::Segment;
+use google_cloud_gax::error::binding::BindingError;
+use std::sync::Arc;
+
+/// A builder to create a protobuf stream writer
+#[derive(Clone, Debug)]
+pub struct WriterBuilder {
+    inner: Arc<Transport>,
+    schema: ProtoSchema,
+}
+
+impl WriterBuilder {
+    pub(crate) fn new(inner: Arc<Transport>, schema: ProtoSchema) -> Self {
+        Self { inner, schema }
+    }
+
+    /// Create a writer for the [default stream] for the given table.
+    ///
+    /// [default stream]: https://docs.cloud.google.com/bigquery/docs/write-api#default_stream
+    pub fn default<T: Into<String>>(self, table: T) -> Result<DefaultWriter> {
+        let table = table.into();
+        validate_table(table.as_str())?;
+        let mut write_stream = table;
+        write_stream.push_str("/streams/_default");
+        Ok(DefaultWriter::new(self.inner, write_stream, self.schema))
+    }
+}
+
+fn validate_table(table: &str) -> Result<()> {
+    let segments = &[
+        Segment::Literal("projects/"),
+        Segment::SingleWildcard,
+        Segment::Literal("/datasets/"),
+        Segment::SingleWildcard,
+        Segment::Literal("/tables/"),
+        Segment::SingleWildcard,
+    ];
+    try_match(Some(table), segments)
+        .ok_or_else(|| {
+            let builder = PathMismatchBuilder::default().maybe_add(
+                Some(table),
+                segments,
+                "table",
+                "projects/*/datasets/*/tables/*",
+            );
+            Error::binding(BindingError {
+                paths: vec![builder.build()],
+            })
+        })
+        .map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::write::test::*;
+    use test_case::test_case;
+
+    #[tokio::test]
+    async fn default() -> anyhow::Result<()> {
+        let transport = Arc::new(test_transport("http://ignored:1").await?);
+        let builder = WriterBuilder::new(transport, proto_schema());
+        let writer = builder.default("projects/p/datasets/d/tables/t")?;
+        assert_eq!(
+            writer.write_stream,
+            "projects/p/datasets/d/tables/t/streams/_default"
+        );
+        assert_eq!(writer.schema, proto_schema());
+        Ok(())
+    }
+
+    #[test_case("projects/p")]
+    #[test_case("projects/p/tables/t")]
+    #[test_case("projects/p/datasets/d/tables/")]
+    #[test_case("projects/p/instances/i/tables/t")]
+    #[test_case("projects/p/datasets/d/tables/t/streams")]
+    #[test_case("projects/p/datasets/d/tables/t/streams/_default")]
+    #[tokio::test]
+    async fn bad_table_format(table: &str) -> anyhow::Result<()> {
+        let transport = Arc::new(test_transport("http://ignored:1").await?);
+        let builder = WriterBuilder::new(transport, proto_schema());
+        let err = builder
+            .default(table)
+            .expect_err("should fail locally on bad format");
+        assert!(err.is_binding(), "{err:?}");
+        Ok(())
+    }
+}

--- a/src/bigquery/src/write/proto/writer_builder.rs
+++ b/src/bigquery/src/write/proto/writer_builder.rs
@@ -13,12 +13,10 @@
 // limitations under the License.
 
 use super::super::transport::Transport;
+use super::super::validate::validate_table;
 use super::DefaultWriter;
+use crate::Result;
 use crate::model::ProtoSchema;
-use crate::{Error, Result};
-use gaxi::path_parameter::{PathMismatchBuilder, try_match};
-use gaxi::routing_parameter::Segment;
-use google_cloud_gax::error::binding::BindingError;
 use std::sync::Arc;
 
 /// A builder to create a protobuf stream writer
@@ -43,30 +41,6 @@ impl WriterBuilder {
         write_stream.push_str("/streams/_default");
         Ok(DefaultWriter::new(self.inner, write_stream, self.schema))
     }
-}
-
-fn validate_table(table: &str) -> Result<()> {
-    let segments = &[
-        Segment::Literal("projects/"),
-        Segment::SingleWildcard,
-        Segment::Literal("/datasets/"),
-        Segment::SingleWildcard,
-        Segment::Literal("/tables/"),
-        Segment::SingleWildcard,
-    ];
-    try_match(Some(table), segments)
-        .ok_or_else(|| {
-            let builder = PathMismatchBuilder::default().maybe_add(
-                Some(table),
-                segments,
-                "table",
-                "projects/*/datasets/*/tables/*",
-            );
-            Error::binding(BindingError {
-                paths: vec![builder.build()],
-            })
-        })
-        .map(|_| ())
 }
 
 #[cfg(test)]

--- a/src/bigquery/src/write/test.rs
+++ b/src/bigquery/src/write/test.rs
@@ -19,7 +19,7 @@ use super::runner::WriteRequest;
 use super::transport::Transport;
 use crate::google::cloud::bigquery::storage::v1::append_rows_response::{AppendResult, Response};
 use crate::google::cloud::bigquery::storage::v1::{AppendRowsRequest, AppendRowsResponse};
-use crate::model::ArrowSchema;
+use crate::model::{ArrowSchema, ProtoSchema};
 use bigquery_grpc_mock::google::cloud::bigquery::storage::v1;
 use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
 use std::sync::Arc;
@@ -32,6 +32,11 @@ pub(super) fn write_stream() -> String {
 
 pub(super) fn schema() -> ArrowSchema {
     ArrowSchema::new().set_serialized_schema("test")
+}
+
+pub(super) fn proto_schema() -> ProtoSchema {
+    let descriptor = wkt::DescriptorProto::default().set_name("TestMessage".to_string());
+    ProtoSchema::new().set_proto_descriptor(descriptor)
 }
 
 pub(super) async fn test_transport<T: Into<String>>(endpoint: T) -> anyhow::Result<Transport> {

--- a/src/bigquery/src/write/validate.rs
+++ b/src/bigquery/src/write/validate.rs
@@ -1,0 +1,104 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{Error, Result};
+use gaxi::path_parameter::{PathMismatchBuilder, try_match};
+use gaxi::routing_parameter::Segment;
+use google_cloud_gax::error::binding::BindingError;
+
+pub(crate) fn validate_table(table: &str) -> Result<()> {
+    let segments = &[
+        Segment::Literal("projects/"),
+        Segment::SingleWildcard,
+        Segment::Literal("/datasets/"),
+        Segment::SingleWildcard,
+        Segment::Literal("/tables/"),
+        Segment::SingleWildcard,
+    ];
+    try_match(Some(table), segments)
+        .ok_or_else(|| {
+            let builder = PathMismatchBuilder::default().maybe_add(
+                Some(table),
+                segments,
+                "table",
+                "projects/*/datasets/*/tables/*",
+            );
+            Error::binding(BindingError {
+                paths: vec![builder.build()],
+            })
+        })
+        .map(|_| ())
+}
+
+pub(crate) fn validate_stream(stream: &str) -> Result<()> {
+    let segments = &[
+        Segment::Literal("projects/"),
+        Segment::SingleWildcard,
+        Segment::Literal("/datasets/"),
+        Segment::SingleWildcard,
+        Segment::Literal("/tables/"),
+        Segment::SingleWildcard,
+        Segment::Literal("/streams/"),
+        Segment::SingleWildcard,
+    ];
+    try_match(Some(stream), segments)
+        .ok_or_else(|| {
+            let builder = PathMismatchBuilder::default().maybe_add(
+                Some(stream),
+                segments,
+                "write_stream",
+                "projects/*/datasets/*/tables/*/streams/*",
+            );
+            Error::binding(BindingError {
+                paths: vec![builder.build()],
+            })
+        })
+        .map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    #[test]
+    fn valid_table() {
+        assert!(validate_table("projects/p/datasets/d/tables/t").is_ok());
+    }
+
+    #[test_case("projects/p")]
+    #[test_case("projects/p/tables/t")]
+    #[test_case("projects/p/datasets/d/tables/")]
+    #[test_case("projects/p/instances/i/tables/t")]
+    #[test_case("projects/p/datasets/d/tables/t/streams")]
+    #[test_case("projects/p/datasets/d/tables/t/streams/_default")]
+    fn bad_table_format(table: &str) {
+        let err = validate_table(table).expect_err("should fail locally on bad format");
+        assert!(err.is_binding(), "{err:?}");
+    }
+
+    #[test]
+    fn valid_stream() {
+        assert!(validate_stream("projects/p/datasets/d/tables/t/streams/s").is_ok());
+    }
+
+    #[test_case("projects/p")]
+    #[test_case("projects/p/tables/t")]
+    #[test_case("projects/p/datasets/d/tables/t")]
+    #[test_case("projects/p/datasets/d/tables/t/streams/")]
+    fn bad_stream_format(stream: &str) {
+        let err = validate_stream(stream).expect_err("should fail locally on bad format");
+        assert!(err.is_binding(), "{err:?}");
+    }
+}


### PR DESCRIPTION
Introduce the internal `write::proto` module with `DefaultWriter` and `WriterBuilder`, mirroring the `arrow` default stream implementation https://github.com/googleapis/google-cloud-rust/pull/6241.

For #6598