### PR TITLE
cleanup(bigquery)!: mark `JobPollerError` as non-exhaustive

### DIFF
--- a/src/generated/cloud/bigquery/v2/src/operation.rs
+++ b/src/generated/cloud/bigquery/v2/src/operation.rs
@@ -91,6 +91,7 @@ impl Default for JobRetryPolicy {
 
 /// Errors returned by the JobPoller.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum JobPollerError {
     /// An error occurred during the RPC or LRO polling.
     #[error(transparent)]

--- a/tests/bigquery/src/job.rs
+++ b/tests/bigquery/src/job.rs
@@ -186,10 +186,8 @@ pub async fn job_service_poller_error() -> Result<()> {
                 "expected non-empty error reason in ErrorProto"
             );
         }
-        google_cloud_bigquery_v2::operation::JobPollerError::Rpc(rpc_err) => {
-            panic!(
-                "expected JobPollerError::ErrorProto from BigQuery job, got RPC error: {rpc_err:?}"
-            );
+        _ => {
+            panic!("expected JobPollerError::ErrorProto, got {err:?}");
         }
     }
 


### PR DESCRIPTION
It is safest to mark error enums as non-exhaustive. The ergonomics do not suffer too much.