### PR TITLE
fix(bigquery): handle 409 errors and attach to existing job

### DIFF
--- a/src/bigquery/src/query/execution.rs
+++ b/src/bigquery/src/query/execution.rs
@@ -16,11 +16,13 @@ use crate::error::QueryError;
 use crate::query::builder::{
     QUERY_REQUEST_ID_PREFIX, Query, generate_job_reference, generate_prefixed_id,
 };
-use crate::query::retry_policy::JobRetryResult;
+use crate::query::query_handle::build_get_job;
+use crate::query::retry_policy::{JobRetryResult, is_duplicate_job_error};
 use crate::query::{Query as QueryHandle, Result};
 use google_cloud_bigquery_v2::client::JobService;
 use google_cloud_bigquery_v2::model::{
-    InsertJobRequest, Job, JobConfiguration, PostQueryRequest, QueryRequest, QueryResponse,
+    InsertJobRequest, Job, JobConfiguration, JobReference, PostQueryRequest, QueryRequest,
+    QueryResponse,
 };
 use google_cloud_gax::options::RequestOptionsBuilder as _;
 use google_cloud_gax::retry_state::RetryState;
@@ -41,13 +43,14 @@ impl PostQueryExecutor {
     }
 
     pub(crate) async fn execute(self) -> Result<QueryResponse> {
+        // Safe to resend: `request_id` merges a duplicate that is still in
+        // flight, and a duplicate that arrives after the original completed
+        // returns 409, which the caller recovers by adopting the named job.
         let res = self
             .job_service
             .query()
-            // requests to jobs.query are idempotent because every request
-            // carries a generated request_id.
-            .with_idempotency(true)
             .with_request(self.request)
+            .with_idempotency(true)
             .send()
             .await?;
 
@@ -94,15 +97,7 @@ impl InsertJobExecutor {
             .send()
             .await?;
 
-        let job_status = res.status.as_ref();
-        if let Some(status) = job_status
-            && status.error_result.is_some()
-        {
-            let errors = status.errors.clone();
-            return Err(QueryError::JobFailed { errors });
-        }
-
-        Ok(res)
+        check_job_status(res)
     }
 }
 
@@ -176,13 +171,32 @@ impl RetryContext {
         let job_ref = generate_job_reference(project_id, &self.template.request.location);
         let job = Job::new()
             .set_configuration(job_config)
-            .set_job_reference(job_ref);
+            .set_job_reference(job_ref.clone());
         let req = InsertJobRequest::new()
             .set_job(job)
             .set_project_id(project_id);
 
         // Box heavy RPC call future to avoid large stack frames.
-        let job = Box::pin(InsertJobExecutor::new(job_service.clone(), req).execute()).await?;
+        let job = match Box::pin(InsertJobExecutor::new(job_service.clone(), req).execute()).await {
+            Ok(job) => job,
+            Err(err) if is_duplicate_job_error(&err) => {
+                // A fresh job ID is generated per attempt, so a duplicate means
+                // an earlier attempt of this request reached the service. Adopt
+                // the job it created rather than fail a running, billing query.
+                let existing_job = match build_get_job(&job_service, &job_ref) {
+                    Some(get) => Box::pin(get.send()).await.ok(),
+                    None => None,
+                };
+                let Some(existing_job) = existing_job else {
+                    // The original error names the running job, and unlike a
+                    // `jobs.get` failure it never makes the job retry loop
+                    // reissue the query.
+                    return Err(err);
+                };
+                check_job_status(existing_job)?
+            }
+            Err(err) => return Err(err),
+        };
 
         Ok(QueryHandle::from_job(
             job_service,
@@ -210,7 +224,33 @@ impl RetryContext {
             .set_query_request(query_request);
 
         // Box heavy RPC call future to avoid large stack frames.
-        let res = Box::pin(PostQueryExecutor::new(job_service.clone(), req).execute()).await?;
+        let res = match Box::pin(PostQueryExecutor::new(job_service.clone(), req).execute()).await {
+            Ok(res) => res,
+            Err(err) if is_duplicate_job_error(&err) => {
+                // A resent request collided with the job its earlier attempt
+                // created. That job ran and was billed, so adopt it instead of
+                // reporting a failure for a query that already succeeded.
+                let get = parse_duplicate_job_reference(&err)
+                    .and_then(|job_ref| build_get_job(&job_service, &job_ref));
+                let existing_job = match get {
+                    Some(get) => Box::pin(get.send()).await.ok(),
+                    None => None,
+                };
+                let Some(existing_job) = existing_job else {
+                    // The original error names the job, and unlike a `jobs.get`
+                    // failure it never makes the job retry loop reissue the
+                    // query.
+                    return Err(err);
+                };
+                return Ok(QueryHandle::from_job(
+                    job_service,
+                    check_job_status(existing_job)?,
+                    Some(self.clone()),
+                    max_results,
+                ));
+            }
+            Err(err) => return Err(err),
+        };
 
         Ok(QueryHandle::from_query_response(
             job_service,
@@ -219,6 +259,49 @@ impl RetryContext {
             max_results,
         ))
     }
+}
+
+/// Returns [`QueryError::JobFailed`] if the service reports the job as failed.
+fn check_job_status(job: Job) -> Result<Job> {
+    if let Some(status) = job.status.as_ref()
+        && status.error_result.is_some()
+    {
+        let errors = status.errors.clone();
+        return Err(QueryError::JobFailed { errors });
+    }
+
+    Ok(job)
+}
+
+/// Extracts the job named by an `Already Exists: Job my-project:US.job_123`
+/// error message.
+///
+/// `jobs.query` does not let the caller name the job it creates, and the 409
+/// carries no structured reference, so the message is the only handle on the
+/// duplicated job. Best effort by design: when the message does not parse the
+/// caller reports the original error, which is what it would have reported
+/// anyway.
+fn parse_duplicate_job_reference(error: &QueryError) -> Option<JobReference> {
+    const PREFIX: &str = "Already Exists: Job ";
+
+    let QueryError::Rpc { source } = error else {
+        return None;
+    };
+    let name = source.status()?.message.strip_prefix(PREFIX)?;
+    // Split from the right: domain scoped project IDs contain both separators,
+    // as in `example.com:my-project:US.job_123`.
+    let (project_and_location, job_id) = name.rsplit_once('.')?;
+    let (project_id, location) = project_and_location.rsplit_once(':')?;
+    if project_id.is_empty() || location.is_empty() || job_id.is_empty() {
+        return None;
+    }
+
+    Some(
+        JobReference::new()
+            .set_project_id(project_id)
+            .set_location(location)
+            .set_job_id(job_id),
+    )
 }
 
 #[cfg(test)]
@@ -230,12 +313,30 @@ mod tests {
         QueryResponse,
     };
     use google_cloud_gax::error::Error as GaxError;
-    use google_cloud_gax::error::rpc::{Code, Status};
+    use google_cloud_gax::error::rpc::{Code, Status, StatusDetails};
     use google_cloud_gax::response::Response;
+    use google_cloud_rpc::model::ErrorInfo;
     use serde_json::{Map, json};
+    use std::sync::Mutex;
     use test_case::test_case;
 
     type TestResult = anyhow::Result<()>;
+
+    // The error BigQuery returns when a request tries to create a job that a
+    // previous, apparently failed, attempt of the same request already created.
+    fn duplicate_job_error(job_id: &str) -> GaxError {
+        let message = format!("Already Exists: Job my-project:US.{job_id}");
+        let status = Status::default()
+            .set_code(Code::AlreadyExists)
+            .set_message(message.clone())
+            .set_details(vec![StatusDetails::ErrorInfo(
+                ErrorInfo::new()
+                    .set_reason("duplicate")
+                    .set_domain("global")
+                    .set_metadata([("message".to_string(), message)]),
+            )]);
+        GaxError::service(status)
+    }
 
     #[tokio::test]
     async fn test_jobs_query_execute_success() -> TestResult {
@@ -465,6 +566,227 @@ mod tests {
 
         let handle = retry_ctx.execute_once("my-project").await?;
         assert_eq!(handle.metadata.job_reference.unwrap().job_id, "query-job");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_jobs_insert_duplicate_adopts_existing_job() -> TestResult {
+        let inserted = Arc::new(Mutex::new(None));
+
+        let mut mock = MockJobService::new();
+        let captured = inserted.clone();
+        mock.expect_insert_job().return_once(move |req, _| {
+            let job_ref = req.job.unwrap().job_reference.unwrap();
+            let err = duplicate_job_error(&job_ref.job_id);
+            *captured.lock().unwrap() = Some(job_ref);
+            Err(err)
+        });
+        mock.expect_get_job().return_once(move |req, _| {
+            let job_ref = JobReference::new()
+                .set_project_id(req.project_id)
+                .set_job_id(req.job_id)
+                .set_location(req.location);
+            let job = Job::new()
+                .set_configuration(JobConfiguration::new().set_query(JobConfigurationQuery::new()))
+                .set_job_reference(job_ref)
+                .set_status(JobStatus::new().set_state("RUNNING"));
+            Ok(Response::from(job))
+        });
+
+        let job_service = create_job_service(mock);
+        let query = Query::new(job_service, "SELECT 1".to_string())
+            .with_project_id("my-project")
+            .set_location("us-central1")
+            .set_priority("BATCH");
+
+        let retry_ctx = RetryContext::new(query);
+        assert!(retry_ctx.force_job_path(), "priority should force job path");
+
+        let handle = retry_ctx.execute_once("my-project").await?;
+
+        // The recovered job must be the one the earlier attempt created, and it
+        // must be fetched from the location of the query.
+        let inserted = inserted.lock().unwrap().clone().expect("job inserted");
+        let job_ref = handle.metadata.job_reference.expect("job reference");
+        assert_eq!(job_ref, inserted, "{job_ref:?}");
+        assert_eq!(job_ref.location.as_deref(), Some("us-central1"));
+        assert!(!handle.completed, "the recovered job is still running");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_jobs_insert_duplicate_reports_original_error() -> TestResult {
+        let mut mock = MockJobService::new();
+        mock.expect_insert_job()
+            .return_once(move |_, _| Err(duplicate_job_error("job_123")));
+        // The job cannot be fetched, for example because the caller lacks
+        // permissions to read it.
+        mock.expect_get_job().return_once(move |_, _| {
+            let status = Status::default()
+                .set_code(Code::PermissionDenied)
+                .set_message("simulated permission denied");
+            Err(GaxError::service(status))
+        });
+
+        let job_service = create_job_service(mock);
+        let query = Query::new(job_service, "SELECT 1".to_string())
+            .with_project_id("my-project")
+            .set_priority("BATCH");
+
+        let err = RetryContext::new(query)
+            .execute_once("my-project")
+            .await
+            .unwrap_err();
+
+        // The duplicate error names the running job, so it is more useful than
+        // the error from `jobs.get`.
+        let QueryError::Rpc { source } = &err else {
+            panic!("expected QueryError::Rpc, got {err:?}");
+        };
+        let status = source.status().expect("status");
+        assert_eq!(status.code, Code::AlreadyExists, "{status:?}");
+        assert!(status.message.contains("Already Exists: Job"), "{status:?}");
+        Ok(())
+    }
+    #[tokio::test]
+    async fn test_jobs_query_duplicate_adopts_existing_job() -> TestResult {
+        let mut mock = MockJobService::new();
+        mock.expect_query()
+            .return_once(move |_, _| Err(duplicate_job_error("job_123")));
+        mock.expect_get_job().return_once(move |req, _| {
+            let job_ref = JobReference::new()
+                .set_project_id(req.project_id)
+                .set_job_id(req.job_id)
+                .set_location(req.location);
+            let job = Job::new()
+                .set_configuration(JobConfiguration::new().set_query(JobConfigurationQuery::new()))
+                .set_job_reference(job_ref)
+                .set_status(JobStatus::new().set_state("RUNNING"));
+            Ok(Response::from(job))
+        });
+
+        let job_service = create_job_service(mock);
+        let query = Query::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
+
+        let retry_ctx = RetryContext::new(query);
+        assert!(!retry_ctx.force_job_path(), "must use the jobs.query path");
+
+        let handle = retry_ctx.execute_once("my-project").await?;
+
+        // The adopted job is the one the 409 names, fetched in its location.
+        let job_ref = handle.metadata.job_reference.expect("job reference");
+        assert_eq!(job_ref.project_id, "my-project");
+        assert_eq!(job_ref.location.as_deref(), Some("US"));
+        assert_eq!(job_ref.job_id, "job_123");
+        assert!(!handle.completed, "the adopted job is still running");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_jobs_query_duplicate_reports_original_error() -> TestResult {
+        let mut mock = MockJobService::new();
+        mock.expect_query()
+            .return_once(move |_, _| Err(duplicate_job_error("job_123")));
+        mock.expect_get_job().return_once(move |_, _| {
+            let status = Status::default()
+                .set_code(Code::PermissionDenied)
+                .set_message("simulated permission denied");
+            Err(GaxError::service(status))
+        });
+
+        let job_service = create_job_service(mock);
+        let query = Query::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
+
+        let err = RetryContext::new(query)
+            .execute_once("my-project")
+            .await
+            .unwrap_err();
+
+        // The duplicate error names the running job, so it is more useful than
+        // the error from `jobs.get`.
+        let QueryError::Rpc { source } = &err else {
+            panic!("expected QueryError::Rpc, got {err:?}");
+        };
+        let status = source.status().expect("status");
+        assert_eq!(status.code, Code::AlreadyExists, "{status:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_duplicate_job_reference() {
+        let rpc = |message: &str| {
+            QueryError::from(GaxError::service(
+                Status::default()
+                    .set_code(Code::AlreadyExists)
+                    .set_message(message),
+            ))
+        };
+
+        let err = rpc("Already Exists: Job my-project:US.job_123");
+        let job_ref = parse_duplicate_job_reference(&err).expect("job reference");
+        assert_eq!(job_ref.project_id, "my-project");
+        assert_eq!(job_ref.location.as_deref(), Some("US"));
+        assert_eq!(job_ref.job_id, "job_123");
+
+        // Domain scoped project IDs contain both separators.
+        let err = rpc("Already Exists: Job example.com:my-project:US.job_123");
+        let job_ref = parse_duplicate_job_reference(&err).expect("job reference");
+        assert_eq!(job_ref.project_id, "example.com:my-project");
+        assert_eq!(job_ref.location.as_deref(), Some("US"));
+        assert_eq!(job_ref.job_id, "job_123");
+
+        let unparsable = [
+            "Already Exists: Job my-project:US.",
+            "Already Exists: Job my-project.job_123",
+            "Already Exists: Job my-project:US:job_123",
+            "Already Exists: Job ",
+            "Some other error",
+        ];
+        for message in unparsable {
+            let err = rpc(message);
+            assert!(parse_duplicate_job_reference(&err).is_none(), "{message}");
+        }
+
+        // Only RPC failures carry a service message.
+        let job_failed = QueryError::JobFailed { errors: vec![] };
+        assert!(parse_duplicate_job_reference(&job_failed).is_none());
+    }
+
+    // Both RPCs opt into retries: each can recover the job a resend collides
+    // with, `jobs.insert` from the ID it generated and `jobs.query` from the
+    // ID the 409 names.
+    #[tokio::test]
+    async fn test_query_rpcs_are_idempotent() -> TestResult {
+        let mut mock = MockJobService::new();
+        mock.expect_query().times(1).returning(|_, options| {
+            assert_eq!(options.idempotent(), Some(true), "jobs.query");
+            Err(GaxError::service(
+                Status::default().set_code(Code::Unavailable),
+            ))
+        });
+        mock.expect_insert_job().times(1).returning(|_, options| {
+            assert_eq!(options.idempotent(), Some(true), "jobs.insert");
+            Err(GaxError::service(
+                Status::default().set_code(Code::Unavailable),
+            ))
+        });
+        let job_service = create_job_service(mock);
+
+        let query = Query::new(job_service.clone(), "SELECT 1".to_string())
+            .with_project_id("my-project")
+            .set_dry_run(false);
+        RetryContext::new(query)
+            .execute_once("my-project")
+            .await
+            .unwrap_err();
+
+        let query = Query::new(job_service, "SELECT 1".to_string())
+            .with_project_id("my-project")
+            .set_dry_run(true);
+        RetryContext::new(query)
+            .execute_once("my-project")
+            .await
+            .unwrap_err();
         Ok(())
     }
 }

--- a/src/bigquery/src/query/query_handle.rs
+++ b/src/bigquery/src/query/query_handle.rs
@@ -436,7 +436,7 @@ impl CompleteQuery {
 /// Builds a `jobs.get` request from a job reference, or `None` if the
 /// reference cannot identify a job. Dry-run queries return a job reference
 /// without a job ID.
-fn build_get_job(job_service: &JobService, job_ref: &JobReference) -> Option<GetJob> {
+pub(crate) fn build_get_job(job_service: &JobService, job_ref: &JobReference) -> Option<GetJob> {
     if job_ref.job_id.is_empty() {
         return None;
     }

--- a/src/bigquery/src/query/retry_policy.rs
+++ b/src/bigquery/src/query/retry_policy.rs
@@ -47,13 +47,25 @@ use std::time::Duration;
 /// This policy must be decorated to limit the duration of the retry loop or
 /// the number of attempts.
 ///
+/// Errors that occur before the request is sent are always retried. Any other
+/// error is only retried for idempotent requests, because the service may
+/// already have acted on the request.
+///
 /// [error handling]: https://cloud.google.com/bigquery/docs/error-messages
 #[derive(Clone, Debug)]
 pub struct RetryableErrors;
 
 impl RetryPolicy for RetryableErrors {
-    fn on_error(&self, _state: &RetryState, error: GaxError) -> RetryResult {
-        if error.is_transient_and_before_rpc() || error.is_io() || error.is_timeout() {
+    fn on_error(&self, state: &RetryState, error: GaxError) -> RetryResult {
+        if error.is_transient_and_before_rpc() {
+            return RetryResult::Continue(error);
+        }
+        // The request may have reached the service, so it is only safe to
+        // resend when it is idempotent.
+        if !state.idempotent {
+            return RetryResult::Permanent(error);
+        }
+        if error.is_io() || error.is_timeout() {
             return RetryResult::Continue(error);
         }
         if error.is_transport() && error.http_status_code().is_none() {
@@ -194,6 +206,21 @@ pub(crate) fn is_rpc_error_retryable(error: &GaxError) -> bool {
     false
 }
 
+/// Returns true if `error` reports a conflict with a resource that already
+/// exists, such as `409 Already Exists: Job my-project:US.job_1234567890`.
+///
+/// Deliberately coarse: the caller confirms the conflict by fetching the job
+/// ID it generated, so an unrelated conflict resolves to a `404` there.
+pub(crate) fn is_duplicate_job_error(error: &QueryError) -> bool {
+    let QueryError::Rpc { source } = error else {
+        return false;
+    };
+    source.http_status_code() == Some(409)
+        || source
+            .status()
+            .is_some_and(|s| s.code == Code::AlreadyExists)
+}
+
 pub(crate) fn is_retryable_errors(errors: &[ErrorProto]) -> bool {
     !errors.is_empty() && errors.iter().all(|e| is_retryable_error_reason(&e.reason))
 }
@@ -214,6 +241,7 @@ mod tests {
     use super::*;
     use crate::query::tests::create_test_backoff_policy;
     use google_cloud_bigquery_v2::model::ErrorProto;
+    use google_cloud_gax::error::CredentialsError;
     use google_cloud_gax::error::rpc::{Code, Status};
     use google_cloud_gax::retry_state::RetryState;
     use google_cloud_rpc::model::ErrorInfo;
@@ -253,10 +281,59 @@ mod tests {
     }
 
     #[test]
+    fn test_is_duplicate_job_error() {
+        let rpc = |source| QueryError::Rpc { source };
+        let status = |code| GaxError::service(Status::default().set_code(code));
+        let http = |code| GaxError::http(code, HeaderMap::new(), bytes::Bytes::new());
+
+        // Any conflict counts, including one that has nothing to do with a
+        // duplicate job: the caller rules those out by fetching the job ID it
+        // generated.
+        assert!(is_duplicate_job_error(&rpc(http(409))));
+        assert!(is_duplicate_job_error(&rpc(status(Code::AlreadyExists))));
+
+        assert!(!is_duplicate_job_error(&rpc(status(Code::Aborted))));
+        assert!(!is_duplicate_job_error(&rpc(http(500))));
+        assert!(!is_duplicate_job_error(&QueryError::JobFailed {
+            errors: vec![ErrorProto::new().set_reason("duplicate")],
+        }));
+    }
+
+    // Reissuing a duplicate would run and bill the query a second time, so the
+    // job retry loop must treat a real duplicate payload as permanent.
+    #[test]
+    fn test_duplicate_job_error_is_not_retryable() {
+        const BQ_DUPLICATE_PAYLOAD: &[u8] = br#"{
+  "error": {
+    "code": 409,
+    "message": "Already Exists: Job my-project:US.job_1234567890",
+    "errors": [
+      {
+        "message": "Already Exists: Job my-project:US.job_1234567890",
+        "domain": "global",
+        "reason": "duplicate"
+      }
+    ],
+    "status": "ALREADY_EXISTS"
+  }
+}"#;
+        let status = Status::try_from(&bytes::Bytes::from_static(BQ_DUPLICATE_PAYLOAD))
+            .expect("should deserialize BigQuery REST error");
+        let err = QueryError::Rpc {
+            source: GaxError::service(status),
+        };
+        assert!(is_duplicate_job_error(&err), "{err:?}");
+        assert!(!is_query_error_retryable(&err), "{err:?}");
+    }
+
+    #[test]
     fn test_retryable_errors_on_error() {
         let p = RetryableErrors;
-        let state = RetryState::default();
+        let idempotent = RetryState::new(true);
+        let non_idempotent = RetryState::new(false);
 
+        // Whatever we retry for an idempotent request is permanent when the
+        // request is not, because the service may already have acted on it.
         let retryable_codes = [
             Code::Aborted,
             Code::DeadlineExceeded,
@@ -266,11 +343,11 @@ mod tests {
             Code::Unknown,
         ];
         for code in retryable_codes {
-            let err = GaxError::service(Status::default().set_code(code));
+            let err = || GaxError::service(Status::default().set_code(code));
+            assert!(p.on_error(&idempotent, err()).is_continue(), "{code:?}");
             assert!(
-                p.on_error(&state, err).is_continue(),
-                "expected continue for {:?}",
-                code
+                p.on_error(&non_idempotent, err()).is_permanent(),
+                "{code:?}"
             );
         }
 
@@ -280,33 +357,48 @@ mod tests {
             Code::InvalidArgument,
         ];
         for code in permanent_codes {
-            let err = GaxError::service(Status::default().set_code(code));
+            let err = || GaxError::service(Status::default().set_code(code));
+            assert!(p.on_error(&idempotent, err()).is_permanent(), "{code:?}");
             assert!(
-                p.on_error(&state, err).is_permanent(),
-                "expected permanent for {:?}",
-                code
+                p.on_error(&non_idempotent, err()).is_permanent(),
+                "{code:?}"
             );
         }
 
         let retryable_http = [429, 500, 502, 503, 504];
         for code in retryable_http {
-            let err = GaxError::http(code, HeaderMap::new(), bytes::Bytes::new());
+            let err = || GaxError::http(code, HeaderMap::new(), bytes::Bytes::new());
+            assert!(p.on_error(&idempotent, err()).is_continue(), "HTTP {code}");
             assert!(
-                p.on_error(&state, err).is_continue(),
-                "expected continue for HTTP {}",
-                code
+                p.on_error(&non_idempotent, err()).is_permanent(),
+                "HTTP {code}"
             );
         }
 
         let permanent_http = [400, 404, 408, 409, 501];
         for code in permanent_http {
-            let err = GaxError::http(code, HeaderMap::new(), bytes::Bytes::new());
+            let err = || GaxError::http(code, HeaderMap::new(), bytes::Bytes::new());
+            assert!(p.on_error(&idempotent, err()).is_permanent(), "HTTP {code}");
             assert!(
-                p.on_error(&state, err).is_permanent(),
-                "expected permanent for HTTP {}",
-                code
+                p.on_error(&non_idempotent, err()).is_permanent(),
+                "HTTP {code}"
             );
         }
+
+        let io = || GaxError::io("connection reset");
+        assert!(p.on_error(&idempotent, io()).is_continue());
+        assert!(p.on_error(&non_idempotent, io()).is_permanent());
+
+        let timeout = || GaxError::timeout("deadline");
+        assert!(p.on_error(&idempotent, timeout()).is_continue());
+        assert!(p.on_error(&non_idempotent, timeout()).is_permanent());
+
+        // Failures before the request is sent cannot have reached the service,
+        // so they are retried either way.
+        let before_rpc =
+            || GaxError::authentication(CredentialsError::from_msg(true, "token refresh failed"));
+        assert!(p.on_error(&idempotent, before_rpc()).is_continue());
+        assert!(p.on_error(&non_idempotent, before_rpc()).is_continue());
     }
 
     #[test]


### PR DESCRIPTION
Towards #6717 