### PR TITLE
chore(storage): remove TODO on checksum validation on reopen

### DIFF
--- a/src/storage/src/storage/bidi_write/transport.rs
+++ b/src/storage/src/storage/bidi_write/transport.rs
@@ -186,7 +186,6 @@ impl AppendableObjectWriterTransport {
         }
         // If persisted_size > 0 but the server didn't provide a checksum,
         // we can't reliably continue a running checksum, so it remains `None`.
-        // TODO(#5716): Check whether this is a valid case.
 
         let (tx, rx) = tokio::sync::mpsc::channel(CHANNEL_BUFFER_SIZE);
         let worker = Worker::new(connector);


### PR DESCRIPTION
Removes TODO(#5716) in transport.rs.

`persisted_data_checksums` is optional in the GCS v2 API, and the backend may omit it on reopen (e.g. emulator mocks).
The client already handles this by falling back to `running_crc32c = None` (verified by `reopen_server_does_not_return_checksum`), so the TODO is resolved.