### PR TITLE
feat(storage): make GrpcRustClient available to Storage GAPIC methods

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1566,7 +1566,7 @@ libraries:
     output: src/storage
     rust:
       resource_name_heuristic: true
-      grpc_client: crate::storage::bidi::GrpcClient
+      grpc_client: crate::GrpcClient
       modules:
         - module_path: crate::generated::gapic_control::model
           name_overrides: .google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_buckets=CloudStorageBucketsOneOf,.google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_locations=CloudStorageLocationsOneOf

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1566,6 +1566,7 @@ libraries:
     output: src/storage
     rust:
       resource_name_heuristic: true
+      grpc_client: crate::storage::bidi::GrpcClient
       modules:
         - module_path: crate::generated::gapic_control::model
           name_overrides: .google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_buckets=CloudStorageBucketsOneOf,.google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_locations=CloudStorageLocationsOneOf

--- a/src/storage/src/generated/gapic/transport.rs
+++ b/src/storage/src/generated/gapic/transport.rs
@@ -37,7 +37,7 @@ mod info {
 /// Implements [StorageControl](super::stub::StorageControl) using a gRPC client.
 #[derive(Clone)]
 pub struct StorageControl {
-    inner: gaxi::grpc::Client,
+    inner: crate::storage::bidi::GrpcClient,
 }
 
 impl std::fmt::Debug for StorageControl {
@@ -51,14 +51,14 @@ impl std::fmt::Debug for StorageControl {
 impl StorageControl {
     pub async fn new(config: gaxi::options::ClientConfig) -> crate::ClientBuilderResult<Self> {
         let inner = if gaxi::options::tracing_enabled(&config) {
-            gaxi::grpc::Client::new_with_instrumentation(
+            crate::storage::bidi::GrpcClient::new_with_instrumentation(
                 config,
                 DEFAULT_HOST,
                 &super::tracing::info::INSTRUMENTATION_CLIENT_INFO,
             )
             .await?
         } else {
-            gaxi::grpc::Client::new(config, DEFAULT_HOST).await?
+            crate::storage::bidi::GrpcClient::new(config, DEFAULT_HOST).await?
         };
         Ok(Self { inner })
     }

--- a/src/storage/src/generated/gapic/transport.rs
+++ b/src/storage/src/generated/gapic/transport.rs
@@ -37,7 +37,7 @@ mod info {
 /// Implements [StorageControl](super::stub::StorageControl) using a gRPC client.
 #[derive(Clone)]
 pub struct StorageControl {
-    inner: crate::storage::bidi::GrpcClient,
+    inner: crate::GrpcClient,
 }
 
 impl std::fmt::Debug for StorageControl {
@@ -51,14 +51,14 @@ impl std::fmt::Debug for StorageControl {
 impl StorageControl {
     pub async fn new(config: gaxi::options::ClientConfig) -> crate::ClientBuilderResult<Self> {
         let inner = if gaxi::options::tracing_enabled(&config) {
-            crate::storage::bidi::GrpcClient::new_with_instrumentation(
+            crate::GrpcClient::new_with_instrumentation(
                 config,
                 DEFAULT_HOST,
                 &super::tracing::info::INSTRUMENTATION_CLIENT_INFO,
             )
             .await?
         } else {
-            crate::storage::bidi::GrpcClient::new(config, DEFAULT_HOST).await?
+            crate::GrpcClient::new(config, DEFAULT_HOST).await?
         };
         Ok(Self { inner })
     }

--- a/src/storage/src/generated/gapic_control/transport.rs
+++ b/src/storage/src/generated/gapic_control/transport.rs
@@ -37,7 +37,7 @@ mod info {
 /// Implements [StorageControl](super::stub::StorageControl) using a gRPC client.
 #[derive(Clone)]
 pub struct StorageControl {
-    inner: gaxi::grpc::Client,
+    inner: crate::storage::bidi::GrpcClient,
 }
 
 impl std::fmt::Debug for StorageControl {
@@ -51,14 +51,14 @@ impl std::fmt::Debug for StorageControl {
 impl StorageControl {
     pub async fn new(config: gaxi::options::ClientConfig) -> crate::ClientBuilderResult<Self> {
         let inner = if gaxi::options::tracing_enabled(&config) {
-            gaxi::grpc::Client::new_with_instrumentation(
+            crate::storage::bidi::GrpcClient::new_with_instrumentation(
                 config,
                 DEFAULT_HOST,
                 &super::tracing::info::INSTRUMENTATION_CLIENT_INFO,
             )
             .await?
         } else {
-            gaxi::grpc::Client::new(config, DEFAULT_HOST).await?
+            crate::storage::bidi::GrpcClient::new(config, DEFAULT_HOST).await?
         };
         Ok(Self { inner })
     }

--- a/src/storage/src/generated/gapic_control/transport.rs
+++ b/src/storage/src/generated/gapic_control/transport.rs
@@ -37,7 +37,7 @@ mod info {
 /// Implements [StorageControl](super::stub::StorageControl) using a gRPC client.
 #[derive(Clone)]
 pub struct StorageControl {
-    inner: crate::storage::bidi::GrpcClient,
+    inner: crate::GrpcClient,
 }
 
 impl std::fmt::Debug for StorageControl {
@@ -51,14 +51,14 @@ impl std::fmt::Debug for StorageControl {
 impl StorageControl {
     pub async fn new(config: gaxi::options::ClientConfig) -> crate::ClientBuilderResult<Self> {
         let inner = if gaxi::options::tracing_enabled(&config) {
-            crate::storage::bidi::GrpcClient::new_with_instrumentation(
+            crate::GrpcClient::new_with_instrumentation(
                 config,
                 DEFAULT_HOST,
                 &super::tracing::info::INSTRUMENTATION_CLIENT_INFO,
             )
             .await?
         } else {
-            crate::storage::bidi::GrpcClient::new(config, DEFAULT_HOST).await?
+            crate::GrpcClient::new(config, DEFAULT_HOST).await?
         };
         Ok(Self { inner })
     }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -55,6 +55,11 @@ pub(crate) use google_cloud_gax::options::RequestOptions;
 pub(crate) use google_cloud_gax::options::internal::RequestBuilder;
 pub(crate) use google_cloud_gax::response::Response;
 
+#[cfg(google_cloud_unstable_grpc_rust)]
+pub(crate) type GrpcClient = gaxi::grpc::GrpcRustClient;
+#[cfg(not(google_cloud_unstable_grpc_rust))]
+pub(crate) type GrpcClient = gaxi::grpc::Client;
+
 #[cfg(google_cloud_unstable_storage_bidi)]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable-stream")))]
 pub mod appendable_object_writer;

--- a/src/storage/src/storage/bidi.rs
+++ b/src/storage/src/storage/bidi.rs
@@ -25,18 +25,15 @@ pub(crate) mod stub;
 pub(crate) mod transport;
 mod worker;
 
+use crate::GrpcClient;
 use crate::google::storage::v2::{BidiReadObjectRequest, BidiReadObjectResponse};
 use crate::request_options::RequestOptions;
 use gaxi::grpc::tonic::{Extensions, Response as TonicResponse, Result as TonicResult};
 use tokio::sync::mpsc::Receiver;
 
 #[cfg(google_cloud_unstable_grpc_rust)]
-pub(crate) type GrpcClient = gaxi::grpc::GrpcRustClient;
-#[cfg(google_cloud_unstable_grpc_rust)]
 pub(crate) type GrpcStream = gaxi::grpc::GrpcRustStreaming<BidiReadObjectResponse>;
 
-#[cfg(not(google_cloud_unstable_grpc_rust))]
-pub(crate) type GrpcClient = gaxi::grpc::Client;
 #[cfg(not(google_cloud_unstable_grpc_rust))]
 pub(crate) type GrpcStream = gaxi::grpc::tonic::Streaming<BidiReadObjectResponse>;
 

--- a/src/storage/src/storage/bidi/connector.rs
+++ b/src/storage/src/storage/bidi/connector.rs
@@ -14,7 +14,8 @@
 
 use super::redirect::handle_redirect;
 use super::retry_redirect::RetryRedirect;
-use super::{Client, GrpcClient, GrpcStream, TonicStreaming};
+use super::{Client, GrpcStream, TonicStreaming};
+use crate::GrpcClient;
 use crate::google::storage::v2::{
     BidiReadObjectRequest, BidiReadObjectResponse, BidiReadObjectSpec, ReadRange as ProtoRange,
 };

--- a/src/storage/src/storage/bidi_write.rs
+++ b/src/storage/src/storage/bidi_write.rs
@@ -30,6 +30,7 @@ pub(crate) mod transport;
 #[allow(dead_code)]
 mod worker;
 
+use crate::GrpcClient;
 use crate::google::storage::v2::{BidiWriteObjectRequest, BidiWriteObjectResponse};
 use crate::request_options::RequestOptions;
 use gaxi::grpc::tonic::{Extensions, Response as TonicResponse, Result as TonicResult};
@@ -45,12 +46,8 @@ use tokio::sync::mpsc::Receiver;
 pub(crate) const MAX_WRITE_CHUNK_SIZE: usize = 2 * 1024 * 1024;
 
 #[cfg(google_cloud_unstable_grpc_rust)]
-pub(crate) type GrpcClient = gaxi::grpc::GrpcRustClient;
-#[cfg(google_cloud_unstable_grpc_rust)]
 pub(crate) type GrpcStream = gaxi::grpc::GrpcRustStreaming<BidiWriteObjectResponse>;
 
-#[cfg(not(google_cloud_unstable_grpc_rust))]
-pub(crate) type GrpcClient = gaxi::grpc::Client;
 #[cfg(not(google_cloud_unstable_grpc_rust))]
 pub(crate) type GrpcStream = gaxi::grpc::tonic::Streaming<BidiWriteObjectResponse>;
 

--- a/src/storage/src/storage/bidi_write/connector.rs
+++ b/src/storage/src/storage/bidi_write/connector.rs
@@ -16,7 +16,8 @@
 
 use super::retry_redirect::RetryRedirect;
 use super::state::AppendObjectSpecState;
-use super::{Client, GrpcClient, GrpcStream, TonicStreaming};
+use super::{Client, GrpcStream, TonicStreaming};
+use crate::GrpcClient;
 use crate::google::storage::v2::{
     AppendObjectSpec, BidiWriteObjectRequest, BidiWriteObjectResponse, CommonObjectRequestParams,
     Object, WriteObjectSpec, bidi_write_object_request::FirstMessage,

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::request_options::RequestOptions;
+use crate::GrpcClient;
 #[cfg(google_cloud_unstable_storage_bidi)]
 use crate::builder::storage::OpenAppendableObject;
 use crate::builder::storage::ReadObject;
@@ -20,7 +21,7 @@ use crate::builder::storage::ReadObject;
 use crate::builder::storage::ReopenAppendableObject;
 use crate::builder::storage::WriteObject;
 use crate::read_resume_policy::ReadResumePolicy;
-use crate::storage::bidi::{GrpcClient, OpenObject};
+use crate::storage::bidi::OpenObject;
 use crate::storage::common_options::CommonOptions;
 use crate::streaming_source::Payload;
 use base64::Engine;


### PR DESCRIPTION
Configure `grpc_client: crate::storage::bidi::GrpcClient` specifically for `google-cloud-storage` in librarian.yaml and regenerate the GAPIC transports.

This makes `GrpcRustClient` available exclusively to Storage's GAPIC transports under `--cfg google_cloud_unstable_grpc_rust`, while defaulting to `gaxi::grpc::Client` (Tonic) when the flag is absent.

For #5991.