### PR TITLE
refactor(bigquery): use stream pool of size one

### DIFF
--- a/src/bigquery/src/write.rs
+++ b/src/bigquery/src/write.rs
@@ -28,10 +28,8 @@ pub(super) mod client;
 pub(super) mod client_builder;
 pub(super) mod error;
 
-#[cfg_attr(not(test), expect(dead_code))]
 mod dispatcher;
 mod entry;
-#[cfg_attr(not(test), expect(dead_code))]
 mod pool;
 mod proto_schema;
 mod runner;

--- a/src/bigquery/src/write/arrow/default.rs
+++ b/src/bigquery/src/write/arrow/default.rs
@@ -13,35 +13,27 @@
 // limitations under the License.
 
 use super::super::builder::Append;
-use super::super::entry::StreamEntry;
-use super::super::runner::Runner;
-use super::super::transport::Transport;
+use super::super::dispatcher::Dispatcher;
+use super::super::pool::StreamPool;
 use crate::model::append_rows_request::ArrowData;
 use crate::model::{AppendRowsRequest, ArrowRecordBatch, ArrowSchema};
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
 
 /// A writer for the [default stream]
 ///
 /// [default stream]: https://docs.cloud.google.com/bigquery/docs/write-api#default_stream
 #[derive(Debug)]
 pub struct DefaultWriter {
-    entry: Arc<StreamEntry>,
+    inner: Arc<Dispatcher>,
     pub(crate) write_stream: String,
     pub(crate) schema: ArrowSchema,
 }
 
 impl DefaultWriter {
-    pub(crate) fn new(inner: Arc<Transport>, write_stream: String, schema: ArrowSchema) -> Self {
-        let runner = Runner::new(inner);
-        let entry = Arc::new(StreamEntry {
-            id: 0,
-            req_tx: runner.req_tx,
-            outstanding_requests: Arc::new(AtomicU64::new(0)),
-            outstanding_bytes: Arc::new(AtomicU64::new(0)),
-        });
+    pub(crate) fn new(pool: Arc<StreamPool>, write_stream: String, schema: ArrowSchema) -> Self {
+        let inner = Arc::new(Dispatcher::new(pool));
         Self {
-            entry,
+            inner,
             write_stream,
             schema,
         }
@@ -57,7 +49,7 @@ impl DefaultWriter {
                     .set_writer_schema(self.schema.clone())
                     .set_rows(rows),
             );
-        Append::new(self.entry.clone(), req)
+        Append::new(self.inner.clone(), req)
     }
 }
 
@@ -73,7 +65,8 @@ mod tests {
     #[tokio::test]
     async fn request_fields() -> anyhow::Result<()> {
         let transport = Arc::new(test_transport("http://ignored:1").await?);
-        let writer = DefaultWriter::new(transport, write_stream(), schema());
+        let pool = Arc::new(StreamPool::new(transport, 1));
+        let writer = DefaultWriter::new(pool, write_stream(), schema());
 
         let b = writer.append(rows(1));
         assert_eq!(b.req.write_stream, write_stream());
@@ -103,8 +96,9 @@ mod tests {
             .return_once(|_| Ok(TonicResponse::from(response_rx)));
         let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
         let transport = Arc::new(test_transport(endpoint).await?);
+        let pool = Arc::new(StreamPool::new(transport, 1));
 
-        let writer = DefaultWriter::new(transport, write_stream(), schema());
+        let writer = DefaultWriter::new(pool, write_stream(), schema());
 
         response_tx.send(Ok(convert(&test_response(1)))).await?;
         let resp = writer.append(rows(1)).send().await?;

--- a/src/bigquery/src/write/arrow/writer_builder.rs
+++ b/src/bigquery/src/write/arrow/writer_builder.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::super::generated::gapic_storage::client::BigQueryWrite;
+use super::super::pool::StreamPool;
 use super::super::transport::Transport;
 use super::super::validate::{validate_stream, validate_table};
 use super::{BufferedWriter, CommittedWriter, DefaultWriter, PendingWriter, Writer};
@@ -58,7 +59,9 @@ impl WriterBuilder {
         validate_table(table.as_str())?;
         let mut write_stream = table;
         write_stream.push_str("/streams/_default");
-        Ok(DefaultWriter::new(self.inner, write_stream, self.schema))
+        // TODO(#6765) - use client's pool if multiplexing is enabled
+        let pool = Arc::new(StreamPool::new(self.inner, 1));
+        Ok(DefaultWriter::new(pool, write_stream, self.schema))
     }
 
     /// Creates a pending writer for the given table.

--- a/src/bigquery/src/write/builder/append.rs
+++ b/src/bigquery/src/write/builder/append.rs
@@ -13,24 +13,21 @@
 // limitations under the License.
 
 use super::super::append_future::AppendFuture;
-use super::super::append_response::to_result;
-use super::super::entry::StreamEntry;
-use crate::Error;
+use super::super::dispatcher::Dispatcher;
 use crate::model::AppendRowsRequest;
-use gaxi::prost::{FromProto, ToProto};
 use std::sync::Arc;
 use tokio::sync::oneshot;
 
 /// A request builder for appending rows on the default stream.
 #[derive(Clone, Debug)]
 pub struct Append {
-    entry: Arc<StreamEntry>,
+    inner: Arc<Dispatcher>,
     pub(crate) req: AppendRowsRequest,
 }
 
 impl Append {
-    pub(crate) fn new(entry: Arc<StreamEntry>, req: AppendRowsRequest) -> Self {
-        Self { entry, req }
+    pub(crate) fn new(inner: Arc<Dispatcher>, req: AppendRowsRequest) -> Self {
+        Self { inner, req }
     }
 
     /// Append rows to the stream.
@@ -58,13 +55,7 @@ impl Append {
     pub fn send(self) -> AppendFuture {
         let (tx, rx) = oneshot::channel();
         tokio::spawn(async move {
-            let res = async move {
-                let req = self.req.to_proto().map_err(Error::deser)?;
-                let resp = self.entry.send(req).await?;
-                let resp = resp.cnv().map_err(Error::ser)?;
-                to_result(resp)
-            }
-            .await;
+            let res = self.inner.send(self.req).await;
             let _ = tx.send(res);
         });
         AppendFuture::new(rx)
@@ -74,6 +65,7 @@ impl Append {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Error;
     use crate::error::AppendError;
     use crate::google::cloud::bigquery::storage::v1;
     use crate::google::cloud::bigquery::storage::v1::append_rows_response::{
@@ -86,10 +78,10 @@ mod tests {
     #[tokio::test]
     async fn success() -> anyhow::Result<()> {
         let (req_tx, mut req_rx) = mpsc::unbounded_channel();
-        let entry = test_entry(req_tx);
+        let dispatcher = test_dispatcher(req_tx).await?;
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
-        let builder = Append::new(entry, req);
+        let builder = Append::new(dispatcher, req);
         let handle = tokio::spawn(async move { builder.send().await });
 
         // Receive and verify the request
@@ -117,10 +109,10 @@ mod tests {
     #[tokio::test]
     async fn stream_closed() -> anyhow::Result<()> {
         let (req_tx, req_rx) = mpsc::unbounded_channel();
-        let entry = test_entry(req_tx);
+        let dispatcher = test_dispatcher(req_tx).await?;
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
-        let builder = Append::new(entry, req);
+        let builder = Append::new(dispatcher, req);
         let handle = tokio::spawn(async move { builder.send().await });
 
         // Simulate a stream closure
@@ -134,10 +126,10 @@ mod tests {
     #[tokio::test]
     async fn rpc_error() -> anyhow::Result<()> {
         let (req_tx, mut req_rx) = mpsc::unbounded_channel();
-        let entry = test_entry(req_tx);
+        let dispatcher = test_dispatcher(req_tx).await?;
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
-        let builder = Append::new(entry, req);
+        let builder = Append::new(dispatcher, req);
         let handle = tokio::spawn(async move { builder.send().await });
 
         // Simulate a stream ending in a known error
@@ -156,10 +148,10 @@ mod tests {
     #[tokio::test]
     async fn row_errors() -> anyhow::Result<()> {
         let (req_tx, mut req_rx) = mpsc::unbounded_channel();
-        let entry = test_entry(req_tx);
+        let dispatcher = test_dispatcher(req_tx).await?;
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
-        let builder = Append::new(entry, req);
+        let builder = Append::new(dispatcher, req);
         let handle = tokio::spawn(async move { builder.send().await });
 
         let write = req_rx.recv().await.expect("should receive request");

--- a/src/bigquery/src/write/pool.rs
+++ b/src/bigquery/src/write/pool.rs
@@ -392,7 +392,7 @@ mod tests {
 
     impl StreamPool {
         // Seed the pool with loaded streams to simplify testing.
-        fn seed(&self, loads: impl IntoIterator<Item = u64>) {
+        pub(crate) fn seed(&self, loads: impl IntoIterator<Item = u64>) {
             for load in loads.into_iter() {
                 let s = self.new_stream_entry();
                 s.outstanding_requests.store(load, Ordering::Relaxed);

--- a/src/bigquery/src/write/proto/default.rs
+++ b/src/bigquery/src/write/proto/default.rs
@@ -13,35 +13,27 @@
 // limitations under the License.
 
 use super::super::builder::Append;
-use super::super::entry::StreamEntry;
-use super::super::runner::Runner;
-use super::super::transport::Transport;
+use super::super::dispatcher::Dispatcher;
+use super::super::pool::StreamPool;
 use crate::model::append_rows_request::ProtoData;
 use crate::model::{AppendRowsRequest, ProtoRows, ProtoSchema};
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
 
 /// A writer for the [default stream] using Protobuf as the data format.
 ///
 /// [default stream]: https://docs.cloud.google.com/bigquery/docs/write-api#default_stream
 #[derive(Debug)]
 pub struct DefaultWriter {
-    entry: Arc<StreamEntry>,
+    inner: Arc<Dispatcher>,
     pub(crate) write_stream: String,
     pub(crate) schema: ProtoSchema,
 }
 
 impl DefaultWriter {
-    pub(crate) fn new(inner: Arc<Transport>, write_stream: String, schema: ProtoSchema) -> Self {
-        let runner = Runner::new(inner);
-        let entry = Arc::new(StreamEntry {
-            id: 0,
-            req_tx: runner.req_tx,
-            outstanding_requests: Arc::new(AtomicU64::new(0)),
-            outstanding_bytes: Arc::new(AtomicU64::new(0)),
-        });
+    pub(crate) fn new(pool: Arc<StreamPool>, write_stream: String, schema: ProtoSchema) -> Self {
+        let inner = Arc::new(Dispatcher::new(pool));
         Self {
-            entry,
+            inner,
             write_stream,
             schema,
         }
@@ -57,7 +49,7 @@ impl DefaultWriter {
                     .set_writer_schema(self.schema.clone())
                     .set_rows(rows),
             );
-        Append::new(self.entry.clone(), req)
+        Append::new(self.inner.clone(), req)
     }
 }
 
@@ -73,7 +65,8 @@ mod tests {
     #[tokio::test]
     async fn request_fields() -> anyhow::Result<()> {
         let transport = Arc::new(test_transport("http://ignored:1").await?);
-        let writer = DefaultWriter::new(transport, write_stream(), proto_schema());
+        let pool = Arc::new(StreamPool::new(transport, 1));
+        let writer = DefaultWriter::new(pool, write_stream(), proto_schema());
 
         let b = writer.append(rows(1));
         assert_eq!(b.req.write_stream, write_stream());
@@ -103,8 +96,9 @@ mod tests {
             .return_once(|_| Ok(TonicResponse::from(response_rx)));
         let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
         let transport = Arc::new(test_transport(endpoint).await?);
+        let pool = Arc::new(StreamPool::new(transport, 1));
 
-        let writer = DefaultWriter::new(transport, write_stream(), proto_schema());
+        let writer = DefaultWriter::new(pool, write_stream(), proto_schema());
 
         response_tx.send(Ok(convert(&test_response(1)))).await?;
         let resp = writer.append(rows(1)).send().await?;

--- a/src/bigquery/src/write/proto/writer_builder.rs
+++ b/src/bigquery/src/write/proto/writer_builder.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::super::generated::gapic_storage::client::BigQueryWrite;
+use super::super::pool::StreamPool;
 use super::super::transport::Transport;
 use super::super::validate::{validate_stream, validate_table};
 use super::{BufferedWriter, CommittedWriter, DefaultWriter, PendingWriter, Writer};
@@ -42,7 +43,9 @@ impl WriterBuilder {
         validate_table(table.as_str())?;
         let mut write_stream = table;
         write_stream.push_str("/streams/_default");
-        Ok(DefaultWriter::new(self.inner, write_stream, self.schema))
+        // TODO(#6765) - use client's pool if multiplexing is enabled
+        let pool = Arc::new(StreamPool::new(self.inner, 1));
+        Ok(DefaultWriter::new(pool, write_stream, self.schema))
     }
 
     /// Creates a writer for a [pending stream] for the given table.

--- a/src/bigquery/src/write/test.rs
+++ b/src/bigquery/src/write/test.rs
@@ -15,7 +15,6 @@
 //! Test helpers for the `Write` client internals
 
 use super::dispatcher::Dispatcher;
-use super::entry::StreamEntry;
 use super::pool::StreamPool;
 use super::runner::WriteRequest;
 use super::transport::Transport;
@@ -80,14 +79,13 @@ pub(super) async fn test_dispatcher(
 ) -> anyhow::Result<Arc<Dispatcher>> {
     let transport = Arc::new(test_transport("http://ignored:1").await?);
     let pool = Arc::new(StreamPool::new(transport, 1));
+    // Seed the pool with a stream.
+    pool.seed([0]);
+    // Override its channel with the provided channel.
+    pool.lock()
+        .first_mut()
+        .expect("there is one entry in the pool")
+        .req_tx = req_tx;
     let dispatcher = Arc::new(Dispatcher::new(pool));
-
-    // Override the stream entry's channel with the provided channel.
-    let current = dispatcher.entry.load();
-    let updated = StreamEntry {
-        req_tx,
-        ..(**current).clone()
-    };
-    dispatcher.entry.store(Arc::new(updated));
     Ok(dispatcher)
 }

--- a/src/bigquery/src/write/test.rs
+++ b/src/bigquery/src/write/test.rs
@@ -14,7 +14,9 @@
 
 //! Test helpers for the `Write` client internals
 
+use super::dispatcher::Dispatcher;
 use super::entry::StreamEntry;
+use super::pool::StreamPool;
 use super::runner::WriteRequest;
 use super::transport::Transport;
 use crate::google::cloud::bigquery::storage::v1::append_rows_response::{AppendResult, Response};
@@ -23,7 +25,6 @@ use crate::model::{ArrowSchema, ProtoSchema};
 use bigquery_grpc_mock::google::cloud::bigquery::storage::v1;
 use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
 use tokio::sync::mpsc;
 
 pub(super) fn write_stream() -> String {
@@ -73,12 +74,20 @@ pub(super) fn test_response(index: i64) -> AppendRowsResponse {
     }
 }
 
-// Return a stream entry that sends requests on the provided channel.
-pub(super) fn test_entry(req_tx: mpsc::UnboundedSender<WriteRequest>) -> Arc<StreamEntry> {
-    Arc::new(StreamEntry {
-        id: 0,
+// Return a dispatcher that sends requests on the provided channel.
+pub(super) async fn test_dispatcher(
+    req_tx: mpsc::UnboundedSender<WriteRequest>,
+) -> anyhow::Result<Arc<Dispatcher>> {
+    let transport = Arc::new(test_transport("http://ignored:1").await?);
+    let pool = Arc::new(StreamPool::new(transport, 1));
+    let dispatcher = Arc::new(Dispatcher::new(pool));
+
+    // Override the stream entry's channel with the provided channel.
+    let current = dispatcher.entry.load();
+    let updated = StreamEntry {
         req_tx,
-        outstanding_requests: Arc::new(AtomicU64::new(0)),
-        outstanding_bytes: Arc::new(AtomicU64::new(0)),
-    })
+        ..(**current).clone()
+    };
+    dispatcher.entry.store(Arc::new(updated));
+    Ok(dispatcher)
 }


### PR DESCRIPTION
Hook up the writers to the stream pool with a max size of 1 stream. (This is equivalent to disabling multiplexing, which is the current state of the client).

Refactoring to use the stream pool lets us write the retry logic in one place (the `Dispatcher`) and have it work for both simplex and multiplex stream pools.

Fixes #5831 