### PR TITLE
chore(storage): remove TODOs to lift to shared bidi module

### DIFF
--- a/src/storage/src/storage/bidi_write/connector.rs
+++ b/src/storage/src/storage/bidi_write/connector.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(#5716): Lift to shared bidi module
-
 use super::retry_redirect::RetryRedirect;
 use super::state::AppendObjectSpecState;
 use super::{Client, TonicStreaming};

--- a/src/storage/src/storage/bidi_write/mocks.rs
+++ b/src/storage/src/storage/bidi_write/mocks.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(#5716): Lift to shared bidi module.
-
 use super::connector::Connector;
 use super::tests::test_options;
 use super::{Client, Receiver, RequestOptions, TonicStreaming};

--- a/src/storage/src/storage/bidi_write/redirect.rs
+++ b/src/storage/src/storage/bidi_write/redirect.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(#5716): Lift to shared bidi module
-
 use crate::Error;
 use crate::google::rpc::Status as RpcStatus;
 use crate::google::storage::v2::BidiWriteObjectRedirectedError;

--- a/src/storage/src/storage/bidi_write/retry_redirect.rs
+++ b/src/storage/src/storage/bidi_write/retry_redirect.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(#5716): Lift to shared bidi module
-
 use super::redirect::is_redirect;
 use google_cloud_gax::error::Error;
 use google_cloud_gax::retry_policy::RetryPolicy;

--- a/src/storage/src/storage/bidi_write/transport.rs
+++ b/src/storage/src/storage/bidi_write/transport.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(#5716): Lift to shared bidi module
-
 use super::coalescing_buffer::CoalescingBuffer;
 use super::connector::{Connection, Connector};
 use super::worker::{UploadIntent, Worker};

--- a/src/storage/src/storage/bidi_write/worker.rs
+++ b/src/storage/src/storage/bidi_write/worker.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(#5716): Lift to shared bidi module
-
 use super::connector::Connection;
 use super::{Client, TonicStreaming};
 use crate::Error;


### PR DESCRIPTION
Removes TODO(#5716) header comments in bidi_write.

Bidi read and bidi write use distinct protobuf message and error types, follow different flow control patterns, and have different stability boundaries (read is stable, write is feature-gated). Abstracting them into a shared module introduces unnecessary complexity for minimal reuse. Cross-bidi refactoring can be evaluated independently from #5716.