### PR TITLE
refactor(bigquery)!: making default writer is async

### DIFF
--- a/src/bigquery/examples/src/write/arrow_default.rs
+++ b/src/bigquery/examples/src/write/arrow_default.rs
@@ -40,7 +40,8 @@ pub async fn sample(project_id: &str, dataset_id: &str, table_id: &str) -> anyho
     // Create a writer for the default stream
     let writer = client
         .arrow(ArrowSchema::new().set_serialized_schema(schema_buf))
-        .default(table)?;
+        .default(table)
+        .await?;
 
     let mut writes = JoinSet::new();
     for i in 0..100 {

--- a/src/bigquery/examples/src/write/json_default.rs
+++ b/src/bigquery/examples/src/write/json_default.rs
@@ -44,7 +44,8 @@ pub async fn sample(project_id: &str, dataset_id: &str, table_id: &str) -> anyho
     // Create a writer for the default stream
     let writer = client
         .arrow(ArrowSchema::new().set_serialized_schema(schema_buf))
-        .default(table)?;
+        .default(table)
+        .await?;
 
     // Create a decoder to convert JSON to Arrow
     let mut decoder = ReaderBuilder::new(schema).build_decoder()?;

--- a/src/bigquery/src/lib.rs
+++ b/src/bigquery/src/lib.rs
@@ -96,7 +96,8 @@
 //! let client = Write::builder().build().await?;
 //! let writer = client
 //!     .arrow(schema())
-//!     .default("projects/my-project/datasets/my-dataset/tables/my-table")?;
+//!     .default("projects/my-project/datasets/my-dataset/tables/my-table")
+//!     .await?;
 //!
 //! let f1 = writer.append(rows()).send();
 //! let f2 = writer.append(rows()).send();

--- a/src/bigquery/src/write/arrow/writer_builder.rs
+++ b/src/bigquery/src/write/arrow/writer_builder.rs
@@ -43,7 +43,8 @@ impl WriterBuilder {
     /// # async fn sample(client: Write) -> anyhow::Result<()> {
     /// let writer = client
     ///     .arrow(schema())
-    ///     .default("projects/my-project/datasets/my-dataset/tables/my-table")?;
+    ///     .default("projects/my-project/datasets/my-dataset/tables/my-table")
+    ///     .await?;
     /// # Ok(()) }
     ///
     /// use google_cloud_bigquery::model::ArrowSchema;
@@ -53,7 +54,7 @@ impl WriterBuilder {
     /// ```
     ///
     /// [default stream]: https://docs.cloud.google.com/bigquery/docs/write-api#default_stream
-    pub fn default<T: Into<String>>(self, table: T) -> Result<DefaultWriter> {
+    pub async fn default<T: Into<String>>(self, table: T) -> Result<DefaultWriter> {
         let table = table.into();
         validate_table(table.as_str())?;
         let mut write_stream = table;
@@ -306,7 +307,7 @@ mod tests {
     async fn default() -> anyhow::Result<()> {
         let transport = Arc::new(test_transport("http://ignored:1").await?);
         let builder = WriterBuilder::new(transport, schema());
-        let writer = builder.default("projects/p/datasets/d/tables/t")?;
+        let writer = builder.default("projects/p/datasets/d/tables/t").await?;
         assert_eq!(
             writer.write_stream,
             "projects/p/datasets/d/tables/t/streams/_default"
@@ -327,6 +328,7 @@ mod tests {
         let builder = WriterBuilder::new(transport, schema());
         let err = builder
             .default(table)
+            .await
             .expect_err("should fail locally on bad format");
         assert!(err.is_binding(), "{err:?}");
         Ok(())

--- a/src/bigquery/src/write/client.rs
+++ b/src/bigquery/src/write/client.rs
@@ -48,7 +48,8 @@ impl Write {
     /// # async fn sample(client: Write) -> anyhow::Result<()> {
     /// let writer = client
     ///   .arrow(schema())
-    ///   .default("projects/my-project/datasets/my-dataset/tables/my-table")?;
+    ///   .default("projects/my-project/datasets/my-dataset/tables/my-table")
+    ///   .await?;
     /// # Ok(()) }
     ///
     /// use google_cloud_bigquery::model::ArrowSchema;
@@ -90,7 +91,8 @@ mod tests {
             .await?;
         let writer = client
             .arrow(ArrowSchema::new())
-            .default("projects/p/datasets/d/tables/t")?;
+            .default("projects/p/datasets/d/tables/t")
+            .await?;
         let err = writer
             .append(ArrowRecordBatch::new())
             .send()
@@ -114,7 +116,8 @@ mod tests {
             .await?;
         let writer = client
             .proto(ProtoSchema::new())
-            .default("projects/p/datasets/d/tables/t")?;
+            .default("projects/p/datasets/d/tables/t")
+            .await?;
         let err = writer
             .append(ProtoRows::new())
             .send()

--- a/src/bigquery/src/write/proto/writer_builder.rs
+++ b/src/bigquery/src/write/proto/writer_builder.rs
@@ -37,7 +37,7 @@ impl WriterBuilder {
     /// Create a writer for the [default stream] for the given table.
     ///
     /// [default stream]: https://docs.cloud.google.com/bigquery/docs/write-api#default_stream
-    pub fn default<T: Into<String>>(self, table: T) -> Result<DefaultWriter> {
+    pub async fn default<T: Into<String>>(self, table: T) -> Result<DefaultWriter> {
         let table = table.into();
         validate_table(table.as_str())?;
         let mut write_stream = table;
@@ -227,7 +227,7 @@ mod tests {
     async fn default() -> anyhow::Result<()> {
         let transport = Arc::new(test_transport("http://ignored:1").await?);
         let builder = WriterBuilder::new(transport, proto_schema());
-        let writer = builder.default("projects/p/datasets/d/tables/t")?;
+        let writer = builder.default("projects/p/datasets/d/tables/t").await?;
         assert_eq!(
             writer.write_stream,
             "projects/p/datasets/d/tables/t/streams/_default"
@@ -248,6 +248,7 @@ mod tests {
         let builder = WriterBuilder::new(transport, proto_schema());
         let err = builder
             .default(table)
+            .await
             .expect_err("should fail locally on bad format");
         assert!(err.is_binding(), "{err:?}");
         Ok(())

--- a/tests/bigquery/src/writes/arrow.rs
+++ b/tests/bigquery/src/writes/arrow.rs
@@ -33,7 +33,7 @@ pub async fn basic(
     let mut serializer = ArrowSerializer::new("basic")?;
 
     // Create a writer for the default stream
-    let writer = client.arrow(serializer.schema()).default(table)?;
+    let writer = client.arrow(serializer.schema()).default(table).await?;
 
     // Write the batches
     let batch1 = serializer.batch(vec!["Alice", "Bob"], vec![25, 28])?;


### PR DESCRIPTION
The stream pool used by a default writer should be scoped to a region. To find out which region a table lives in, we need to send a `GetWriteStream` RPC. This means the builder function should be async.

Motivation: API stabilization in anticipation of #6765