### PR TITLE
fix(storage): replace stray println! with tracing::debug! in bidi worker

### DIFF
--- a/src/storage/src/storage/bidi/worker.rs
+++ b/src/storage/src/storage/bidi/worker.rs
@@ -101,7 +101,7 @@ where
         };
         // Return errors for any future readers.
         while let Some(mut r) = requests.recv().await {
-            println!("sending error after closed stream: {e:?}");
+            tracing::debug!("sending error after closed stream: {e:?}");
             r.interrupted(e.clone()).await;
         }
         Err(e)


### PR DESCRIPTION
The println! was writing directly to the host application's stdout every time a queued reader was notified of a closed-stream error. This bypassed the tracing framework the rest of the file is using.

debug! is better than error! because the error is already propagated to the caller via `r.interrupted(e.clone()).await`, and this log line is for diagnostic purpose. Using error! would also be noisy because it is fired in a loop.

Fixes #6692.