### PR TITLE
impl(bigquery): support attaching proto writers to existing streams

### DIFF
--- a/src/bigquery/src/write/proto.rs
+++ b/src/bigquery/src/write/proto.rs
@@ -17,10 +17,12 @@ mod buffered;
 mod committed;
 mod default;
 mod pending;
+mod writer;
 mod writer_builder;
 
 pub(crate) use buffered::BufferedWriter;
 pub(crate) use committed::CommittedWriter;
 pub(crate) use default::DefaultWriter;
 pub(crate) use pending::PendingWriter;
+pub(crate) use writer::Writer;
 pub(crate) use writer_builder::WriterBuilder;

--- a/src/bigquery/src/write/proto/writer.rs
+++ b/src/bigquery/src/write/proto/writer.rs
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{BufferedWriter, CommittedWriter, PendingWriter};
+use crate::model::ProtoSchema;
+use crate::model::write_stream::Type;
+use crate::write::transport::Transport;
+use std::sync::Arc;
+
+pub(crate) mod sealed {
+    use super::*;
+
+    pub trait Writer {
+        const STREAM_TYPE: Type;
+        fn build(inner: Arc<Transport>, write_stream: String, schema: ProtoSchema) -> Self;
+    }
+
+    impl Writer for PendingWriter {
+        const STREAM_TYPE: Type = Type::Pending;
+
+        fn build(inner: Arc<Transport>, write_stream: String, schema: ProtoSchema) -> Self {
+            Self::new(inner, write_stream, schema)
+        }
+    }
+
+    impl Writer for CommittedWriter {
+        const STREAM_TYPE: Type = Type::Committed;
+
+        fn build(inner: Arc<Transport>, write_stream: String, schema: ProtoSchema) -> Self {
+            Self::new(inner, write_stream, schema)
+        }
+    }
+
+    impl Writer for BufferedWriter {
+        const STREAM_TYPE: Type = Type::Buffered;
+
+        fn build(inner: Arc<Transport>, write_stream: String, schema: ProtoSchema) -> Self {
+            Self::new(inner, write_stream, schema)
+        }
+    }
+}
+
+/// A trait for strongly-typed stream writers that can be attached to an existing stream.
+///
+/// This trait is sealed and cannot be implemented for types outside of this crate.
+pub trait Writer: sealed::Writer + Sized {}
+
+impl<T: sealed::Writer + Sized> Writer for T {}

--- a/src/bigquery/src/write/proto/writer_builder.rs
+++ b/src/bigquery/src/write/proto/writer_builder.rs
@@ -14,11 +14,12 @@
 
 use super::super::generated::gapic_storage::client::BigQueryWrite;
 use super::super::transport::Transport;
-use super::super::validate::validate_table;
-use super::{BufferedWriter, CommittedWriter, DefaultWriter, PendingWriter};
+use super::super::validate::{validate_stream, validate_table};
+use super::{BufferedWriter, CommittedWriter, DefaultWriter, PendingWriter, Writer};
 use crate::Result;
 use crate::model::write_stream::Type;
 use crate::model::{ProtoSchema, WriteStream};
+use crate::write::error::{AttachError, AttachResult};
 use std::sync::Arc;
 
 /// A builder to create a protobuf stream writer
@@ -109,6 +110,28 @@ impl WriterBuilder {
             self.schema,
         ))
     }
+
+    /// Attaches the builder to an existing stream.
+    pub async fn attach<U: Writer, S: Into<String>>(self, write_stream: S) -> AttachResult<U> {
+        let write_stream = write_stream.into();
+        validate_stream(write_stream.as_str())?;
+
+        let client = BigQueryWrite::from_stub::<Transport>(self.inner.clone());
+        let stream = client
+            .get_write_stream()
+            .set_name(&write_stream)
+            .send()
+            .await?;
+
+        let stream_type = stream.r#type.clone();
+        if stream_type != U::STREAM_TYPE {
+            return Err(AttachError::TypeMismatch {
+                expected: U::STREAM_TYPE,
+                actual: stream_type,
+            });
+        }
+        Ok(U::build(self.inner, write_stream, self.schema))
+    }
 }
 
 #[cfg(test)]
@@ -118,6 +141,7 @@ mod tests {
     use bigquery_grpc_mock::google::cloud::bigquery::storage::v1::WriteStream as MockWriteStream;
     use bigquery_grpc_mock::{MockBigQueryWrite, start};
     use test_case::test_case;
+    use tokio::task::JoinHandle;
 
     #[tokio::test]
     async fn pending_success() -> anyhow::Result<()> {
@@ -266,6 +290,96 @@ mod tests {
             .await
             .expect_err("should fail locally on bad format");
         assert!(err.is_binding(), "{err:?}");
+        Ok(())
+    }
+
+    async fn attach_mock(stream_type: Type) -> anyhow::Result<(Arc<Transport>, JoinHandle<()>)> {
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_get_write_stream().return_once(move |req| {
+            let req = req.into_inner();
+            assert_eq!(req.name, "projects/p/datasets/d/tables/t/streams/s");
+            Ok(gaxi::grpc::tonic::Response::new(MockWriteStream {
+                name: "projects/p/datasets/d/tables/t/streams/s".to_string(),
+                r#type: stream_type.value().expect("known enum value"),
+                ..Default::default()
+            }))
+        });
+        let (endpoint, server) = start("0.0.0.0:0", mock).await?;
+        let transport = Arc::new(test_transport(endpoint).await?);
+        Ok((transport, server))
+    }
+
+    #[tokio::test]
+    async fn attach_committed_success() -> anyhow::Result<()> {
+        let (transport, _server) = attach_mock(Type::Committed).await?;
+        let builder = WriterBuilder::new(transport, proto_schema());
+        let writer: CommittedWriter = builder
+            .attach("projects/p/datasets/d/tables/t/streams/s")
+            .await?;
+        assert_eq!(
+            writer.inner.write_stream,
+            "projects/p/datasets/d/tables/t/streams/s"
+        );
+        assert_eq!(writer.inner.schema, proto_schema());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn attach_pending_success() -> anyhow::Result<()> {
+        let (transport, _server) = attach_mock(Type::Pending).await?;
+        let builder = WriterBuilder::new(transport, proto_schema());
+        let writer: PendingWriter = builder
+            .attach("projects/p/datasets/d/tables/t/streams/s")
+            .await?;
+        assert_eq!(
+            writer.inner.write_stream,
+            "projects/p/datasets/d/tables/t/streams/s"
+        );
+        assert_eq!(writer.inner.schema, proto_schema());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn attach_buffered_success() -> anyhow::Result<()> {
+        let (transport, _server) = attach_mock(Type::Buffered).await?;
+        let builder = WriterBuilder::new(transport, proto_schema());
+        let writer: BufferedWriter = builder
+            .attach("projects/p/datasets/d/tables/t/streams/s")
+            .await?;
+        assert_eq!(
+            writer.inner.write_stream,
+            "projects/p/datasets/d/tables/t/streams/s"
+        );
+        assert_eq!(writer.inner.schema, proto_schema());
+        Ok(())
+    }
+
+    #[test_case("projects/p")]
+    #[test_case("projects/p/tables/t")]
+    #[test_case("projects/p/datasets/d/tables/t")]
+    #[test_case("projects/p/datasets/d/tables/t/streams/")]
+    #[tokio::test]
+    async fn attach_bad_stream_format(stream: &str) -> anyhow::Result<()> {
+        let transport = Arc::new(test_transport("http://ignored:1").await?);
+        let builder = WriterBuilder::new(transport, proto_schema());
+        let err = builder
+            .attach::<CommittedWriter, _>(stream)
+            .await
+            .expect_err("should fail locally on bad format");
+        assert!(matches!(err, AttachError::Rpc { source: e } if e.is_binding()));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn attach_stream_type_mismatch() -> anyhow::Result<()> {
+        let (transport, _server) = attach_mock(Type::Buffered).await?;
+        let builder = WriterBuilder::new(transport, proto_schema());
+        let err = builder
+            .attach::<CommittedWriter, _>("projects/p/datasets/d/tables/t/streams/s")
+            .await
+            .expect_err("should return type mismatch error");
+        assert!(matches!(err, AttachError::TypeMismatch { .. }));
+        assert!(err.to_string().contains("stream type mismatch: requested"));
         Ok(())
     }
 }


### PR DESCRIPTION
Implement the sealed `Writer` trait and `WriterBuilder::attach` to attach protobuf custom stream writers to existing BigQuery write streams.

Towards #6598