### PR TITLE
cleanup(bigquery)!: rename custom mod to `job_poller`

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -611,7 +611,7 @@ libraries:
     version: 0.1.1
     copyright_year: "2025"
     keep:
-      - src/operation.rs
+      - src/job_poller.rs
     rust:
       package_dependencies:
         - name: thiserror

--- a/src/bigquery/tests/job_poller_tests.rs
+++ b/src/bigquery/tests/job_poller_tests.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use google_cloud_bigquery_v2::client::JobService;
+use google_cloud_bigquery_v2::job_poller::JobPollerError;
 use google_cloud_bigquery_v2::model::{ErrorProto, InsertJobRequest, Job, JobReference, JobStatus};
-use google_cloud_bigquery_v2::operation::JobPollerError;
 use google_cloud_bigquery_v2::stub::JobService as JobServiceStub;
 use google_cloud_gax::Result as GaxResult;
 use google_cloud_gax::options::RequestOptions;

--- a/src/generated/cloud/bigquery/v2/src/job_poller.rs
+++ b/src/generated/cloud/bigquery/v2/src/job_poller.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Helpers to await the completion of an [InsertJob] request
+
 use crate::builder::job_service::InsertJob;
 use crate::model::Job;
 use google_cloud_gax::backoff_policy::BackoffPolicy;

--- a/src/generated/cloud/bigquery/v2/src/lib.rs
+++ b/src/generated/cloud/bigquery/v2/src/lib.rs
@@ -114,4 +114,4 @@ pub(crate) use google_cloud_gax::options::internal::RequestBuilder;
 pub(crate) use google_cloud_gax::response::Response;
 
 #[allow(missing_docs)]
-pub mod operation;
+pub mod job_poller;

--- a/tests/bigquery/src/job.rs
+++ b/tests/bigquery/src/job.rs
@@ -16,6 +16,7 @@ use super::{INSTANCE_LABEL, random_id_suffix};
 use anyhow::Result;
 use futures::stream::{StreamExt, TryStreamExt};
 use google_cloud_bigquery_v2::client::JobService;
+use google_cloud_bigquery_v2::job_poller::JobPollerError;
 use google_cloud_bigquery_v2::model::list_jobs_request::Projection;
 use google_cloud_bigquery_v2::model::{Job, JobConfiguration, JobConfigurationQuery, JobReference};
 use google_cloud_gax::paginator::ItemPaginator;
@@ -180,7 +181,7 @@ pub async fn job_service_poller_error() -> Result<()> {
 
     let err = result.expect_err("expected job polling to return error");
     match err {
-        google_cloud_bigquery_v2::operation::JobPollerError::ErrorProto(proto) => {
+        JobPollerError::ErrorProto(proto) => {
             assert!(
                 !proto.reason.is_empty(),
                 "expected non-empty error reason in ErrorProto"


### PR DESCRIPTION
https://docs.rs/google-cloud-bigquery-v2/latest/google_cloud_bigquery_v2/operation/index.html

`mod operation` doesn't make a lot of sense for BigQuery. Update it to reflect the types that are inside. Also give it documentation.